### PR TITLE
Replace AutoRelayer component with a generalized Runner component

### DIFF
--- a/crates/relayer-all-in-one/src/all_for_one/birelay.rs
+++ b/crates/relayer-all-in-one/src/all_for_one/birelay.rs
@@ -1,5 +1,5 @@
+use ibc_relayer_components::core::traits::run::CanRun;
 use ibc_relayer_components::logger::traits::level::HasLoggerWithBaseLevels;
-use ibc_relayer_components::relay::traits::components::auto_relayer::CanAutoRelay;
 use ibc_relayer_components::relay::traits::two_way::HasTwoWayRelay;
 
 use crate::all_for_one::relay::AfoRelay;
@@ -9,7 +9,7 @@ pub trait AfoBiRelay:
     Clone
     + HasAfoRuntime
     + HasLoggerWithBaseLevels
-    + CanAutoRelay
+    + CanRun
     + HasTwoWayRelay<RelayAToB = Self::AfoRelayAToB, RelayBToA = Self::AfoRelayBToA>
 {
     type AfoRelayAToB: AfoRelay;
@@ -27,7 +27,7 @@ where
     BiRelay: Clone
         + HasAfoRuntime
         + HasLoggerWithBaseLevels
-        + CanAutoRelay
+        + CanRun
         + HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
 {
     type AfoRelayAToB = RelayAToB;

--- a/crates/relayer-all-in-one/src/all_for_one/relay.rs
+++ b/crates/relayer-all-in-one/src/all_for_one/relay.rs
@@ -1,9 +1,9 @@
 use ibc_relayer_components::chain::types::aliases::{IncomingPacket, OutgoingPacket};
+use ibc_relayer_components::core::traits::run::CanRun;
 use ibc_relayer_components::logger::traits::level::HasLoggerWithBaseLevels;
 use ibc_relayer_components::relay::traits::chains::HasRelayChains;
 use ibc_relayer_components::relay::traits::channel::open_handshake::CanRelayChannelOpenHandshake;
 use ibc_relayer_components::relay::traits::channel::open_init::CanInitChannel;
-use ibc_relayer_components::relay::traits::components::auto_relayer::CanAutoRelay;
 use ibc_relayer_components::relay::traits::components::client_creator::CanCreateClient;
 use ibc_relayer_components::relay::traits::components::event_relayer::CanRelayEvent;
 use ibc_relayer_components::relay::traits::components::ibc_message_sender::{
@@ -37,7 +37,7 @@ pub trait AfoRelay:
     + CanSendIbcMessages<MainSink, DestinationTarget>
     + CanRelayEvent<SourceTarget>
     + CanRelayEvent<DestinationTarget>
-    + CanAutoRelay
+    + CanRun
     + CanFilterPackets
     + CanRelayReceivePacket
     + CanRelayPacket
@@ -75,7 +75,7 @@ where
         + CanSendIbcMessages<MainSink, DestinationTarget>
         + CanRelayEvent<SourceTarget>
         + CanRelayEvent<DestinationTarget>
-        + CanAutoRelay
+        + CanRun
         + CanFilterPackets
         + CanRelayReceivePacket
         + CanRelayPacket

--- a/crates/relayer-components-extra/src/components/extra/birelay.rs
+++ b/crates/relayer-components-extra/src/components/extra/birelay.rs
@@ -1,13 +1,13 @@
 use core::marker::PhantomData;
 
 use cgp_core::delegate_component;
-use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayerComponent;
+use ibc_relayer_components::core::traits::run::RunnerComponent;
 
 use crate::relay::components::auto_relayers::parallel_two_way::ParallelTwoWayAutoRelay;
 pub struct ExtraBiRelayComponents<BaseComponents>(pub PhantomData<BaseComponents>);
 
 delegate_component!(
-    AutoRelayerComponent,
+    RunnerComponent,
     ExtraBiRelayComponents<BaseComponents>,
     ParallelTwoWayAutoRelay,
 );

--- a/crates/relayer-components-extra/src/components/extra/closures/relay/auto_relayer.rs
+++ b/crates/relayer-components-extra/src/components/extra/closures/relay/auto_relayer.rs
@@ -2,10 +2,10 @@ use cgp_core::traits::{Async, HasComponents};
 use ibc_relayer_components::chain::traits::event_subscription::HasEventSubscription;
 use ibc_relayer_components::chain::traits::logs::event::CanLogChainEvent;
 use ibc_relayer_components::chain::traits::types::chain_id::HasChainId;
+use ibc_relayer_components::core::traits::run::CanRun;
 use ibc_relayer_components::logger::traits::has_logger::{HasLogger, HasLoggerType};
 use ibc_relayer_components::logger::traits::level::HasBaseLogLevels;
 use ibc_relayer_components::relay::traits::chains::HasRelayChains;
-use ibc_relayer_components::relay::traits::components::auto_relayer::CanAutoRelay;
 use ibc_relayer_components::runtime::traits::runtime::HasRuntime;
 
 use crate::components::extra::closures::relay::event_relayer::UseExtraEventRelayer;
@@ -14,7 +14,7 @@ use crate::runtime::traits::spawn::HasSpawner;
 
 pub trait CanUseExtraAutoRelayer: UseExtraAutoRelayer {}
 
-pub trait UseExtraAutoRelayer: CanAutoRelay {}
+pub trait UseExtraAutoRelayer: CanRun {}
 
 impl<Relay, BaseRelayComponents> UseExtraAutoRelayer for Relay
 where

--- a/crates/relayer-components-extra/src/components/extra/relay.rs
+++ b/crates/relayer-components-extra/src/components/extra/relay.rs
@@ -2,13 +2,13 @@ use core::marker::PhantomData;
 
 use cgp_core::{delegate_component, delegate_components};
 use ibc_relayer_components::components::default::relay::DefaultRelayComponents;
+use ibc_relayer_components::core::traits::run::RunnerComponent;
 use ibc_relayer_components::relay::components::message_senders::chain_sender::SendIbcMessagesToChain;
 use ibc_relayer_components::relay::components::message_senders::update_client::SendIbcMessagesWithUpdateClient;
 use ibc_relayer_components::relay::components::packet_relayers::general::filter_relayer::FilterRelayer;
 use ibc_relayer_components::relay::components::packet_relayers::general::full_relay::FullCycleRelayer;
 use ibc_relayer_components::relay::components::packet_relayers::general::lock::LockPacketRelayer;
 use ibc_relayer_components::relay::components::packet_relayers::general::log::LoggerRelayer;
-use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayerComponent;
 use ibc_relayer_components::relay::traits::components::client_creator::ClientCreatorComponent;
 use ibc_relayer_components::relay::traits::components::event_relayer::EventRelayerComponent;
 use ibc_relayer_components::relay::traits::components::ibc_message_sender::{
@@ -49,7 +49,7 @@ delegate_component!(
 );
 
 delegate_component!(
-    AutoRelayerComponent,
+    RunnerComponent,
     ExtraRelayComponents<BaseComponents>,
     ParallelBidirectionalRelayer<ParallelEventSubscriptionRelayer>,
 );

--- a/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_bidirectional.rs
+++ b/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_bidirectional.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use async_trait::async_trait;
 use ibc_relayer_components::core::traits::run::Runner;
 use ibc_relayer_components::relay::traits::chains::HasRelayChains;
-use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayerWithTarget;
+use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayer;
 use ibc_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use ibc_relayer_components::runtime::traits::runtime::HasRuntime;
 
@@ -21,8 +21,8 @@ pub struct ParallelBidirectionalRelayer<InRelayer>(pub PhantomData<InRelayer>);
 impl<Relay, InRelayer, Runtime> Runner<Relay> for ParallelBidirectionalRelayer<InRelayer>
 where
     Relay: HasRelayChains + HasRuntime<Runtime = Runtime> + Clone,
-    InRelayer: AutoRelayerWithTarget<Relay, SourceTarget>,
-    InRelayer: AutoRelayerWithTarget<Relay, DestinationTarget>,
+    InRelayer: AutoRelayer<Relay, SourceTarget>,
+    InRelayer: AutoRelayer<Relay, DestinationTarget>,
     Runtime: HasSpawner,
 {
     async fn run(relay: &Relay) -> Result<(), Relay::Error> {
@@ -31,18 +31,19 @@ where
         let spawner = src_relay.runtime().spawner();
 
         let handle1 = spawner.spawn(async move {
-            let _ = <InRelayer as AutoRelayerWithTarget<Relay, DestinationTarget>>::auto_relay_with_target(
+            let _ = <InRelayer as AutoRelayer<Relay, DestinationTarget>>::auto_relay(
                 &dst_relay,
+                DestinationTarget,
             )
             .await;
         });
 
         let handle2 = spawner.spawn(async move {
-            let _ =
-                <InRelayer as AutoRelayerWithTarget<Relay, SourceTarget>>::auto_relay_with_target(
-                    &src_relay,
-                )
-                .await;
+            let _ = <InRelayer as AutoRelayer<Relay, SourceTarget>>::auto_relay(
+                &src_relay,
+                SourceTarget,
+            )
+            .await;
         });
 
         // Wait for handle1 and handle2 to finish.

--- a/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_bidirectional.rs
+++ b/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_bidirectional.rs
@@ -1,10 +1,9 @@
 use core::marker::PhantomData;
 
 use async_trait::async_trait;
+use ibc_relayer_components::core::traits::run::Runner;
 use ibc_relayer_components::relay::traits::chains::HasRelayChains;
-use ibc_relayer_components::relay::traits::components::auto_relayer::{
-    AutoRelayer, AutoRelayerWithTarget,
-};
+use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayerWithTarget;
 use ibc_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use ibc_relayer_components::runtime::traits::runtime::HasRuntime;
 
@@ -19,14 +18,14 @@ use crate::std_prelude::*;
 pub struct ParallelBidirectionalRelayer<InRelayer>(pub PhantomData<InRelayer>);
 
 #[async_trait]
-impl<Relay, InRelayer, Runtime> AutoRelayer<Relay> for ParallelBidirectionalRelayer<InRelayer>
+impl<Relay, InRelayer, Runtime> Runner<Relay> for ParallelBidirectionalRelayer<InRelayer>
 where
     Relay: HasRelayChains + HasRuntime<Runtime = Runtime> + Clone,
     InRelayer: AutoRelayerWithTarget<Relay, SourceTarget>,
     InRelayer: AutoRelayerWithTarget<Relay, DestinationTarget>,
     Runtime: HasSpawner,
 {
-    async fn auto_relay(relay: &Relay) -> Result<(), Relay::Error> {
+    async fn run(relay: &Relay) -> Result<(), Relay::Error> {
         let src_relay = relay.clone();
         let dst_relay = relay.clone();
         let spawner = src_relay.runtime().spawner();

--- a/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_event.rs
+++ b/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_event.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use futures_util::stream::StreamExt;
 use ibc_relayer_components::chain::traits::event_subscription::HasEventSubscription;
 use ibc_relayer_components::logger::traits::level::HasBaseLogLevels;
-use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayerWithTarget;
+use ibc_relayer_components::relay::traits::components::auto_relayer::AutoRelayer;
 use ibc_relayer_components::relay::traits::components::event_relayer::CanRelayEvent;
 use ibc_relayer_components::relay::traits::logs::event::CanLogTargetEvent;
 use ibc_relayer_components::relay::traits::logs::logger::CanLogRelay;
@@ -15,15 +15,14 @@ use crate::std_prelude::*;
 pub struct ParallelEventSubscriptionRelayer;
 
 #[async_trait]
-impl<Relay, Target, Runtime> AutoRelayerWithTarget<Relay, Target>
-    for ParallelEventSubscriptionRelayer
+impl<Relay, Target, Runtime> AutoRelayer<Relay, Target> for ParallelEventSubscriptionRelayer
 where
     Relay: Clone + CanRelayEvent<Target> + CanLogRelay + CanLogTargetEvent<Target>,
     Target: ChainTarget<Relay>,
     Target::TargetChain: HasRuntime<Runtime = Runtime> + HasEventSubscription,
     Runtime: HasSpawner,
 {
-    async fn auto_relay_with_target(relay: &Relay) -> Result<(), Relay::Error> {
+    async fn auto_relay(relay: &Relay, _target: Target) -> Result<(), Relay::Error> {
         let chain = Target::target_chain(relay);
         let runtime = chain.runtime();
         let subscription = chain.event_subscription();

--- a/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_two_way.rs
+++ b/crates/relayer-components-extra/src/relay/components/auto_relayers/parallel_two_way.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use ibc_relayer_components::relay::traits::components::auto_relayer::{AutoRelayer, CanAutoRelay};
+use ibc_relayer_components::core::traits::run::{CanRun, Runner};
 use ibc_relayer_components::relay::traits::two_way::HasTwoWayRelay;
 use ibc_relayer_components::runtime::traits::runtime::HasRuntime;
 
@@ -18,24 +18,24 @@ use crate::std_prelude::*;
 pub struct ParallelTwoWayAutoRelay;
 
 #[async_trait]
-impl<BiRelay, Runtime> AutoRelayer<BiRelay> for ParallelTwoWayAutoRelay
+impl<BiRelay, Runtime> Runner<BiRelay> for ParallelTwoWayAutoRelay
 where
     BiRelay: HasTwoWayRelay,
     Runtime: HasSpawner,
-    BiRelay::RelayAToB: CanAutoRelay + HasRuntime<Runtime = Runtime> + Clone,
-    BiRelay::RelayBToA: CanAutoRelay + Clone,
+    BiRelay::RelayAToB: CanRun + HasRuntime<Runtime = Runtime> + Clone,
+    BiRelay::RelayBToA: CanRun + Clone,
 {
-    async fn auto_relay(birelay: &BiRelay) -> Result<(), BiRelay::Error> {
+    async fn run(birelay: &BiRelay) -> Result<(), BiRelay::Error> {
         let relay_a_to_b = birelay.relay_a_to_b().clone();
         let relay_b_to_a = birelay.relay_b_to_a().clone();
         let spawner = relay_a_to_b.runtime().spawner();
 
         let handle1 = spawner.spawn(async move {
-            let _ = BiRelay::RelayAToB::auto_relay(&relay_a_to_b).await;
+            let _ = BiRelay::RelayAToB::run(&relay_a_to_b).await;
         });
 
         let handle2 = spawner.spawn(async move {
-            let _ = BiRelay::RelayBToA::auto_relay(&relay_b_to_a).await;
+            let _ = BiRelay::RelayBToA::run(&relay_b_to_a).await;
         });
 
         handle1.into_future().await;

--- a/crates/relayer-components/src/components/default/birelay.rs
+++ b/crates/relayer-components/src/components/default/birelay.rs
@@ -2,13 +2,13 @@ use core::marker::PhantomData;
 
 use cgp_core::delegate_component;
 
+use crate::core::traits::run::RunnerComponent;
 use crate::relay::components::auto_relayers::concurrent_two_way::ConcurrentTwoWayAutoRelay;
-use crate::relay::traits::components::auto_relayer::AutoRelayerComponent;
 
 pub struct DefaultBiRelayComponents<BaseComponents>(pub PhantomData<BaseComponents>);
 
 delegate_component!(
-    AutoRelayerComponent,
+    RunnerComponent,
     DefaultBiRelayComponents<BaseComponents>,
     ConcurrentTwoWayAutoRelay,
 );

--- a/crates/relayer-components/src/components/default/closures/relay/auto_relayer.rs
+++ b/crates/relayer-components/src/components/default/closures/relay/auto_relayer.rs
@@ -4,12 +4,12 @@ use cgp_core::traits::Async;
 use crate::chain::traits::event_subscription::HasEventSubscription;
 use crate::components::default::closures::relay::event_relayer::UseDefaultEventRelayer;
 use crate::components::default::relay::DefaultRelayComponents;
+use crate::core::traits::run::CanRun;
 use crate::relay::traits::chains::HasRelayChains;
-use crate::relay::traits::components::auto_relayer::CanAutoRelay;
 
 pub trait CanUseDefaultAutoRelayer: UseDefaultAutoRelayer {}
 
-pub trait UseDefaultAutoRelayer: CanAutoRelay {}
+pub trait UseDefaultAutoRelayer: CanRun {}
 
 impl<Relay, BaseRelayComponents> UseDefaultAutoRelayer for Relay
 where

--- a/crates/relayer-components/src/components/default/relay.rs
+++ b/crates/relayer-components/src/components/default/relay.rs
@@ -2,6 +2,7 @@ use core::marker::PhantomData;
 
 use cgp_core::delegate_component;
 
+use crate::core::traits::run::RunnerComponent;
 use crate::relay::components::auto_relayers::concurrent_bidirectional::ConcurrentBidirectionalRelayer;
 use crate::relay::components::auto_relayers::concurrent_event::ConcurrentEventSubscriptionRelayer;
 use crate::relay::components::create_client::CreateClientWithChains;
@@ -20,7 +21,6 @@ use crate::relay::components::packet_relayers::timeout_unordered::timeout_unorde
 use crate::relay::components::update_client::build::BuildUpdateClientMessages;
 use crate::relay::components::update_client::skip::SkipUpdateClient;
 use crate::relay::components::update_client::wait::WaitUpdateClient;
-use crate::relay::traits::components::auto_relayer::AutoRelayerComponent;
 use crate::relay::traits::components::client_creator::ClientCreatorComponent;
 use crate::relay::traits::components::event_relayer::EventRelayerComponent;
 use crate::relay::traits::components::ibc_message_sender::{IbcMessageSenderComponent, MainSink};
@@ -83,7 +83,7 @@ delegate_component!(
 );
 
 delegate_component!(
-    AutoRelayerComponent,
+    RunnerComponent,
     DefaultRelayComponents<BaseComponents>,
     ConcurrentBidirectionalRelayer<ConcurrentEventSubscriptionRelayer>,
 );

--- a/crates/relayer-components/src/core/mod.rs
+++ b/crates/relayer-components/src/core/mod.rs
@@ -1,0 +1,1 @@
+pub mod traits;

--- a/crates/relayer-components/src/core/traits/mod.rs
+++ b/crates/relayer-components/src/core/traits/mod.rs
@@ -1,0 +1,1 @@
+pub mod run;

--- a/crates/relayer-components/src/core/traits/run.rs
+++ b/crates/relayer-components/src/core/traits/run.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use cgp_core::traits::HasErrorType;
+use cgp_macros::derive_component;
+
+use crate::std_prelude::*;
+
+#[derive_component(RunnerComponent, Runner<App>)]
+#[async_trait]
+pub trait CanRun: HasErrorType {
+    async fn run(&self) -> Result<(), Self::Error>;
+}

--- a/crates/relayer-components/src/lib.rs
+++ b/crates/relayer-components/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 pub mod build;
 pub mod chain;
 pub mod components;
+pub mod core;
 pub mod logger;
 pub mod relay;
 pub mod runtime;

--- a/crates/relayer-components/src/relay/components/auto_relayers/concurrent_bidirectional.rs
+++ b/crates/relayer-components/src/relay/components/auto_relayers/concurrent_bidirectional.rs
@@ -5,8 +5,9 @@ use core::pin::Pin;
 use async_trait::async_trait;
 use futures_util::stream::{self, StreamExt};
 
+use crate::core::traits::run::Runner;
 use crate::relay::traits::chains::HasRelayChains;
-use crate::relay::traits::components::auto_relayer::{AutoRelayer, AutoRelayerWithTarget};
+use crate::relay::traits::components::auto_relayer::AutoRelayerWithTarget;
 use crate::relay::traits::target::{DestinationTarget, SourceTarget};
 use crate::std_prelude::*;
 
@@ -25,13 +26,13 @@ use crate::std_prelude::*;
 pub struct ConcurrentBidirectionalRelayer<InRelayer>(pub PhantomData<InRelayer>);
 
 #[async_trait]
-impl<Relay, InRelayer> AutoRelayer<Relay> for ConcurrentBidirectionalRelayer<InRelayer>
+impl<Relay, InRelayer> Runner<Relay> for ConcurrentBidirectionalRelayer<InRelayer>
 where
     Relay: HasRelayChains,
     InRelayer: AutoRelayerWithTarget<Relay, SourceTarget>,
     InRelayer: AutoRelayerWithTarget<Relay, DestinationTarget>,
 {
-    async fn auto_relay(relay: &Relay) -> Result<(), Relay::Error> {
+    async fn run(relay: &Relay) -> Result<(), Relay::Error> {
         let src_task: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
             let _ =
                 <InRelayer as AutoRelayerWithTarget<Relay, SourceTarget>>::auto_relay_with_target(

--- a/crates/relayer-components/src/relay/components/auto_relayers/concurrent_event.rs
+++ b/crates/relayer-components/src/relay/components/auto_relayers/concurrent_event.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use futures_util::stream::StreamExt;
 
 use crate::chain::traits::event_subscription::HasEventSubscription;
-use crate::relay::traits::components::auto_relayer::AutoRelayerWithTarget;
+use crate::relay::traits::components::auto_relayer::AutoRelayer;
 use crate::relay::traits::components::event_relayer::CanRelayEvent;
 use crate::relay::traits::target::ChainTarget;
 use crate::std_prelude::*;
@@ -13,13 +13,13 @@ use crate::std_prelude::*;
 pub struct ConcurrentEventSubscriptionRelayer;
 
 #[async_trait]
-impl<Relay, Target> AutoRelayerWithTarget<Relay, Target> for ConcurrentEventSubscriptionRelayer
+impl<Relay, Target> AutoRelayer<Relay, Target> for ConcurrentEventSubscriptionRelayer
 where
     Relay: CanRelayEvent<Target>,
     Target: ChainTarget<Relay>,
     Target::TargetChain: HasEventSubscription,
 {
-    async fn auto_relay_with_target(relay: &Relay) -> Result<(), Relay::Error> {
+    async fn auto_relay(relay: &Relay, _target: Target) -> Result<(), Relay::Error> {
         let subscription = Target::target_chain(relay).event_subscription();
 
         loop {

--- a/crates/relayer-components/src/relay/components/auto_relayers/concurrent_two_way.rs
+++ b/crates/relayer-components/src/relay/components/auto_relayers/concurrent_two_way.rs
@@ -4,7 +4,7 @@ use core::pin::Pin;
 use async_trait::async_trait;
 use futures_util::stream::{self, StreamExt};
 
-use crate::relay::traits::components::auto_relayer::{AutoRelayer, CanAutoRelay};
+use crate::core::traits::run::{CanRun, Runner};
 use crate::relay::traits::two_way::HasTwoWayRelay;
 use crate::std_prelude::*;
 
@@ -16,19 +16,19 @@ use crate::std_prelude::*;
 pub struct ConcurrentTwoWayAutoRelay;
 
 #[async_trait]
-impl<BiRelay> AutoRelayer<BiRelay> for ConcurrentTwoWayAutoRelay
+impl<BiRelay> Runner<BiRelay> for ConcurrentTwoWayAutoRelay
 where
     BiRelay: HasTwoWayRelay,
-    BiRelay::RelayAToB: CanAutoRelay,
-    BiRelay::RelayBToA: CanAutoRelay,
+    BiRelay::RelayAToB: CanRun,
+    BiRelay::RelayBToA: CanRun,
 {
-    async fn auto_relay(birelay: &BiRelay) -> Result<(), BiRelay::Error> {
+    async fn run(birelay: &BiRelay) -> Result<(), BiRelay::Error> {
         let a_to_b_task: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
-            let _ = birelay.relay_a_to_b().auto_relay().await;
+            let _ = birelay.relay_a_to_b().run().await;
         });
 
         let b_to_a_task: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
-            let _ = birelay.relay_b_to_a().auto_relay().await;
+            let _ = birelay.relay_b_to_a().run().await;
         });
 
         stream::iter([a_to_b_task, b_to_a_task])

--- a/crates/relayer-components/src/relay/components/auto_relayers/sequential_event.rs
+++ b/crates/relayer-components/src/relay/components/auto_relayers/sequential_event.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use futures_util::stream::StreamExt;
 
 use crate::chain::traits::event_subscription::HasEventSubscription;
-use crate::relay::traits::components::auto_relayer::AutoRelayerWithTarget;
+use crate::relay::traits::components::auto_relayer::AutoRelayer;
 use crate::relay::traits::components::event_relayer::CanRelayEvent;
 use crate::relay::traits::target::ChainTarget;
 use crate::std_prelude::*;
@@ -10,13 +10,13 @@ use crate::std_prelude::*;
 pub struct SequentialEventSubscriptionRelayer;
 
 #[async_trait]
-impl<Relay, Target> AutoRelayerWithTarget<Relay, Target> for SequentialEventSubscriptionRelayer
+impl<Relay, Target> AutoRelayer<Relay, Target> for SequentialEventSubscriptionRelayer
 where
     Relay: CanRelayEvent<Target>,
     Target: ChainTarget<Relay>,
     Target::TargetChain: HasEventSubscription,
 {
-    async fn auto_relay_with_target(relay: &Relay) -> Result<(), Relay::Error> {
+    async fn auto_relay(relay: &Relay, _target: Target) -> Result<(), Relay::Error> {
         let subscription = Target::target_chain(relay).event_subscription();
 
         loop {

--- a/crates/relayer-components/src/relay/traits/components/auto_relayer.rs
+++ b/crates/relayer-components/src/relay/traits/components/auto_relayer.rs
@@ -1,28 +1,9 @@
 use async_trait::async_trait;
-use cgp_core::traits::{Async, HasErrorType};
-use cgp_macros::derive_component;
+use cgp_core::traits::Async;
 
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
 use crate::std_prelude::*;
-
-/// Trait that encodes the capability of a relayer to relay
-/// in a "set it and forget it" manner. This trait is agnostic
-/// as far as the provided context is concerned, i.e., it doesn't
-/// require an implementing type to be of any particular context.
-///
-/// For example, if this trait is implemented for a two-way relay
-/// context, then starting the auto-relay process will handle relaying
-/// between both connected chains in a bi-directional manner. If it is
-/// instead implemented for a one-way relay context, then starting the
-/// auto-relay process will relay in one direction as appropriate for
-/// the implementing context.
-#[derive_component(AutoRelayerComponent, AutoRelayer<Relay>)]
-#[async_trait]
-pub trait CanAutoRelay: HasErrorType {
-    /// Starts the auto-relaying process.
-    async fn auto_relay(&self) -> Result<(), Self::Error>;
-}
 
 /// Similar to the `CanAutoRelay` trait, the main differences are that this
 /// trait only relays to a specific target, i.e., in one direction, as well

--- a/crates/relayer-components/src/relay/traits/components/auto_relayer.rs
+++ b/crates/relayer-components/src/relay/traits/components/auto_relayer.rs
@@ -1,20 +1,15 @@
 use async_trait::async_trait;
-use cgp_core::traits::Async;
+use cgp_macros::derive_component;
 
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
 use crate::std_prelude::*;
 
-/// Similar to the `CanAutoRelay` trait, the main differences are that this
-/// trait only relays to a specific target, i.e., in one direction, as well
-/// as the fact that it is specific to the `Relay` context.
+#[derive_component(AutoRelayerComponent, AutoRelayer<Relay>)]
 #[async_trait]
-pub trait AutoRelayerWithTarget<Relay, Target>: Async
+pub trait CanAutoRelay<Target>: HasRelayChains
 where
-    Relay: HasRelayChains,
-    Target: ChainTarget<Relay>,
+    Target: ChainTarget<Self>,
 {
-    /// Starts the auto-relaying process of relaying to the given `Relay` context's
-    /// target.
-    async fn auto_relay_with_target(relay: &Relay) -> Result<(), Relay::Error>;
+    async fn auto_relay(&self, target: Target) -> Result<(), Self::Error>;
 }

--- a/tools/integration-test/src/tests/transfer.rs
+++ b/tools/integration-test/src/tests/transfer.rs
@@ -1,7 +1,7 @@
 use std::thread::sleep;
 
 use ibc_relayer::config::PacketFilter;
-use ibc_relayer_components::relay::traits::components::auto_relayer::CanAutoRelay;
+use ibc_relayer_components::core::traits::run::CanRun;
 use ibc_test_framework::framework::next::chain::{HasTwoChains, HasTwoChannels};
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
@@ -36,7 +36,7 @@ impl BinaryChannelTest for IbcTransferTest {
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 
         runtime.spawn(async move {
-            let _ = relay_context.auto_relay().await;
+            let _ = relay_context.run().await;
         });
 
         let denom_a = chains.node_a.denom();

--- a/tools/test-framework/src/framework/binary/next.rs
+++ b/tools/test-framework/src/framework/binary/next.rs
@@ -9,7 +9,7 @@ use ibc_relayer::foreign_client::ForeignClient;
 use ibc_relayer::path::PathIdentifiers;
 use ibc_relayer_all_in_one::one_for_all::traits::birelay::OfaBiRelay;
 use ibc_relayer_all_in_one::one_for_all::types::birelay::OfaBiRelayWrapper;
-use ibc_relayer_components::relay::traits::components::auto_relayer::CanAutoRelay;
+use ibc_relayer_components::core::traits::run::CanRun;
 use ibc_relayer_cosmos::contexts::birelay::CosmosBiRelay;
 use ibc_relayer_types::core::ics04_channel::channel::{ChannelEnd, IdentifiedChannelEnd};
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
@@ -285,7 +285,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> CanSpawnRelayer for TestContextV2
         let birelay = self.relayer.clone();
 
         let handle = runtime.runtime.spawn(async move {
-            let _ = birelay.auto_relay().await;
+            let _ = birelay.run().await;
         });
 
         Ok(Some(handle))


### PR DESCRIPTION
- The `CanAutoRelay` and `AutoRelayer` traits have been renamed to `CanRun` and `Runner` so that they can be used in any context.
- The `CanAutoRelayWithTarget` and `AutoRelayerWithTarget` traits have been renamed to `CanAutoRelay` and `AutoRelayer`.