### PR TITLE
Build `CosmosChain` inside test bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "ibc-relayer-types",
  "serde_json",
  "stable-eyre",
+ "tendermint-rpc",
  "tokio",
  "toml 0.8.8",
 ]

--- a/crates/cosmos/cosmos-integration-tests/Cargo.toml
+++ b/crates/cosmos/cosmos-integration-tests/Cargo.toml
@@ -24,6 +24,7 @@ hermes-cosmos-relayer               = { workspace = true }
 hermes-test-components              = { workspace = true }
 hermes-cosmos-client-components     = { workspace = true }
 hermes-cosmos-test-components       = { workspace = true }
+tendermint-rpc                      = { workspace = true }
 
 eyre            = { workspace = true }
 tokio           = { workspace = true }

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/chain.rs
@@ -1,5 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_cosmos_client_components::components::types::chain::ProvideCosmosChainTypes;
+use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_test_components::chain::impls::address::ProvideStringAddress;
 use hermes_cosmos_test_components::chain::impls::amount::ProvideU128AmountWithDenom;
 use hermes_cosmos_test_components::chain::impls::chain_id::BuildCosmosChainIdFromString;
@@ -13,8 +14,12 @@ use hermes_test_components::chain::traits::types::denom::DenomTypeComponent;
 use hermes_test_components::chain::traits::types::wallet::{
     WalletSignerComponent, WalletTypeComponent,
 };
+use tokio::process::Child;
 
-pub struct CosmosTestChain;
+pub struct CosmosTestChain {
+    pub base_chain: CosmosChain,
+    pub full_node_process: Child,
+}
 
 pub struct CosmosTestChainComponents;
 

--- a/crates/cosmos/cosmos-integration-tests/src/tests/bootstrap.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/tests/bootstrap.rs
@@ -19,6 +19,7 @@ fn test_bootstrap_cosmos_chain() -> Result<(), Error> {
         should_randomize_identifiers: false,
         test_dir: "./test-data".into(),
         chain_command_path: "gaiad".into(),
+        account_prefix: "cosmos".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     };

--- a/crates/cosmos/cosmos-relayer/src/contexts/builder.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/builder.rs
@@ -15,7 +15,6 @@ use ibc_relayer::spawn::spawn_chain_runtime;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
 use tendermint_rpc::client::CompatMode;
 use tendermint_rpc::{Client, HttpClient};
-use tokio::runtime::Runtime as TokioRuntime;
 use tokio::task;
 
 use crate::contexts::chain::CosmosChain;
