### PR TITLE
Remove generic `ChainHandle` parameter from `CosmosChain`

### DIFF
--- a/crates/cosmos/cosmos-relayer/src/contexts/birelay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/birelay.rs
@@ -1,24 +1,19 @@
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::contexts::relay::CosmosRelay;
 
 #[derive(Clone)]
-pub struct CosmosBiRelay<ChainA, ChainB> {
+pub struct CosmosBiRelay {
     pub runtime: HermesRuntime,
-    pub relay_a_to_b: CosmosRelay<ChainA, ChainB>,
-    pub relay_b_to_a: CosmosRelay<ChainB, ChainA>,
+    pub relay_a_to_b: CosmosRelay,
+    pub relay_b_to_a: CosmosRelay,
 }
 
-impl<ChainA, ChainB> CosmosBiRelay<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
+impl CosmosBiRelay {
     pub fn new(
         runtime: HermesRuntime,
-        relay_a_to_b: CosmosRelay<ChainA, ChainB>,
-        relay_b_to_a: CosmosRelay<ChainB, ChainA>,
+        relay_a_to_b: CosmosRelay,
+        relay_b_to_a: CosmosRelay,
     ) -> Self {
         Self {
             runtime,

--- a/crates/cosmos/cosmos-relayer/src/contexts/builder.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/builder.rs
@@ -31,15 +31,8 @@ pub struct CosmosBuilder {
     pub runtime: HermesRuntime,
     pub batch_config: BatchConfig,
     pub key_map: HashMap<ChainId, Secp256k1KeyPair>,
-    pub chain_cache: Arc<Mutex<BTreeMap<ChainId, CosmosChain<BaseChainHandle>>>>,
-    pub relay_cache: Arc<
-        Mutex<
-            BTreeMap<
-                (ChainId, ChainId, ClientId, ClientId),
-                CosmosRelay<BaseChainHandle, BaseChainHandle>,
-            >,
-        >,
-    >,
+    pub chain_cache: Arc<Mutex<BTreeMap<ChainId, CosmosChain>>>,
+    pub relay_cache: Arc<Mutex<BTreeMap<(ChainId, ChainId, ClientId, ClientId), CosmosRelay>>>,
     pub batch_senders:
         Arc<Mutex<BTreeMap<(ChainId, ChainId, ClientId, ClientId), CosmosBatchSender>>>,
 }
@@ -68,10 +61,7 @@ impl CosmosBuilder {
         }
     }
 
-    pub async fn build_chain(
-        &self,
-        chain_id: &ChainId,
-    ) -> Result<CosmosChain<BaseChainHandle>, Error> {
+    pub async fn build_chain(&self, chain_id: &ChainId) -> Result<CosmosChain, Error> {
         let runtime = self.runtime.runtime.clone();
 
         let (handle, key, chain_config) = task::block_in_place(|| -> Result<_, Error> {
@@ -115,11 +105,11 @@ impl CosmosBuilder {
         &self,
         src_client_id: &ClientId,
         dst_client_id: &ClientId,
-        src_chain: CosmosChain<BaseChainHandle>,
-        dst_chain: CosmosChain<BaseChainHandle>,
+        src_chain: CosmosChain,
+        dst_chain: CosmosChain,
         src_batch_sender: CosmosBatchSender,
         dst_batch_sender: CosmosBatchSender,
-    ) -> Result<CosmosRelay<BaseChainHandle, BaseChainHandle>, Error> {
+    ) -> Result<CosmosRelay, Error> {
         let relay = CosmosRelay::new(
             self.runtime.clone(),
             src_chain,

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -4,7 +4,7 @@ use hermes_async_runtime_components::subscription::impls::empty::EmptySubscripti
 use hermes_async_runtime_components::subscription::traits::subscription::Subscription;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
 use ibc_relayer::chain::cosmos::types::config::TxConfig;
-use ibc_relayer::chain::handle::ChainHandle;
+use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer::config::EventSourceMode;
 use ibc_relayer::event::source::queries::all as all_queries;
 use ibc_relayer::keyring::Secp256k1KeyPair;
@@ -19,8 +19,8 @@ use crate::impls::subscription::CanCreateAbciEventSubscription;
 use crate::types::telemetry::CosmosTelemetry;
 
 #[derive(Clone)]
-pub struct CosmosChain<Handle> {
-    pub handle: Handle,
+pub struct CosmosChain {
+    pub handle: BaseChainHandle,
     pub chain_id: ChainId,
     pub compat_mode: CompatMode,
     pub runtime: HermesRuntime,
@@ -29,9 +29,9 @@ pub struct CosmosChain<Handle> {
     pub tx_context: Arc<CosmosTxContext>,
 }
 
-impl<Handle: ChainHandle> CosmosChain<Handle> {
+impl CosmosChain {
     pub fn new(
-        handle: Handle,
+        handle: BaseChainHandle,
         tx_config: TxConfig,
         rpc_client: HttpClient,
         compat_mode: CompatMode,

--- a/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 
 use futures::lock::Mutex;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ClientId, PortId};
@@ -12,10 +11,10 @@ use crate::contexts::chain::CosmosChain;
 use crate::types::batch::CosmosBatchSender;
 
 #[derive(Clone)]
-pub struct CosmosRelay<SrcChain, DstChain> {
+pub struct CosmosRelay {
     pub runtime: HermesRuntime,
-    pub src_chain: CosmosChain<SrcChain>,
-    pub dst_chain: CosmosChain<DstChain>,
+    pub src_chain: CosmosChain,
+    pub dst_chain: CosmosChain,
     pub src_client_id: ClientId,
     pub dst_client_id: ClientId,
     pub packet_filter: PacketFilter,
@@ -24,15 +23,11 @@ pub struct CosmosRelay<SrcChain, DstChain> {
     pub dst_chain_message_batch_sender: CosmosBatchSender,
 }
 
-impl<SrcChain, DstChain> CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CosmosRelay {
     pub fn new(
         runtime: HermesRuntime,
-        src_chain: CosmosChain<SrcChain>,
-        dst_chain: CosmosChain<DstChain>,
+        src_chain: CosmosChain,
+        dst_chain: CosmosChain,
         src_client_id: ClientId,
         dst_client_id: ClientId,
         packet_filter: PacketFilter,

--- a/crates/cosmos/cosmos-relayer/src/impls/birelay/components.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/birelay/components.rs
@@ -15,11 +15,7 @@ use crate::impls::error::HandleCosmosError;
 
 pub struct CosmosBiRelayComponents;
 
-impl<ChainA, ChainB> HasComponents for CosmosBiRelay<ChainA, ChainB>
-where
-    ChainA: Async,
-    ChainB: Async,
-{
+impl HasComponents for CosmosBiRelay {
     type Components = CosmosBiRelayComponents;
 }
 

--- a/crates/cosmos/cosmos-relayer/src/impls/birelay/types.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/birelay/types.rs
@@ -1,56 +1,38 @@
-use cgp_core::Async;
 use hermes_relayer_components::birelay::traits::two_way::{
     HasTwoChainTypes, HasTwoWayRelay, HasTwoWayRelayTypes,
 };
 use hermes_relayer_components::runtime::traits::runtime::ProvideRuntime;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::contexts::birelay::CosmosBiRelay;
 use crate::contexts::chain::CosmosChain;
 use crate::contexts::relay::CosmosRelay;
 use crate::impls::birelay::components::CosmosBiRelayComponents;
 
-impl<ChainA, ChainB> HasTwoChainTypes for CosmosBiRelay<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
-    type ChainA = CosmosChain<ChainA>;
+impl HasTwoChainTypes for CosmosBiRelay {
+    type ChainA = CosmosChain;
 
-    type ChainB = CosmosChain<ChainB>;
+    type ChainB = CosmosChain;
 }
 
-impl<ChainA, ChainB> HasTwoWayRelayTypes for CosmosBiRelay<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
-    type RelayAToB = CosmosRelay<ChainA, ChainB>;
+impl HasTwoWayRelayTypes for CosmosBiRelay {
+    type RelayAToB = CosmosRelay;
 
-    type RelayBToA = CosmosRelay<ChainB, ChainA>;
+    type RelayBToA = CosmosRelay;
 }
 
-impl<ChainA, ChainB> HasTwoWayRelay for CosmosBiRelay<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
-    fn relay_a_to_b(&self) -> &CosmosRelay<ChainA, ChainB> {
+impl HasTwoWayRelay for CosmosBiRelay {
+    fn relay_a_to_b(&self) -> &CosmosRelay {
         &self.relay_a_to_b
     }
 
-    fn relay_b_to_a(&self) -> &CosmosRelay<ChainB, ChainA> {
+    fn relay_b_to_a(&self) -> &CosmosRelay {
         &self.relay_b_to_a
     }
 }
 
-impl<ChainA, ChainB> ProvideRuntime<CosmosBiRelay<ChainA, ChainB>> for CosmosBiRelayComponents
-where
-    ChainA: Async,
-    ChainB: Async,
-{
-    fn runtime(birelay: &CosmosBiRelay<ChainA, ChainB>) -> &HermesRuntime {
+impl ProvideRuntime<CosmosBiRelay> for CosmosBiRelayComponents {
+    fn runtime(birelay: &CosmosBiRelay) -> &HermesRuntime {
         &birelay.runtime
     }
 }

--- a/crates/cosmos/cosmos-relayer/src/impls/build/birelay.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/build/birelay.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use hermes_relayer_components::build::traits::components::birelay_from_relay_builder::BiRelayFromRelayBuilder;
-use ibc_relayer::chain::handle::BaseChainHandle;
 
 use crate::contexts::birelay::CosmosBiRelay;
 use crate::contexts::builder::CosmosBuilder;
@@ -12,9 +11,9 @@ use crate::types::error::Error;
 impl BiRelayFromRelayBuilder<CosmosBuilder> for CosmosBuildComponents {
     async fn build_birelay_from_relays(
         build: &CosmosBuilder,
-        relay_a_to_b: CosmosRelay<BaseChainHandle, BaseChainHandle>,
-        relay_b_to_a: CosmosRelay<BaseChainHandle, BaseChainHandle>,
-    ) -> Result<CosmosBiRelay<BaseChainHandle, BaseChainHandle>, Error> {
+        relay_a_to_b: CosmosRelay,
+        relay_b_to_a: CosmosRelay,
+    ) -> Result<CosmosBiRelay, Error> {
         let birelay = CosmosBiRelay {
             runtime: build.runtime.clone(),
             relay_a_to_b,

--- a/crates/cosmos/cosmos-relayer/src/impls/build/cache.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/build/cache.rs
@@ -5,7 +5,7 @@ use hermes_relayer_components::build::traits::cache::{HasChainCache, HasRelayCac
 use hermes_relayer_components::build::traits::target::chain::{ChainATarget, ChainBTarget};
 use hermes_relayer_components::build::traits::target::relay::{RelayAToBTarget, RelayBToATarget};
 use hermes_relayer_components_extra::build::traits::cache::HasBatchSenderCache;
-use ibc_relayer::chain::handle::BaseChainHandle;
+
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
 
 use crate::contexts::builder::CosmosBuilder;
@@ -15,39 +15,25 @@ use crate::types::batch::CosmosBatchSender;
 use crate::types::error::Error;
 
 impl HasChainCache<ChainATarget> for CosmosBuilder {
-    fn chain_cache(&self) -> &Mutex<BTreeMap<ChainId, CosmosChain<BaseChainHandle>>> {
+    fn chain_cache(&self) -> &Mutex<BTreeMap<ChainId, CosmosChain>> {
         &self.chain_cache
     }
 }
 
 impl HasChainCache<ChainBTarget> for CosmosBuilder {
-    fn chain_cache(&self) -> &Mutex<BTreeMap<ChainId, CosmosChain<BaseChainHandle>>> {
+    fn chain_cache(&self) -> &Mutex<BTreeMap<ChainId, CosmosChain>> {
         &self.chain_cache
     }
 }
 
 impl HasRelayCache<RelayAToBTarget> for CosmosBuilder {
-    fn relay_cache(
-        &self,
-    ) -> &Mutex<
-        BTreeMap<
-            (ChainId, ChainId, ClientId, ClientId),
-            CosmosRelay<BaseChainHandle, BaseChainHandle>,
-        >,
-    > {
+    fn relay_cache(&self) -> &Mutex<BTreeMap<(ChainId, ChainId, ClientId, ClientId), CosmosRelay>> {
         &self.relay_cache
     }
 }
 
 impl HasRelayCache<RelayBToATarget> for CosmosBuilder {
-    fn relay_cache(
-        &self,
-    ) -> &Mutex<
-        BTreeMap<
-            (ChainId, ChainId, ClientId, ClientId),
-            CosmosRelay<BaseChainHandle, BaseChainHandle>,
-        >,
-    > {
+    fn relay_cache(&self) -> &Mutex<BTreeMap<(ChainId, ChainId, ClientId, ClientId), CosmosRelay>> {
         &self.relay_cache
     }
 }

--- a/crates/cosmos/cosmos-relayer/src/impls/build/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/build/chain.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use hermes_relayer_components::build::traits::components::chain_builder::ChainBuilder;
 use hermes_relayer_components::build::traits::target::chain::{ChainATarget, ChainBTarget};
-use ibc_relayer::chain::handle::BaseChainHandle;
+
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 
 use crate::contexts::builder::CosmosBuilder;
@@ -15,7 +15,7 @@ impl ChainBuilder<CosmosBuilder, ChainATarget> for CosmosBaseBuildComponents {
         build: &CosmosBuilder,
         _target: ChainATarget,
         chain_id: &ChainId,
-    ) -> Result<CosmosChain<BaseChainHandle>, Error> {
+    ) -> Result<CosmosChain, Error> {
         let chain = build.build_chain(chain_id).await?;
 
         Ok(chain)
@@ -28,7 +28,7 @@ impl ChainBuilder<CosmosBuilder, ChainBTarget> for CosmosBaseBuildComponents {
         build: &CosmosBuilder,
         _target: ChainBTarget,
         chain_id: &ChainId,
-    ) -> Result<CosmosChain<BaseChainHandle>, Error> {
+    ) -> Result<CosmosChain, Error> {
         let chain = build.build_chain(chain_id).await?;
 
         Ok(chain)

--- a/crates/cosmos/cosmos-relayer/src/impls/build/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/build/relay.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use hermes_relayer_components::build::traits::target::relay::{RelayAToBTarget, RelayBToATarget};
 use hermes_relayer_components_extra::build::traits::components::relay_with_batch_builder::RelayWithBatchBuilder;
-use ibc_relayer::chain::handle::BaseChainHandle;
+
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 
 use crate::contexts::builder::CosmosBuilder;
@@ -17,11 +17,11 @@ impl RelayWithBatchBuilder<CosmosBuilder, RelayAToBTarget> for CosmosBuildCompon
         build: &CosmosBuilder,
         src_client_id: &ClientId,
         dst_client_id: &ClientId,
-        src_chain: CosmosChain<BaseChainHandle>,
-        dst_chain: CosmosChain<BaseChainHandle>,
+        src_chain: CosmosChain,
+        dst_chain: CosmosChain,
         src_batch_sender: CosmosBatchSender,
         dst_batch_sender: CosmosBatchSender,
-    ) -> Result<CosmosRelay<BaseChainHandle, BaseChainHandle>, Error> {
+    ) -> Result<CosmosRelay, Error> {
         let relay = build.build_relay(
             src_client_id,
             dst_client_id,
@@ -41,11 +41,11 @@ impl RelayWithBatchBuilder<CosmosBuilder, RelayBToATarget> for CosmosBuildCompon
         build: &CosmosBuilder,
         src_client_id: &ClientId,
         dst_client_id: &ClientId,
-        src_chain: CosmosChain<BaseChainHandle>,
-        dst_chain: CosmosChain<BaseChainHandle>,
+        src_chain: CosmosChain,
+        dst_chain: CosmosChain,
         src_batch_sender: CosmosBatchSender,
         dst_batch_sender: CosmosBatchSender,
-    ) -> Result<CosmosRelay<BaseChainHandle, BaseChainHandle>, Error> {
+    ) -> Result<CosmosRelay, Error> {
         let relay = build.build_relay(
             src_client_id,
             dst_client_id,

--- a/crates/cosmos/cosmos-relayer/src/impls/build/types.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/build/types.rs
@@ -1,14 +1,13 @@
 use hermes_relayer_components::build::traits::birelay::HasBiRelayType;
 use hermes_relayer_components::runtime::traits::runtime::ProvideRuntime;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::BaseChainHandle;
 
 use crate::contexts::birelay::CosmosBiRelay;
 use crate::contexts::builder::CosmosBuilder;
 use crate::impls::build::components::CosmosBuildComponents;
 
 impl HasBiRelayType for CosmosBuilder {
-    type BiRelay = CosmosBiRelay<BaseChainHandle, BaseChainHandle>;
+    type BiRelay = CosmosBiRelay;
 }
 
 impl ProvideRuntime<CosmosBuilder> for CosmosBuildComponents {

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/component.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/component.rs
@@ -27,7 +27,7 @@ use hermes_cosmos_client_components::components::timeout_packet_payload::BuildCo
 use hermes_cosmos_client_components::components::types::chain::ProvideCosmosChainTypes;
 use hermes_cosmos_client_components::components::update_client_message::BuildCosmosUpdateClientMessage;
 use hermes_cosmos_client_components::components::update_client_payload::BuildUpdateClientPayloadWithChainHandle;
-use ibc_relayer::chain::handle::ChainHandle;
+
 use hermes_relayer_components::chain::traits::components::ack_packet_message_builder::AckPacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::components::ack_packet_payload_builder::AckPacketPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::components::chain_status_querier::ChainStatusQuerierComponent;
@@ -91,10 +91,7 @@ impl HasComponents for CosmosChainComponents {
     type Components = CosmosBaseChainComponents;
 }
 
-impl<Chain> HasComponents for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl HasComponents for CosmosChain {
     type Components = CosmosChainComponents;
 }
 
@@ -104,13 +101,7 @@ delegate_all!(
     CosmosChainComponents,
 );
 
-impl<Chain, Counterparty> CanUseExtraChainComponents<CosmosChain<Counterparty>>
-    for CosmosChain<Chain>
-where
-    Chain: ChainHandle,
-    Counterparty: ChainHandle,
-{
-}
+impl CanUseExtraChainComponents<CosmosChain> for CosmosChain {}
 
 delegate_components! {
     CosmosChainComponents {

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/components/connection_handshake_message.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/components/connection_handshake_message.rs
@@ -8,7 +8,7 @@ use hermes_cosmos_client_components::types::connection::CosmosInitConnectionOpti
 use hermes_relayer_components::chain::traits::components::connection_handshake_message_builder::ConnectionHandshakeMessageBuilder;
 use hermes_relayer_components::chain::traits::types::connection::HasConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use ibc_relayer::chain::handle::ChainHandle;
+
 use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 
 use crate::contexts::chain::CosmosChain;
@@ -16,27 +16,20 @@ use crate::types::error::Error;
 
 pub struct DelegateCosmosConnectionHandshakeBuilder;
 
-impl<Counterparty> DelegateComponent<CosmosChain<Counterparty>>
-    for DelegateCosmosConnectionHandshakeBuilder
-where
-    Counterparty: ChainHandle,
-{
+impl DelegateComponent<CosmosChain> for DelegateCosmosConnectionHandshakeBuilder {
     type Delegate = BuildCosmosConnectionHandshakeMessage;
 }
 
 #[async_trait]
-impl<Chain, Counterparty, Delegate>
-    ConnectionHandshakeMessageBuilder<CosmosChain<Chain>, Counterparty>
+impl<Counterparty, Delegate> ConnectionHandshakeMessageBuilder<CosmosChain, Counterparty>
     for DelegateCosmosConnectionHandshakeBuilder
 where
-    Chain: ChainHandle,
-    Counterparty:
-        HasConnectionHandshakePayloads<CosmosChain<Chain>> + HasIbcChainTypes<CosmosChain<Chain>>,
-    Delegate: ConnectionHandshakeMessageBuilder<CosmosChain<Chain>, Counterparty>,
+    Counterparty: HasConnectionHandshakePayloads<CosmosChain> + HasIbcChainTypes<CosmosChain>,
+    Delegate: ConnectionHandshakeMessageBuilder<CosmosChain, Counterparty>,
     Self: DelegateComponent<Counterparty, Delegate = Delegate>,
 {
     async fn build_connection_open_init_message(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         client_id: &ClientId,
         counterparty_client_id: &Counterparty::ClientId,
         init_connection_options: &CosmosInitConnectionOptions,
@@ -53,7 +46,7 @@ where
     }
 
     async fn build_connection_open_try_message(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         client_id: &ClientId,
         counterparty_client_id: &Counterparty::ClientId,
         counterparty_connection_id: &Counterparty::ConnectionId,
@@ -70,7 +63,7 @@ where
     }
 
     async fn build_connection_open_ack_message(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         connection_id: &ConnectionId,
         counterparty_connection_id: &Counterparty::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenAckPayload,
@@ -85,7 +78,7 @@ where
     }
 
     async fn build_connection_open_confirm_message(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         connection_id: &ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenConfirmPayload,
     ) -> Result<Arc<dyn CosmosMessage>, Error> {

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/components/create_client_message.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/components/create_client_message.rs
@@ -6,30 +6,26 @@ use hermes_cosmos_client_components::components::create_client_message::BuildCos
 use hermes_cosmos_client_components::traits::message::CosmosMessage;
 use hermes_relayer_components::chain::traits::components::create_client_message_builder::CreateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayload;
-use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::contexts::chain::CosmosChain;
 use crate::types::error::Error;
 
 pub struct DelegateCosmosCreateClientMessageBuilder;
 
-impl<Counterparty> DelegateComponent<CosmosChain<Counterparty>>
-    for DelegateCosmosCreateClientMessageBuilder
-{
+impl DelegateComponent<CosmosChain> for DelegateCosmosCreateClientMessageBuilder {
     type Delegate = BuildCosmosCreateClientMessage;
 }
 
 #[async_trait]
-impl<Chain, Counterparty, Delegate> CreateClientMessageBuilder<CosmosChain<Chain>, Counterparty>
+impl<Counterparty, Delegate> CreateClientMessageBuilder<CosmosChain, Counterparty>
     for DelegateCosmosCreateClientMessageBuilder
 where
-    Chain: ChainHandle,
-    Counterparty: HasCreateClientPayload<CosmosChain<Chain>>,
-    Delegate: CreateClientMessageBuilder<CosmosChain<Chain>, Counterparty>,
+    Counterparty: HasCreateClientPayload<CosmosChain>,
+    Delegate: CreateClientMessageBuilder<CosmosChain, Counterparty>,
     Self: DelegateComponent<Counterparty, Delegate = Delegate>,
 {
     async fn build_create_client_message(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         counterparty_payload: Counterparty::CreateClientPayload,
     ) -> Result<Arc<dyn CosmosMessage>, Error> {
         Delegate::build_create_client_message(chain, counterparty_payload).await

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/components/query_client_state.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/components/query_client_state.rs
@@ -3,7 +3,6 @@ use cgp_core::DelegateComponent;
 use hermes_cosmos_client_components::components::query_client_state::QueryCosmosClientStateFromChainHandle;
 use hermes_relayer_components::chain::traits::components::client_state_querier::ClientStateQuerier;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
-use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 
 use crate::contexts::chain::CosmosChain;
@@ -12,25 +11,21 @@ use crate::types::error::Error;
 pub struct DelegateCosmosClientStateQuerier;
 
 #[async_trait]
-impl<Chain, Counterparty, Delegate> ClientStateQuerier<CosmosChain<Chain>, Counterparty>
+impl<Counterparty, Delegate> ClientStateQuerier<CosmosChain, Counterparty>
     for DelegateCosmosClientStateQuerier
 where
-    Chain: ChainHandle,
-    Counterparty: HasClientStateType<CosmosChain<Chain>>,
-    Delegate: ClientStateQuerier<CosmosChain<Chain>, Counterparty>,
+    Counterparty: HasClientStateType<CosmosChain>,
+    Delegate: ClientStateQuerier<CosmosChain, Counterparty>,
     Self: DelegateComponent<Counterparty, Delegate = Delegate>,
 {
     async fn query_client_state(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         client_id: &ClientId,
     ) -> Result<Counterparty::ClientState, Error> {
         Delegate::query_client_state(chain, client_id).await
     }
 }
 
-impl<Counterparty> DelegateComponent<CosmosChain<Counterparty>> for DelegateCosmosClientStateQuerier
-where
-    Counterparty: ChainHandle,
-{
+impl DelegateComponent<CosmosChain> for DelegateCosmosClientStateQuerier {
     type Delegate = QueryCosmosClientStateFromChainHandle;
 }

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/components/query_consensus_state.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/components/query_consensus_state.rs
@@ -4,7 +4,6 @@ use hermes_cosmos_client_components::components::query_consensus_state::QueryCos
 use hermes_relayer_components::chain::traits::components::consensus_state_querier::ConsensusStateQuerier;
 use hermes_relayer_components::chain::traits::types::consensus_state::HasConsensusStateType;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
-use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 
 use crate::contexts::chain::CosmosChain;
@@ -13,16 +12,15 @@ use crate::types::error::Error;
 pub struct DelegateCosmosConsensusStateQuerier;
 
 #[async_trait]
-impl<Chain, Counterparty, Delegate> ConsensusStateQuerier<CosmosChain<Chain>, Counterparty>
+impl<Counterparty, Delegate> ConsensusStateQuerier<CosmosChain, Counterparty>
     for DelegateCosmosConsensusStateQuerier
 where
-    Chain: ChainHandle,
-    Counterparty: HasConsensusStateType<CosmosChain<Chain>> + HasHeightType,
-    Delegate: ConsensusStateQuerier<CosmosChain<Chain>, Counterparty>,
+    Counterparty: HasConsensusStateType<CosmosChain> + HasHeightType,
+    Delegate: ConsensusStateQuerier<CosmosChain, Counterparty>,
     Self: DelegateComponent<Counterparty, Delegate = Delegate>,
 {
     async fn query_consensus_state(
-        chain: &CosmosChain<Chain>,
+        chain: &CosmosChain,
         client_id: &ClientId,
         height: &Counterparty::Height,
     ) -> Result<Counterparty::ConsensusState, Error> {
@@ -30,10 +28,6 @@ where
     }
 }
 
-impl<Counterparty> DelegateComponent<CosmosChain<Counterparty>>
-    for DelegateCosmosConsensusStateQuerier
-where
-    Counterparty: ChainHandle,
-{
+impl DelegateComponent<CosmosChain> for DelegateCosmosConsensusStateQuerier {
     type Delegate = QueryCosmosConsensusStateFromChainHandle;
 }

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/events.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/events.rs
@@ -1,6 +1,5 @@
 use alloc::sync::Arc;
 
-use cgp_core::Async;
 use hermes_cosmos_client_components::methods::event::{
     try_extract_channel_open_init_event, try_extract_channel_open_try_event,
     try_extract_connection_open_init_event, try_extract_connection_open_try_event,
@@ -29,10 +28,7 @@ use tendermint::abci::Event as AbciEvent;
 
 use crate::contexts::chain::CosmosChain;
 
-impl<Chain, Counterparty> HasCreateClientEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasCreateClientEvent<Counterparty> for CosmosChain {
     type CreateClientEvent = CosmosCreateClientEvent;
 
     fn try_extract_create_client_event(event: Arc<AbciEvent>) -> Option<CosmosCreateClientEvent> {
@@ -44,10 +40,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasSendPacketEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasSendPacketEvent<Counterparty> for CosmosChain {
     type SendPacketEvent = SendPacket;
 
     fn try_extract_send_packet_event(event: &Arc<AbciEvent>) -> Option<SendPacket> {
@@ -59,10 +52,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasWriteAckEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasWriteAckEvent<Counterparty> for CosmosChain {
     type WriteAckEvent = WriteAcknowledgement;
 
     fn try_extract_write_ack_event(event: &Arc<AbciEvent>) -> Option<WriteAcknowledgement> {
@@ -70,10 +60,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasConnectionOpenInitEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasConnectionOpenInitEvent<Counterparty> for CosmosChain {
     type ConnectionOpenInitEvent = CosmosConnectionOpenInitEvent;
 
     fn try_extract_connection_open_init_event(
@@ -89,10 +76,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasConnectionOpenTryEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasConnectionOpenTryEvent<Counterparty> for CosmosChain {
     type ConnectionOpenTryEvent = CosmosConnectionOpenTryEvent;
 
     fn try_extract_connection_open_try_event(
@@ -108,10 +92,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasChannelOpenInitEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasChannelOpenInitEvent<Counterparty> for CosmosChain {
     type ChannelOpenInitEvent = CosmosChannelOpenInitEvent;
 
     fn try_extract_channel_open_init_event(
@@ -125,10 +106,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasChannelOpenTryEvent<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasChannelOpenTryEvent<Counterparty> for CosmosChain {
     type ChannelOpenTryEvent = CosmosChannelOpenTryEvent;
 
     fn try_extract_channel_open_try_event(

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/ext.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/ext.rs
@@ -1,21 +1,18 @@
 use async_trait::async_trait;
-use cgp_core::Async;
+
 use hermes_cosmos_client_components::traits::chain_handle::HasBlockingChainHandle;
 use hermes_cosmos_client_components::traits::grpc_address::HasGrpcAddress;
 use hermes_cosmos_client_components::traits::has_tx_context::HasTxContext;
 use hermes_cosmos_client_components::traits::rpc_client::HasRpcClient;
 use http::Uri;
-use ibc_relayer::chain::handle::ChainHandle;
+use ibc_relayer::chain::handle::BaseChainHandle;
 use tendermint_rpc::{HttpClient, Url};
 
 use crate::contexts::chain::CosmosChain;
 use crate::contexts::transaction::CosmosTxContext;
 use crate::types::error::{BaseError, Error};
 
-impl<Chain> HasTxContext for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl HasTxContext for CosmosChain {
     type TxContext = CosmosTxContext;
 
     fn tx_context(&self) -> &Self::TxContext {
@@ -23,19 +20,13 @@ where
     }
 }
 
-impl<Chain> HasGrpcAddress for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl HasGrpcAddress for CosmosChain {
     fn grpc_address(&self) -> &Uri {
         &self.tx_context.tx_config.grpc_address
     }
 }
 
-impl<Chain> HasRpcClient for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl HasRpcClient for CosmosChain {
     fn rpc_client(&self) -> &HttpClient {
         &self.tx_context.rpc_client
     }
@@ -46,15 +37,12 @@ where
 }
 
 #[async_trait]
-impl<Chain> HasBlockingChainHandle for CosmosChain<Chain>
-where
-    Chain: ChainHandle,
-{
-    type ChainHandle = Chain;
+impl HasBlockingChainHandle for CosmosChain {
+    type ChainHandle = BaseChainHandle;
 
     async fn with_blocking_chain_handle<R>(
         &self,
-        cont: impl FnOnce(Chain) -> Result<R, Error> + Send + 'static,
+        cont: impl FnOnce(BaseChainHandle) -> Result<R, Error> + Send + 'static,
     ) -> Result<R, Error>
     where
         R: Send + 'static,

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/fields.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/fields.rs
@@ -1,6 +1,5 @@
 use alloc::sync::Arc;
 
-use cgp_core::Async;
 use hermes_async_runtime_components::subscription::traits::subscription::Subscription;
 use hermes_cosmos_client_components::traits::message::CosmosMessage;
 use hermes_cosmos_client_components::types::tendermint::TendermintClientState;
@@ -20,19 +19,13 @@ use crate::contexts::chain::CosmosChain;
 use crate::impls::chain::component::CosmosChainComponents;
 use crate::types::error::{BaseError, Error};
 
-impl<Chain> CanIncrementHeight for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl CanIncrementHeight for CosmosChain {
     fn increment_height(height: &Height) -> Result<Height, Error> {
         Ok(height.increment())
     }
 }
 
-impl<Chain> CanEstimateMessageSize for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl CanEstimateMessageSize for CosmosChain {
     fn estimate_message_size(message: &Arc<dyn CosmosMessage>) -> Result<usize, Error> {
         let raw = message
             .encode_protobuf(&Signer::dummy())
@@ -42,27 +35,20 @@ where
     }
 }
 
-impl<Chain> ChainIdGetter<CosmosChain<Chain>> for CosmosChainComponents
-where
-    Chain: Async,
-{
-    fn chain_id(chain: &CosmosChain<Chain>) -> &ChainId {
+impl ChainIdGetter<CosmosChain> for CosmosChainComponents {
+    fn chain_id(chain: &CosmosChain) -> &ChainId {
         &chain.chain_id
     }
 }
 
-impl<Chain> HasEventSubscription for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl HasEventSubscription for CosmosChain {
     fn event_subscription(&self) -> &Arc<dyn Subscription<Item = (Height, Arc<AbciEvent>)>> {
         &self.subscription
     }
 }
 
-impl<Chain, Counterparty> HasCounterpartyMessageHeight<Counterparty> for CosmosChain<Chain>
+impl<Counterparty> HasCounterpartyMessageHeight<Counterparty> for CosmosChain
 where
-    Chain: Async,
     Counterparty: HasHeightType<Height = Height>,
 {
     fn counterparty_message_height_for_update_client(
@@ -72,10 +58,7 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasClientStateFields<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasClientStateFields<Counterparty> for CosmosChain {
     fn client_state_latest_height(client_state: &TendermintClientState) -> &Height {
         &client_state.latest_height
     }

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/log.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/log.rs
@@ -1,6 +1,5 @@
 use alloc::sync::Arc;
 
-use cgp_core::Async;
 use hermes_relayer_components::chain::traits::logs::event::CanLogChainEvent;
 use hermes_relayer_components::chain::traits::logs::packet::CanLogChainPacket;
 use hermes_relayer_runtime::types::log::value::LogValue;
@@ -9,19 +8,13 @@ use tendermint::abci::Event as AbciEvent;
 
 use crate::contexts::chain::CosmosChain;
 
-impl<Chain> CanLogChainEvent for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl CanLogChainEvent for CosmosChain {
     fn log_event(event: &Arc<AbciEvent>) -> LogValue<'_> {
         LogValue::Debug(event)
     }
 }
 
-impl<Chain, Counterparty> CanLogChainPacket<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> CanLogChainPacket<Counterparty> for CosmosChain {
     fn log_incoming_packet(packet: &Packet) -> LogValue<'_> {
         LogValue::Display(packet)
     }

--- a/crates/cosmos/cosmos-relayer/src/impls/chain/types.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/chain/types.rs
@@ -1,4 +1,3 @@
-use cgp_core::Async;
 use hermes_cosmos_client_components::types::channel::CosmosInitChannelOptions;
 use hermes_cosmos_client_components::types::connection::CosmosInitConnectionOptions;
 use hermes_cosmos_client_components::types::payloads::channel::{
@@ -41,19 +40,13 @@ use crate::contexts::chain::CosmosChain;
 use crate::impls::chain::component::CosmosChainComponents;
 use crate::types::telemetry::CosmosTelemetry;
 
-impl<Chain> ProvideRuntime<CosmosChain<Chain>> for CosmosChainComponents
-where
-    Chain: Async,
-{
-    fn runtime(chain: &CosmosChain<Chain>) -> &HermesRuntime {
+impl ProvideRuntime<CosmosChain> for CosmosChainComponents {
+    fn runtime(chain: &CosmosChain) -> &HermesRuntime {
         &chain.runtime
     }
 }
 
-impl<Chain> HasTelemetry for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl HasTelemetry for CosmosChain {
     type Telemetry = CosmosTelemetry;
 
     fn telemetry(&self) -> &CosmosTelemetry {
@@ -61,59 +54,35 @@ where
     }
 }
 
-impl<Chain, Counterparty> HasClientStateType<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasClientStateType<Counterparty> for CosmosChain {
     type ClientState = TendermintClientState;
 }
 
-impl<Chain, Counterparty> HasConsensusStateType<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasConsensusStateType<Counterparty> for CosmosChain {
     type ConsensusState = TendermintConsensusState;
 }
 
-impl<Chain, Counterparty> HasCreateClientOptions<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasCreateClientOptions<Counterparty> for CosmosChain {
     type CreateClientPayloadOptions = ClientSettings;
 }
 
-impl<Chain, Counterparty> HasInitConnectionOptionsType<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasInitConnectionOptionsType<Counterparty> for CosmosChain {
     type InitConnectionOptions = CosmosInitConnectionOptions;
 }
 
-impl<Chain, Counterparty> HasInitChannelOptionsType<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasInitChannelOptionsType<Counterparty> for CosmosChain {
     type InitChannelOptions = CosmosInitChannelOptions;
 }
 
-impl<Chain, Counterparty> HasCreateClientPayload<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasCreateClientPayload<Counterparty> for CosmosChain {
     type CreateClientPayload = CosmosCreateClientPayload;
 }
 
-impl<Chain, Counterparty> HasUpdateClientPayload<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasUpdateClientPayload<Counterparty> for CosmosChain {
     type UpdateClientPayload = CosmosUpdateClientPayload;
 }
 
-impl<Chain, Counterparty> HasConnectionHandshakePayloads<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasConnectionHandshakePayloads<Counterparty> for CosmosChain {
     type ConnectionOpenInitPayload = CosmosConnectionOpenInitPayload;
 
     type ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload;
@@ -123,10 +92,7 @@ where
     type ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload;
 }
 
-impl<Chain, Counterparty> HasChannelHandshakePayloads<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasChannelHandshakePayloads<Counterparty> for CosmosChain {
     type ChannelOpenTryPayload = CosmosChannelOpenTryPayload;
 
     type ChannelOpenAckPayload = CosmosChannelOpenAckPayload;
@@ -134,23 +100,14 @@ where
     type ChannelOpenConfirmPayload = CosmosChannelOpenConfirmPayload;
 }
 
-impl<Chain, Counterparty> HasReceivePacketPayload<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasReceivePacketPayload<Counterparty> for CosmosChain {
     type ReceivePacketPayload = CosmosReceivePacketPayload;
 }
 
-impl<Chain, Counterparty> HasAckPacketPayload<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasAckPacketPayload<Counterparty> for CosmosChain {
     type AckPacketPayload = CosmosAckPacketPayload;
 }
 
-impl<Chain, Counterparty> HasTimeoutUnorderedPacketPayload<Counterparty> for CosmosChain<Chain>
-where
-    Chain: Async,
-{
+impl<Counterparty> HasTimeoutUnorderedPacketPayload<Counterparty> for CosmosChain {
     type TimeoutUnorderedPacketPayload = CosmosTimeoutUnorderedPacketPayload;
 }

--- a/crates/cosmos/cosmos-relayer/src/impls/relay/batch.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/relay/batch.rs
@@ -1,29 +1,19 @@
 use async_trait::async_trait;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_relayer_components_extra::batch::traits::channel::HasMessageBatchSender;
-use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::contexts::relay::CosmosRelay;
 use crate::types::batch::CosmosBatchSender;
 
 #[async_trait]
-impl<SrcChain, DstChain> HasMessageBatchSender<SourceTarget> for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl HasMessageBatchSender<SourceTarget> for CosmosRelay {
     fn get_batch_sender(&self) -> &CosmosBatchSender {
         &self.src_chain_message_batch_sender
     }
 }
 
 #[async_trait]
-impl<SrcChain, DstChain> HasMessageBatchSender<DestinationTarget>
-    for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl HasMessageBatchSender<DestinationTarget> for CosmosRelay {
     fn get_batch_sender(&self) -> &CosmosBatchSender {
         &self.dst_chain_message_batch_sender
     }

--- a/crates/cosmos/cosmos-relayer/src/impls/relay/component.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/relay/component.rs
@@ -10,7 +10,6 @@ use hermes_relayer_components_extra::components::extra::relay::{
 };
 use hermes_relayer_runtime::impls::logger::components::ProvideTracingLogger;
 use hermes_relayer_runtime::impls::types::runtime::ProvideTokioRuntimeType;
-use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::contexts::relay::CosmosRelay;
 use crate::impls::error::HandleCosmosError;
@@ -40,17 +39,8 @@ delegate_all!(
     CosmosRelayComponents,
 );
 
-impl<SrcChain, DstChain> HasComponents for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: Async,
-    DstChain: Async,
-{
+impl HasComponents for CosmosRelay {
     type Components = CosmosRelayComponents;
 }
 
-impl<SrcChain, DstChain> CanUseExtraAutoRelayer for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
-}
+impl CanUseExtraAutoRelayer for CosmosRelay {}

--- a/crates/cosmos/cosmos-relayer/src/impls/relay/error.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/relay/error.rs
@@ -1,4 +1,3 @@
-use cgp_core::Async;
 use eyre::eyre;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
 use hermes_relayer_components::relay::components::create_client::CanRaiseMissingCreateClientEventError;
@@ -8,18 +7,14 @@ use hermes_relayer_components::relay::impls::connection::open_init::CanRaiseMiss
 use hermes_relayer_components::relay::impls::connection::open_try::CanRaiseMissingConnectionTryEventError;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_relayer_components_extra::relay::components::packet_relayers::retry::SupportsPacketRetry;
-use ibc_relayer::chain::handle::ChainHandle;
+
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ConnectionId};
 
 use crate::contexts::chain::CosmosChain;
 use crate::contexts::relay::CosmosRelay;
 use crate::types::error::{BaseError, Error};
 
-impl<SrcChain, DstChain> SupportsPacketRetry for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: Async,
-    DstChain: Async,
-{
+impl SupportsPacketRetry for CosmosRelay {
     const MAX_RETRY: usize = 3;
 
     fn is_retryable_error(_: &Error) -> bool {
@@ -31,15 +26,10 @@ where
     }
 }
 
-impl<SrcChain, DstChain> CanRaiseMissingCreateClientEventError<SourceTarget>
-    for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CanRaiseMissingCreateClientEventError<SourceTarget> for CosmosRelay {
     fn missing_create_client_event_error(
-        src_chain: &CosmosChain<SrcChain>,
-        dst_chain: &CosmosChain<DstChain>,
+        src_chain: &CosmosChain,
+        dst_chain: &CosmosChain,
     ) -> Error {
         BaseError::generic(eyre!("missing CreateClient event when creating client from chain {} with counterparty chain {}",
             src_chain.chain_id(),
@@ -48,15 +38,10 @@ where
     }
 }
 
-impl<SrcChain, DstChain> CanRaiseMissingCreateClientEventError<DestinationTarget>
-    for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CanRaiseMissingCreateClientEventError<DestinationTarget> for CosmosRelay {
     fn missing_create_client_event_error(
-        dst_chain: &CosmosChain<DstChain>,
-        src_chain: &CosmosChain<SrcChain>,
+        dst_chain: &CosmosChain,
+        src_chain: &CosmosChain,
     ) -> Error {
         BaseError::generic(eyre!("missing CreateClient event when creating client from chain {} with counterparty chain {}",
             dst_chain.chain_id(),
@@ -65,21 +50,13 @@ where
     }
 }
 
-impl<SrcChain, DstChain> CanRaiseMissingConnectionInitEventError for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CanRaiseMissingConnectionInitEventError for CosmosRelay {
     fn missing_connection_init_event_error(&self) -> Error {
         BaseError::generic(eyre!("missing_connection_init_event_error")).into()
     }
 }
 
-impl<SrcChain, DstChain> CanRaiseMissingConnectionTryEventError for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CanRaiseMissingConnectionTryEventError for CosmosRelay {
     fn missing_connection_try_event_error(&self, src_connection_id: &ConnectionId) -> Error {
         BaseError::generic(eyre!(
             "missing_connection_try_event_error: {}",
@@ -89,21 +66,13 @@ where
     }
 }
 
-impl<SrcChain, DstChain> CanRaiseMissingChannelInitEventError for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CanRaiseMissingChannelInitEventError for CosmosRelay {
     fn missing_channel_init_event_error(&self) -> Error {
         BaseError::generic(eyre!("missing_channel_init_event_error")).into()
     }
 }
 
-impl<SrcChain, DstChain> CanRaiseMissingChannelTryEventError for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl CanRaiseMissingChannelTryEventError for CosmosRelay {
     fn missing_channel_try_event_error(&self, src_channel_id: &ChannelId) -> Error {
         BaseError::generic(eyre!("missing_channel_try_event_error: {}", src_channel_id)).into()
     }

--- a/crates/cosmos/cosmos-relayer/src/impls/relay/packet_filter.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/relay/packet_filter.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use hermes_relayer_components::relay::traits::components::packet_filter::PacketFilter;
-use ibc_relayer::chain::handle::ChainHandle;
+
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
 
 use crate::contexts::relay::CosmosRelay;
@@ -8,15 +8,8 @@ use crate::impls::relay::component::CosmosRelayComponents;
 use crate::types::error::Error;
 
 #[async_trait]
-impl<SrcChain, DstChain> PacketFilter<CosmosRelay<SrcChain, DstChain>> for CosmosRelayComponents
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
-    async fn should_relay_packet(
-        relay: &CosmosRelay<SrcChain, DstChain>,
-        packet: &Packet,
-    ) -> Result<bool, Error> {
+impl PacketFilter<CosmosRelay> for CosmosRelayComponents {
+    async fn should_relay_packet(relay: &CosmosRelay, packet: &Packet) -> Result<bool, Error> {
         Ok(relay
             .packet_filter
             .channel_policy

--- a/crates/cosmos/cosmos-relayer/src/impls/relay/packet_lock.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/relay/packet_lock.rs
@@ -2,17 +2,13 @@ use async_trait::async_trait;
 use hermes_cosmos_client_components::methods::packet_lock::try_acquire_packet_lock;
 use hermes_cosmos_client_components::types::packet_lock::PacketLock;
 use hermes_relayer_components::relay::traits::packet_lock::HasPacketLock;
-use ibc_relayer::chain::handle::ChainHandle;
+
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
 
 use crate::contexts::relay::CosmosRelay;
 
 #[async_trait]
-impl<SrcChain, DstChain> HasPacketLock for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
+impl HasPacketLock for CosmosRelay {
     type PacketLock<'a> = PacketLock;
 
     async fn try_acquire_packet_lock<'a>(&'a self, packet: &'a Packet) -> Option<PacketLock> {

--- a/crates/cosmos/cosmos-relayer/src/impls/relay/types.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/relay/types.rs
@@ -1,8 +1,7 @@
-use cgp_core::Async;
 use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 use hermes_relayer_components::runtime::traits::runtime::ProvideRuntime;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::ChainHandle;
+
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 
@@ -10,22 +9,18 @@ use crate::contexts::chain::CosmosChain;
 use crate::contexts::relay::CosmosRelay;
 use crate::impls::relay::component::CosmosRelayComponents;
 
-impl<SrcChain, DstChain> HasRelayChains for CosmosRelay<SrcChain, DstChain>
-where
-    SrcChain: ChainHandle,
-    DstChain: ChainHandle,
-{
-    type SrcChain = CosmosChain<SrcChain>;
+impl HasRelayChains for CosmosRelay {
+    type SrcChain = CosmosChain;
 
-    type DstChain = CosmosChain<DstChain>;
+    type DstChain = CosmosChain;
 
     type Packet = Packet;
 
-    fn src_chain(&self) -> &CosmosChain<SrcChain> {
+    fn src_chain(&self) -> &CosmosChain {
         &self.src_chain
     }
 
-    fn dst_chain(&self) -> &CosmosChain<DstChain> {
+    fn dst_chain(&self) -> &CosmosChain {
         &self.dst_chain
     }
 
@@ -38,12 +33,8 @@ where
     }
 }
 
-impl<SrcChain, DstChain> ProvideRuntime<CosmosRelay<SrcChain, DstChain>> for CosmosRelayComponents
-where
-    SrcChain: Async,
-    DstChain: Async,
-{
-    fn runtime(relay: &CosmosRelay<SrcChain, DstChain>) -> &HermesRuntime {
+impl ProvideRuntime<CosmosRelay> for CosmosRelayComponents {
+    fn runtime(relay: &CosmosRelay) -> &HermesRuntime {
         &relay.runtime
     }
 }

--- a/crates/solomachine/solomachine-relayer/src/context/relay.rs
+++ b/crates/solomachine/solomachine-relayer/src/context/relay.rs
@@ -1,6 +1,5 @@
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 
 use crate::types::chain::SolomachineChain;
@@ -8,7 +7,7 @@ use crate::types::chain::SolomachineChain;
 pub struct SolomachineRelay<Chain> {
     pub runtime: HermesRuntime,
     pub src_chain: SolomachineChain<Chain>,
-    pub dst_chain: CosmosChain<BaseChainHandle>,
+    pub dst_chain: CosmosChain,
     pub src_client_id: ClientId,
     pub dst_client_id: ClientId,
 }
@@ -17,7 +16,7 @@ impl<Chain> SolomachineRelay<Chain> {
     pub fn new(
         runtime: HermesRuntime,
         src_chain: SolomachineChain<Chain>,
-        dst_chain: CosmosChain<BaseChainHandle>,
+        dst_chain: CosmosChain,
         src_client_id: ClientId,
         dst_client_id: ClientId,
     ) -> Self {

--- a/crates/solomachine/solomachine-relayer/src/impls/relay/types.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/relay/types.rs
@@ -5,7 +5,6 @@ use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 use hermes_relayer_components::runtime::traits::runtime::ProvideRuntime;
 use hermes_relayer_runtime::types::error::TokioRuntimeError;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
-use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 
@@ -64,7 +63,7 @@ where
 {
     type SrcChain = SolomachineChain<Chain>;
 
-    type DstChain = CosmosChain<BaseChainHandle>;
+    type DstChain = CosmosChain;
 
     type Packet = Packet;
 
@@ -80,7 +79,7 @@ where
         &self.src_chain
     }
 
-    fn dst_chain(&self) -> &CosmosChain<BaseChainHandle> {
+    fn dst_chain(&self) -> &CosmosChain {
         &self.dst_chain
     }
 }

--- a/tools/integration-test/src/tests/context.rs
+++ b/tools/integration-test/src/tests/context.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use hermes_cosmos_relayer::contexts::birelay::CosmosBiRelay;
 use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
 use hermes_relayer_components::build::traits::components::birelay_builder::CanBuildBiRelay;
-use ibc_relayer::chain::handle::{BaseChainHandle, ChainHandle};
+use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer::config::Config;
 use ibc_test_framework::error::{handle_generic_error, Error};
@@ -46,7 +46,7 @@ pub fn build_cosmos_relay_context<ChainA, ChainB>(
     config: &Config,
     chains: &ConnectedChains<ChainA, ChainB>,
     packet_filter: PacketFilter,
-) -> Result<CosmosBiRelay<BaseChainHandle, BaseChainHandle>, Error>
+) -> Result<CosmosBiRelay, Error>
 where
     ChainA: ChainHandle,
     ChainB: ChainHandle,

--- a/tools/integration-test/src/tests/packet_clear.rs
+++ b/tools/integration-test/src/tests/packet_clear.rs
@@ -5,7 +5,6 @@ use hermes_relayer_components::chain::traits::components::send_packets_querier::
 use hermes_relayer_components::chain::traits::components::unreceived_packet_sequences_querier::CanQueryUnreceivedPacketSequences;
 use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 use hermes_relayer_components::relay::traits::components::packet_clearer::CanClearPackets;
-use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer::config::PacketFilter;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::Height;
@@ -85,9 +84,7 @@ impl BinaryChannelTest for IbcClearPacketTest {
             info!("Assert query packet commitments works as expected");
 
             let (src_commitments, src_height): (Vec<Sequence>, Height) =
-                <CosmosChain<BaseChainHandle> as CanQueryPacketCommitments<
-                    CosmosChain<BaseChainHandle>,
-                >>::query_packet_commitments(
+                <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                     chain_a,
                     channel.channel_id_a.value(),
                     channel.port_a.value(),
@@ -98,9 +95,7 @@ impl BinaryChannelTest for IbcClearPacketTest {
             assert_eq!(src_commitments, vec!(Sequence::from(1)));
 
             let (dst_commitments, dst_height): (Vec<Sequence>, Height) =
-                <CosmosChain<BaseChainHandle> as CanQueryPacketCommitments<
-                    CosmosChain<BaseChainHandle>,
-                >>::query_packet_commitments(
+                <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                     chain_b,
                     channel.channel_id_b.value(),
                     channel.port_b.value(),
@@ -113,8 +108,8 @@ impl BinaryChannelTest for IbcClearPacketTest {
             info!("Assert query unreceived packet sequences works as expected");
 
             let unreceived_packet_sequences: Vec<Sequence> =
-                <CosmosChain<BaseChainHandle> as CanQueryUnreceivedPacketSequences<
-                    CosmosChain<BaseChainHandle>,
+                <CosmosChain as CanQueryUnreceivedPacketSequences<
+                    CosmosChain,
                 >>::query_unreceived_packet_sequences(
                     chain_a,
                     channel.channel_id_a.value(),
@@ -127,8 +122,8 @@ impl BinaryChannelTest for IbcClearPacketTest {
             assert_eq!(unreceived_packet_sequences, vec!(Sequence::from(1)));
 
             let unreceived_packet_sequences: Vec<Sequence> =
-                <CosmosChain<BaseChainHandle> as CanQueryUnreceivedPacketSequences<
-                    CosmosChain<BaseChainHandle>,
+                <CosmosChain as CanQueryUnreceivedPacketSequences<
+                    CosmosChain,
                 >>::query_unreceived_packet_sequences(
                     chain_b,
                     channel.channel_id_b.value(),
@@ -142,8 +137,8 @@ impl BinaryChannelTest for IbcClearPacketTest {
 
             info!("Assert query unreceived packets works as expected");
 
-            let send_packets = <CosmosChain<BaseChainHandle> as CanQuerySendPackets<
-                CosmosChain<BaseChainHandle>,
+            let send_packets = <CosmosChain as CanQuerySendPackets<
+                CosmosChain,
             >>::query_send_packets_from_sequences(
                 chain_a,
                 channel.channel_id_a.value(),
@@ -158,8 +153,8 @@ impl BinaryChannelTest for IbcClearPacketTest {
 
             assert_eq!(send_packets.len(), 1);
 
-            let send_packets = <CosmosChain<BaseChainHandle> as CanQuerySendPackets<
-                CosmosChain<BaseChainHandle>,
+            let send_packets = <CosmosChain as CanQuerySendPackets<
+                CosmosChain,
             >>::query_send_packets_from_sequences(
                 chain_b,
                 channel.channel_id_b.value(),

--- a/tools/test-framework/src/framework/binary/next.rs
+++ b/tools/test-framework/src/framework/binary/next.rs
@@ -6,7 +6,7 @@ use eyre::eyre;
 use hermes_cosmos_relayer::contexts::birelay::CosmosBiRelay;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use ibc_relayer::chain::counterparty::unreceived_acknowledgements;
-use ibc_relayer::chain::handle::{BaseChainHandle, ChainHandle};
+use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::chain::requests::{IncludeProof, QueryChannelRequest, QueryHeight};
 use ibc_relayer::foreign_client::ForeignClient;
 use ibc_relayer::path::PathIdentifiers;
@@ -225,7 +225,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> HasContextId for TestContextV1<Ch
 pub struct TestContextV2<ChainA: ChainHandle, ChainB: ChainHandle> {
     pub context_id: String,
     pub config: TestConfig,
-    pub relayer: CosmosBiRelay<BaseChainHandle, BaseChainHandle>,
+    pub relayer: CosmosBiRelay,
     pub chains: ConnectedChains<ChainA, ChainB>,
     pub channel: ConnectedChannel<ChainA, ChainB>,
 }


### PR DESCRIPTION
## Description

With context-generic programming, it is no longer necessary to explicitly tag the source and destination Cosmos chains through the regular generic parameters. Furthermore, we plan to remove the dependency to `ChainHandle` from `CosmosChain`.