@@ -40,14 +39,12 @@ pub struct CosmosBuilder {
 impl CosmosBuilder {
     pub fn new(
         config: Config,
-        runtime: Arc<TokioRuntime>,
+        runtime: HermesRuntime,
         telemetry: CosmosTelemetry,
         packet_filter: PacketFilter,
         batch_config: BatchConfig,
         key_map: HashMap<ChainId, Secp256k1KeyPair>,
     ) -> Self {
-        let runtime = HermesRuntime::new(runtime);
-
         Self {
             config,
             packet_filter,

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk.rs
@@ -98,8 +98,8 @@ where
         + CanRaiseError<IoError>,
     Components: DelegatesToCosmosSdkBootstrapComponents
         + ProvideChainType<Bootstrap, Chain = Chain>
-        + ProvideGenesisConfigType<Bootstrap>
-        + ProvideChainConfigType<Bootstrap>
+        + ProvideGenesisConfigType<Bootstrap, GenesisConfig = CosmosGenesisConfig>
+        + ProvideChainConfigType<Bootstrap, ChainConfig = CosmosChainConfig>
         + TestDirGetter<Bootstrap>
         + ChainCommandPathGetter<Bootstrap>
         + RandomIdFlagGetter<Bootstrap>
@@ -122,7 +122,5 @@ where
     Chain::ChainId: Display,
     Runtime::FilePath: AsRef<Path>,
     Bootstrap::Error: From<Report>,
-    Components::GenesisConfig: From<CosmosGenesisConfig>,
-    Components::ChainConfig: From<CosmosChainConfig>,
 {
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk_legacy.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk_legacy.rs
@@ -92,8 +92,8 @@ where
         + CanRaiseError<IoError>,
     Components: DelegatesToLegacyToCosmosSdkBootstrapComponents
         + ProvideChainType<Bootstrap, Chain = Chain>
-        + ProvideGenesisConfigType<Bootstrap>
-        + ProvideChainConfigType<Bootstrap>
+        + ProvideGenesisConfigType<Bootstrap, GenesisConfig = CosmosGenesisConfig>
+        + ProvideChainConfigType<Bootstrap, ChainConfig = CosmosChainConfig>
         + TestDirGetter<Bootstrap>
         + ChainCommandPathGetter<Bootstrap>
         + RandomIdFlagGetter<Bootstrap>
@@ -116,7 +116,5 @@ where
     Chain::ChainId: Display,
     Runtime::FilePath: AsRef<Path>,
     Bootstrap::Error: From<Report>,
-    Components::GenesisConfig: From<CosmosGenesisConfig>,
-    Components::ChainConfig: From<CosmosChainConfig>,
 {
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/impls/chain/bootstrap_chain.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/impls/chain/bootstrap_chain.rs
@@ -83,7 +83,9 @@ where
         let chain_config = bootstrap.init_chain_config(&chain_home_dir).await?;
 
         // Start the chain full node in the background, and return the child process handle
-        let chain_process = bootstrap.start_chain_full_node(&chain_home_dir).await?;
+        let chain_process = bootstrap
+            .start_chain_full_node(&chain_home_dir, &chain_config)
+            .await?;
 
         // Build the chain context from the bootstrap parameters
         let chain = bootstrap

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/impls/chain/start_chain.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/impls/chain/start_chain.rs
@@ -5,18 +5,24 @@ use hermes_test_components::runtime::traits::types::file_path::HasFilePathType;
 
 use crate::bootstrap::traits::chain::start_chain::ChainFullNodeStarter;
 use crate::bootstrap::traits::fields::chain_command_path::HasChainCommandPath;
+use crate::bootstrap::traits::types::chain_config::HasChainConfigType;
+use crate::bootstrap::types::chain_config::CosmosChainConfig;
 
 pub struct StartCosmosChain;
 
 #[async_trait]
 impl<Bootstrap, Runtime> ChainFullNodeStarter<Bootstrap> for StartCosmosChain
 where
-    Bootstrap: HasRuntime<Runtime = Runtime> + HasErrorType + HasChainCommandPath,
+    Bootstrap: HasRuntime<Runtime = Runtime>
+        + HasErrorType
+        + HasChainCommandPath
+        + HasChainConfigType<ChainConfig = CosmosChainConfig>,
     Runtime: HasFilePathType + CanStartChildProcess,
 {
     async fn start_chain_full_node(
         bootstrap: &Bootstrap,
         chain_home_dir: &Runtime::FilePath,
+        chain_config: &CosmosChainConfig,
     ) -> Result<Runtime::ChildProcess, Bootstrap::Error> {
         let chain_command = bootstrap.chain_command_path();
 
@@ -26,6 +32,10 @@ where
             "start",
             "--pruning",
             "nothing",
+            "--grpc.address",
+            &format!("localhost:{}", chain_config.grpc_port),
+            "--rpc.laddr",
+            &format!("tcp://localhost:{}", chain_config.rpc_port),
         ];
 
         let stdout_path = Runtime::join_file_path(

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/chain/start_chain.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/chain/start_chain.rs
@@ -5,14 +5,17 @@ use hermes_test_components::runtime::traits::types::child_process::{
 };
 use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
 
+use crate::bootstrap::traits::types::chain_config::HasChainConfigType;
+
 #[derive_component(ChainFullNodeStarterComponent, ChainFullNodeStarter<Bootstrap>)]
 #[async_trait]
-pub trait CanStartChainFullNode: HasRuntime + HasErrorType
+pub trait CanStartChainFullNode: HasChainConfigType + HasRuntime + HasErrorType
 where
     Self::Runtime: HasChildProcessType + HasFilePathType,
 {
     async fn start_chain_full_node(
         &self,
         chain_home_dir: &FilePath<Self::Runtime>,
+        chain_config: &Self::ChainConfig,
     ) -> Result<ChildProcess<Self::Runtime>, Self::Error>;
 }

--- a/tools/integration-test/src/tests/context.rs
+++ b/tools/integration-test/src/tests/context.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use hermes_cosmos_relayer::contexts::birelay::CosmosBiRelay;
 use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
 use hermes_relayer_components::build::traits::components::birelay_builder::CanBuildBiRelay;
+use hermes_relayer_runtime::types::runtime::HermesRuntime;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer::config::Config;
@@ -32,7 +33,7 @@ where
 
     let builder = CosmosBuilder::new(
         config.clone(),
-        runtime,
+        HermesRuntime::new(runtime),
         Default::default(),
         packet_filter,
         Default::default(),


### PR DESCRIPTION
## Description

This PR adds the step to construct the `CosmosChain` context inside the bootstrap context after bootstrapping a chain full node.