### PR TITLE
Add -Of postfix to context type aliases

### DIFF
--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/bridge_store_dir.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/bridge_store_dir.rs
@@ -1,12 +1,12 @@
 use cgp_core::prelude::*;
 
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(BridgeStoreDirGetterComponent, BridgeStoreDirGetter<Bootstrap>)]
 pub trait HasBridgeStoreDir: HasRuntime
 where
     Self::Runtime: HasFilePathType,
 {
-    fn bridge_store_dir(&self) -> &FilePath<Self::Runtime>;
+    fn bridge_store_dir(&self) -> &FilePathOf<Self::Runtime>;
 }

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/import_bridge_key.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/import_bridge_key.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 /**
    Initialize a new chain with data files stored at the given home directory
@@ -14,7 +14,7 @@ where
 {
     async fn import_bridge_key(
         &self,
-        bridge_home_dir: &FilePath<Self::Runtime>,
+        bridge_home_dir: &FilePathOf<Self::Runtime>,
         chain_driver: &Self::ChainDriver,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/init_bridge_config.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/init_bridge_config.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntimeType;
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 use crate::bootstrap::traits::types::bridge_config::HasBridgeConfigType;
 
@@ -14,7 +14,7 @@ where
 {
     async fn init_bridge_config(
         &self,
-        bridge_home_dir: &FilePath<Self::Runtime>,
+        bridge_home_dir: &FilePathOf<Self::Runtime>,
         chain_driver: &Self::ChainDriver,
     ) -> Result<Self::BridgeConfig, Self::Error>;
 }

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/init_bridge_data.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/init_bridge_data.rs
@@ -1,9 +1,9 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 /**
    Initialize a new chain with data files stored at the given home directory
@@ -17,7 +17,7 @@ where
 {
     async fn init_bridge_data(
         &self,
-        bridge_home_dir: &FilePath<Self::Runtime>,
-        chain_id: &ChainId<Self::Chain>,
+        bridge_home_dir: &FilePathOf<Self::Runtime>,
+        chain_id: &ChainIdOf<Self::Chain>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/start_bridge.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/start_bridge.rs
@@ -4,7 +4,7 @@ use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverT
 use hermes_test_components::runtime::traits::types::child_process::{
     ChildProcess, HasChildProcessType,
 };
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(BridgeStarterComponent, BridgeStarter<Bootstrap>)]
 #[async_trait]
@@ -14,7 +14,7 @@ where
 {
     async fn start_bridge(
         &self,
-        bridge_home_dir: &FilePath<Self::Runtime>,
+        bridge_home_dir: &FilePathOf<Self::Runtime>,
         chain_driver: &Self::ChainDriver,
     ) -> Result<ChildProcess<Self::Runtime>, Self::Error>;
 }

--- a/crates/cosmos/cosmos-relayer/src/impls/transaction/fields.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/transaction/fields.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 
 use futures::lock::Mutex;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdGetter;
-use hermes_relayer_components::runtime::traits::mutex::HasMutex;
+use hermes_relayer_components::runtime::traits::mutex::MutexGuardOf;
 use hermes_relayer_components::transaction::components::poll_tx_response::HasPollTimeout;
 use hermes_relayer_components::transaction::traits::fee::HasFeeForSimulation;
 use hermes_relayer_components::transaction::traits::nonce::mutex::HasMutexForNonceAllocation;
@@ -48,7 +48,7 @@ impl HasMutexForNonceAllocation for CosmosTxContext {
     }
 
     fn mutex_to_nonce_guard<'a>(
-        mutex_guard: <Self::Runtime as HasMutex>::MutexGuard<'a, ()>,
+        mutex_guard: MutexGuardOf<'a, Self::Runtime, ()>,
         nonce: Self::Nonce,
     ) -> Self::NonceGuard<'a> {
         (mutex_guard, nonce)

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/chain/build_chain.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/chain/build_chain.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::wallet::{HasWalletType, Wallet};
 
@@ -8,7 +8,7 @@ use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverT
 use hermes_test_components::runtime::traits::types::child_process::{
     ChildProcess, HasChildProcessType,
 };
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 use crate::bootstrap::traits::types::chain_config::HasChainConfigType;
 use crate::bootstrap::traits::types::genesis_config::HasGenesisConfigType;
@@ -24,8 +24,8 @@ where
 {
     async fn build_chain_from_bootstrap_params(
         &self,
-        chain_home_dir: FilePath<Self::Runtime>,
-        chain_id: ChainId<Self::Chain>,
+        chain_home_dir: FilePathOf<Self::Runtime>,
+        chain_id: ChainIdOf<Self::Chain>,
         genesis_config: Self::GenesisConfig,
         chain_config: Self::ChainConfig,
         wallets: Vec<Wallet<Self::ChainDriver>>,

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/chain/start_chain.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/chain/start_chain.rs
@@ -3,7 +3,7 @@ use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::runtime::traits::types::child_process::{
     ChildProcess, HasChildProcessType,
 };
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 use crate::bootstrap::traits::types::chain_config::HasChainConfigType;
 
@@ -15,7 +15,7 @@ where
 {
     async fn start_chain_full_nodes(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
         chain_config: &Self::ChainConfig,
     ) -> Result<Vec<ChildProcess<Self::Runtime>>, Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_command_path.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_command_path.rs
@@ -1,11 +1,11 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(ChainCommandPathComponent, ChainCommandPathGetter<Bootstrap>)]
 pub trait HasChainCommandPath: HasRuntime
 where
     Self::Runtime: HasFilePathType,
 {
-    fn chain_command_path(&self) -> &FilePath<Self::Runtime>;
+    fn chain_command_path(&self) -> &FilePathOf<Self::Runtime>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_store_dir.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_store_dir.rs
@@ -1,11 +1,11 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(ChainStoreDirGetterComponent, ChainStoreDirGetter<Bootstrap>)]
 pub trait HasChainStoreDir: HasRuntime
 where
     Self::Runtime: HasFilePathType,
 {
-    fn chain_store_dir(&self) -> &FilePath<Self::Runtime>;
+    fn chain_store_dir(&self) -> &FilePathOf<Self::Runtime>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/generator/generate_chain_id.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/generator/generate_chain_id.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
 
 #[derive_component(ChainIdGeneratorComponent, ChainIdGenerator<Bootstrap>)]
@@ -9,5 +9,5 @@ pub trait CanGenerateChainId: HasChainType
 where
     Self::Chain: HasChainIdType,
 {
-    async fn generate_chain_id(&self, chain_id_prefix: &str) -> ChainId<Self::Chain>;
+    async fn generate_chain_id(&self, chain_id_prefix: &str) -> ChainIdOf<Self::Chain>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/add_genesis_account.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/add_genesis_account.rs
@@ -4,7 +4,7 @@ use hermes_test_components::chain_driver::traits::types::address::{Address, HasA
 use hermes_test_components::chain_driver::traits::types::amount::{Amount, HasAmountType};
 
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(GenesisAccountAdderComponent, GenesisAccountAdder<Bootstrap>)]
 #[async_trait]
@@ -15,7 +15,7 @@ where
 {
     async fn add_genesis_account(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
         address: &Address<Self::ChainDriver>,
         amounts: &[Amount<Self::ChainDriver>],
     ) -> Result<(), Self::Error>;

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/add_genesis_validator.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/add_genesis_validator.rs
@@ -1,11 +1,11 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::amount::{Amount, HasAmountType};
 
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(GenesisValidatorAdderComponent, GenesisValidatorAdder<Bootstrap>)]
 #[async_trait]
@@ -17,8 +17,8 @@ where
 {
     async fn add_genesis_validator(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
-        chain_id: &ChainId<Self::Chain>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
+        chain_id: &ChainIdOf<Self::Chain>,
         wallet_id: &str,
         stake_amount: &Amount<Self::ChainDriver>,
     ) -> Result<(), Self::Error>;

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/add_genesis_wallet.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/add_genesis_wallet.rs
@@ -1,10 +1,10 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::wallet::{HasWalletType, Wallet};
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 use crate::bootstrap::traits::types::wallet_config::HasWalletConfigType;
 
@@ -19,8 +19,8 @@ where
 {
     async fn add_wallet_to_genesis(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
-        chain_id: &ChainId<Self::Chain>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
+        chain_id: &ChainIdOf<Self::Chain>,
         wallet_config: &Self::WalletConfig,
     ) -> Result<Wallet<Self::ChainDriver>, Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/collect_gentxs.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/genesis/collect_gentxs.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(GenesisTransactionsCollectorComponent, GenesisTransactionsCollector<Bootstrap>)]
 #[async_trait]
@@ -10,6 +10,6 @@ where
 {
     async fn collect_genesis_transactions(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_chain_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_chain_config.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntimeType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 use crate::bootstrap::traits::types::chain_config::HasChainConfigType;
 
@@ -12,6 +12,6 @@ where
 {
     async fn init_chain_config(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
     ) -> Result<Self::ChainConfig, Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_chain_data.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_chain_data.rs
@@ -1,9 +1,9 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 /**
    Initialize a new chain with data files stored at the given home directory
@@ -17,7 +17,7 @@ where
 {
     async fn init_chain_data(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
-        chain_id: &ChainId<Self::Chain>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
+        chain_id: &ChainIdOf<Self::Chain>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_chain_home_dir.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_chain_home_dir.rs
@@ -1,9 +1,9 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(ChainHomeDirInitializerComponent, ChainHomeDirInitializer<Bootstrap>)]
 #[async_trait]
@@ -14,6 +14,6 @@ where
 {
     async fn init_chain_home_dir(
         &self,
-        chain_id: &ChainId<Self::Chain>,
-    ) -> Result<FilePath<Self::Runtime>, Self::Error>;
+        chain_id: &ChainIdOf<Self::Chain>,
+    ) -> Result<FilePathOf<Self::Runtime>, Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_genesis_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_genesis_config.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 use crate::bootstrap::traits::types::genesis_config::HasGenesisConfigType;
 
@@ -12,6 +12,6 @@ where
 {
     async fn init_genesis_config(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
     ) -> Result<Self::GenesisConfig, Self::Error>;
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_wallet.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/initializers/init_wallet.rs
@@ -3,7 +3,7 @@ use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::wallet::{HasWalletType, Wallet};
 
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use hermes_test_components::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(WalletInitializerComponent, WalletInitializer<Bootstrap>)]
 #[async_trait]
@@ -14,7 +14,7 @@ where
 {
     async fn initialize_wallet(
         &self,
-        chain_home_dir: &FilePath<Self::Runtime>,
+        chain_home_dir: &FilePathOf<Self::Runtime>,
         wallet_id: &str,
     ) -> Result<Wallet<Self::ChainDriver>, Self::Error>;
 }

--- a/crates/relayer/relayer-components-extra/src/batch/traits/channel.rs
+++ b/crates/relayer/relayer-components-extra/src/batch/traits/channel.rs
@@ -3,7 +3,7 @@ use hermes_relayer_components::chain::traits::types::chain::HasChainTypes;
 use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 use hermes_relayer_components::relay::traits::target::ChainTarget;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_relayer_components::runtime::types::aliases::Runtime;
+use hermes_relayer_components::runtime::types::aliases::RuntimeOf;
 
 use crate::batch::types::aliases::MessageBatchSender;
 use crate::runtime::traits::channel::HasChannelTypes;
@@ -13,7 +13,7 @@ pub trait HasMessageBatchSender<Target>: HasRelayChains
 where
     Target: ChainTarget<Self>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     fn get_batch_sender(&self) -> &MessageBatchSender<Target::TargetChain, Self::Error>;
 }

--- a/crates/relayer/relayer-components-extra/src/batch/types/aliases.rs
+++ b/crates/relayer/relayer-components-extra/src/batch/types/aliases.rs
@@ -2,19 +2,20 @@ use alloc::vec::Vec;
 
 use hermes_relayer_components::chain::traits::types::event::HasEventType;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
-use hermes_relayer_components::runtime::types::aliases::Runtime;
+use hermes_relayer_components::runtime::types::aliases::RuntimeOf;
 
 use crate::runtime::traits::channel::HasChannelTypes;
 use crate::runtime::traits::channel_once::HasChannelOnceTypes;
 
-pub type Sender<Chain, Payload> = <Runtime<Chain> as HasChannelTypes>::Sender<Payload>;
+pub type Sender<Chain, Payload> = <RuntimeOf<Chain> as HasChannelTypes>::Sender<Payload>;
 
-pub type Receiver<Chain, Payload> = <Runtime<Chain> as HasChannelTypes>::Receiver<Payload>;
+pub type Receiver<Chain, Payload> = <RuntimeOf<Chain> as HasChannelTypes>::Receiver<Payload>;
 
-pub type SenderOnce<Chain, Payload> = <Runtime<Chain> as HasChannelOnceTypes>::SenderOnce<Payload>;
+pub type SenderOnce<Chain, Payload> =
+    <RuntimeOf<Chain> as HasChannelOnceTypes>::SenderOnce<Payload>;
 
 pub type ReceiverOnce<Chain, Payload> =
-    <Runtime<Chain> as HasChannelOnceTypes>::ReceiverOnce<Payload>;
+    <RuntimeOf<Chain> as HasChannelOnceTypes>::ReceiverOnce<Payload>;
 
 pub type EventResult<Chain, Error> = Result<Vec<Vec<<Chain as HasEventType>::Event>>, Error>;
 

--- a/crates/relayer/relayer-components-extra/src/batch/worker.rs
+++ b/crates/relayer/relayer-components-extra/src/batch/worker.rs
@@ -18,7 +18,7 @@ use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_relayer_components::runtime::traits::sleep::CanSleep;
 use hermes_relayer_components::runtime::traits::task::Task;
 use hermes_relayer_components::runtime::traits::time::HasTime;
-use hermes_relayer_components::runtime::types::aliases::Runtime;
+use hermes_relayer_components::runtime::types::aliases::RuntimeOf;
 
 use crate::batch::types::aliases::{BatchSubmission, EventResultSender, MessageBatchReceiver};
 use crate::batch::types::config::BatchConfig;
@@ -32,7 +32,7 @@ pub trait CanSpawnBatchMessageWorker<Target>: HasRelayChains
 where
     Target: ChainTarget<Self>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     fn spawn_batch_message_worker(
         &self,
@@ -71,7 +71,7 @@ where
     Relay: HasRelayChains,
     Target: ChainTarget<Relay>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     pub relay: Relay,
     pub config: BatchConfig,
@@ -97,7 +97,7 @@ trait CanRunLoop<Target>: HasRelayChains
 where
     Target: ChainTarget<Self>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     async fn run_loop(
         &self,
@@ -179,14 +179,14 @@ pub trait CanProcessMessageBatches<Target>: HasRelayChains
 where
     Target: ChainTarget<Self>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasTime + HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasTime + HasChannelTypes + HasChannelOnceTypes,
 {
     async fn process_message_batches(
         &self,
         config: &BatchConfig,
         pending_batches: &mut VecDeque<BatchSubmission<Target::TargetChain, Self::Error>>,
-        now: <Runtime<Target::TargetChain> as HasTime>::Time,
-        last_sent_time: &mut <Runtime<Target::TargetChain> as HasTime>::Time,
+        now: <RuntimeOf<Target::TargetChain> as HasTime>::Time,
+        last_sent_time: &mut <RuntimeOf<Target::TargetChain> as HasTime>::Time,
     );
 }
 
@@ -305,7 +305,7 @@ where
     Relay: HasRelayChains,
     Target: ChainTarget<Relay>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     pub relay: Relay,
     pub ready_batches: VecDeque<BatchSubmission<Target::TargetChain, Relay::Error>>,
@@ -317,7 +317,7 @@ where
     Relay: CanSendReadyBatches<Target>,
     Target: ChainTarget<Relay>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     async fn run(self) {
         self.relay.send_ready_batches(self.ready_batches).await
@@ -329,7 +329,7 @@ pub trait CanSendReadyBatches<Target>: HasRelayChains
 where
     Target: ChainTarget<Self>,
     Target::TargetChain: HasRuntime,
-    Runtime<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
 {
     async fn send_ready_batches(
         &self,

--- a/crates/relayer/relayer-components-extra/src/build/traits/cache.rs
+++ b/crates/relayer/relayer-components-extra/src/build/traits/cache.rs
@@ -6,9 +6,9 @@ use hermes_relayer_components::build::traits::target::chain::ChainBuildTarget;
 use hermes_relayer_components::build::types::aliases::{
     CounterpartyChainId, CounterpartyClientId, TargetChain, TargetChainId, TargetClientId,
 };
-use hermes_relayer_components::runtime::traits::mutex::HasMutex;
+use hermes_relayer_components::runtime::traits::mutex::{HasMutex, MutexOf};
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_relayer_components::runtime::types::aliases::MutexOf;
+use hermes_relayer_components::runtime::types::aliases::RuntimeOf;
 
 use crate::batch::traits::channel::HasMessageBatchSenderType;
 
@@ -32,7 +32,7 @@ where
     Build::Runtime: HasMutex,
 {
     type BatchSenderCache = MutexOf<
-        Build,
+        RuntimeOf<Build>,
         BTreeMap<
             (
                 TargetChainId<Build, Target>,

--- a/crates/relayer/relayer-components-extra/src/build/traits/cache.rs
+++ b/crates/relayer/relayer-components-extra/src/build/traits/cache.rs
@@ -8,7 +8,7 @@ use hermes_relayer_components::build::types::aliases::{
 };
 use hermes_relayer_components::runtime::traits::mutex::HasMutex;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
-use hermes_relayer_components::runtime::types::aliases::Mutex;
+use hermes_relayer_components::runtime::types::aliases::MutexOf;
 
 use crate::batch::traits::channel::HasMessageBatchSenderType;
 
@@ -31,7 +31,7 @@ where
     Target::TargetChain: HasMessageBatchSenderType<Error>,
     Build::Runtime: HasMutex,
 {
-    type BatchSenderCache = Mutex<
+    type BatchSenderCache = MutexOf<
         Build,
         BTreeMap<
             (

--- a/crates/relayer/relayer-components-extra/src/clear_packet/worker.rs
+++ b/crates/relayer/relayer-components-extra/src/clear_packet/worker.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 
 use cgp_core::async_trait;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, PortIdOf};
 use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 use hermes_relayer_components::relay::traits::clear_interval::HasClearInterval;
 use hermes_relayer_components::relay::traits::components::packet_clearer::CanClearPackets;
@@ -15,10 +15,10 @@ use crate::runtime::traits::spawn::CanSpawnTask;
 pub trait CanSpawnClearPacketWorker: HasRelayChains {
     fn spawn_packet_clear_worker(
         &self,
-        src_channel_id: ChannelId<Self::SrcChain, Self::DstChain>,
-        src_port_id: PortId<Self::SrcChain, Self::DstChain>,
-        dst_channel_id: ChannelId<Self::DstChain, Self::SrcChain>,
-        dst_port_id: PortId<Self::DstChain, Self::SrcChain>,
+        src_channel_id: ChannelIdOf<Self::SrcChain, Self::DstChain>,
+        src_port_id: PortIdOf<Self::SrcChain, Self::DstChain>,
+        dst_channel_id: ChannelIdOf<Self::DstChain, Self::SrcChain>,
+        dst_port_id: PortIdOf<Self::DstChain, Self::SrcChain>,
     );
 }
 
@@ -27,10 +27,10 @@ where
     Relay: HasRelayChains,
 {
     pub relay: Relay,
-    pub src_channel_id: ChannelId<Relay::SrcChain, Relay::DstChain>,
-    pub src_port_id: PortId<Relay::SrcChain, Relay::DstChain>,
-    pub dst_channel_id: ChannelId<Relay::DstChain, Relay::SrcChain>,
-    pub dst_port_id: PortId<Relay::DstChain, Relay::SrcChain>,
+    pub src_channel_id: ChannelIdOf<Relay::SrcChain, Relay::DstChain>,
+    pub src_port_id: PortIdOf<Relay::SrcChain, Relay::DstChain>,
+    pub dst_channel_id: ChannelIdOf<Relay::DstChain, Relay::SrcChain>,
+    pub dst_port_id: PortIdOf<Relay::DstChain, Relay::SrcChain>,
 }
 
 #[async_trait]
@@ -57,10 +57,10 @@ where
 {
     fn spawn_packet_clear_worker(
         &self,
-        src_channel_id: ChannelId<Relay::SrcChain, Relay::DstChain>,
-        src_port_id: PortId<Relay::SrcChain, Relay::DstChain>,
-        dst_channel_id: ChannelId<Relay::DstChain, Relay::SrcChain>,
-        dst_port_id: PortId<Relay::DstChain, Relay::SrcChain>,
+        src_channel_id: ChannelIdOf<Relay::SrcChain, Relay::DstChain>,
+        src_port_id: PortIdOf<Relay::SrcChain, Relay::DstChain>,
+        dst_channel_id: ChannelIdOf<Relay::DstChain, Relay::SrcChain>,
+        dst_port_id: PortIdOf<Relay::DstChain, Relay::SrcChain>,
     ) {
         let task = ClearPacketTask {
             relay: self.clone(),
@@ -78,10 +78,10 @@ where
 trait CanRunLoop: HasRelayChains {
     async fn run_loop(
         &self,
-        src_channel_id: &ChannelId<Self::SrcChain, Self::DstChain>,
-        src_port_id: &PortId<Self::SrcChain, Self::DstChain>,
-        dst_channel_id: &ChannelId<Self::DstChain, Self::SrcChain>,
-        dst_port_id: &PortId<Self::DstChain, Self::SrcChain>,
+        src_channel_id: &ChannelIdOf<Self::SrcChain, Self::DstChain>,
+        src_port_id: &PortIdOf<Self::SrcChain, Self::DstChain>,
+        dst_channel_id: &ChannelIdOf<Self::DstChain, Self::SrcChain>,
+        dst_port_id: &PortIdOf<Self::DstChain, Self::SrcChain>,
     );
 }
 
@@ -93,10 +93,10 @@ where
 {
     async fn run_loop(
         &self,
-        src_channel_id: &ChannelId<Relay::SrcChain, Relay::DstChain>,
-        src_port_id: &PortId<Relay::SrcChain, Relay::DstChain>,
-        dst_channel_id: &ChannelId<Relay::DstChain, Relay::SrcChain>,
-        dst_port_id: &PortId<Relay::DstChain, Relay::SrcChain>,
+        src_channel_id: &ChannelIdOf<Relay::SrcChain, Relay::DstChain>,
+        src_port_id: &PortIdOf<Relay::SrcChain, Relay::DstChain>,
+        dst_channel_id: &ChannelIdOf<Relay::DstChain, Relay::SrcChain>,
+        dst_port_id: &PortIdOf<Relay::DstChain, Relay::SrcChain>,
     ) {
         let runtime = self.runtime();
         let clear_interval = self.clear_interval().into();

--- a/crates/relayer/relayer-components-extra/src/components/extra/closures/batch.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/closures/batch.rs
@@ -10,7 +10,7 @@ use hermes_relayer_components::runtime::traits::mutex::HasMutex;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_relayer_components::runtime::traits::sleep::CanSleep;
 use hermes_relayer_components::runtime::traits::time::HasTime;
-use hermes_relayer_components::runtime::types::aliases::Runtime;
+use hermes_relayer_components::runtime::types::aliases::RuntimeOf;
 
 use crate::batch::types::sink::BatchWorkerSink;
 use crate::batch::worker::CanSpawnBatchMessageWorker;
@@ -22,8 +22,8 @@ pub trait CanUseBatchMessageWorkerSpawner: UseBatchMessageWorkerSpawner
 where
     Self::SrcChain: HasRuntime,
     Self::DstChain: HasRuntime,
-    Runtime<Self::SrcChain>: HasChannelTypes + HasChannelOnceTypes,
-    Runtime<Self::DstChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Self::SrcChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Self::DstChain>: HasChannelTypes + HasChannelOnceTypes,
 {
 }
 
@@ -34,8 +34,8 @@ pub trait UseBatchMessageWorkerSpawner:
 where
     Self::SrcChain: HasRuntime,
     Self::DstChain: HasRuntime,
-    Runtime<Self::SrcChain>: HasChannelTypes + HasChannelOnceTypes,
-    Runtime<Self::DstChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Self::SrcChain>: HasChannelTypes + HasChannelOnceTypes,
+    RuntimeOf<Self::DstChain>: HasChannelTypes + HasChannelOnceTypes,
 {
 }
 

--- a/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/ack_packet_relayer.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/ack_packet_relayer.rs
@@ -22,6 +22,7 @@ use hermes_relayer_components::relay::traits::components::packet_relayers::ack_p
 use hermes_relayer_components::relay::traits::target::SourceTarget;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_relayer_components::runtime::traits::sleep::CanSleep;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::batch::traits::channel::HasMessageBatchSender;
 use crate::components::extra::relay::DelegatesToExtraRelayComponents;
@@ -58,7 +59,7 @@ where
         + CanQueryConsensusStateHeight<DstChain>
         + CanBuildAckPacketMessage<DstChain>
         + CanBuildUpdateClientMessage<DstChain>
-        + CanRaiseError<<SrcChain::Runtime as HasErrorType>::Error>,
+        + CanRaiseError<ErrorOf<SrcChain::Runtime>>,
     DstChain: HasErrorType
         + HasRuntime
         + HasChainId
@@ -69,7 +70,7 @@ where
         + CanReadPacketFields<SrcChain, IncomingPacket = Relay::Packet>
         + CanBuildAckPacketPayload<SrcChain>
         + CanBuildUpdateClientPayload<SrcChain>
-        + CanRaiseError<<DstChain::Runtime as HasErrorType>::Error>,
+        + CanRaiseError<ErrorOf<DstChain>>,
     SrcChain::Height: Clone,
     DstChain::Height: Clone,
     SrcChain::Runtime: CanCreateChannelsOnce + CanUseChannels + CanUseChannelsOnce,

--- a/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/message_sender.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/message_sender.rs
@@ -1,4 +1,3 @@
-use cgp_core::prelude::HasErrorType;
 use cgp_core::{CanRaiseError, ErrorRaiser, HasComponents};
 use hermes_relayer_components::chain::traits::types::packet::HasIbcPacketTypes;
 use hermes_relayer_components::logger::traits::has_logger::{HasLogger, HasLoggerType};
@@ -10,6 +9,7 @@ use hermes_relayer_components::relay::traits::components::ibc_message_sender::{
 use hermes_relayer_components::relay::traits::components::packet_filter::PacketFilter;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_relayer_components::runtime::traits::sleep::CanSleep;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::batch::traits::channel::HasMessageBatchSender;
 use crate::batch::types::sink::BatchWorkerSink;
@@ -37,10 +37,10 @@ where
     SrcChain: HasLoggerType<Logger = Relay::Logger>
         + HasIbcPacketTypes<DstChain, OutgoingPacket = Relay::Packet>
         + UseExtraChainComponentsForIbcMessageSender<DstChain>
-        + CanRaiseError<<SrcChain::Runtime as HasErrorType>::Error>,
+        + CanRaiseError<ErrorOf<SrcChain::Runtime>>,
     DstChain: HasIbcPacketTypes<SrcChain, IncomingPacket = Relay::Packet>
         + UseExtraChainComponentsForIbcMessageSender<SrcChain>
-        + CanRaiseError<<DstChain::Runtime as HasErrorType>::Error>,
+        + CanRaiseError<ErrorOf<DstChain::Runtime>>,
     SrcChain::Height: Clone,
     DstChain::Height: Clone,
     SrcChain::Runtime: CanSleep + CanCreateChannelsOnce + CanUseChannels + CanUseChannelsOnce,

--- a/crates/relayer/relayer-components/src/birelay/traits/two_way.rs
+++ b/crates/relayer/relayer-components/src/birelay/traits/two_way.rs
@@ -1,6 +1,7 @@
 use cgp_core::prelude::*;
 
 use crate::relay::traits::chains::HasRelayChains;
+use crate::runtime::types::aliases::ErrorOf;
 
 #[derive_component(TwoChainTypesComponent, ProvideTwoChainTypes<BiRelay>)]
 pub trait HasTwoChainTypes: Async {
@@ -32,7 +33,7 @@ pub trait HasTwoWayRelayTypes: HasTwoChainTypes {
     type RelayBToA: HasRelayChains<
         SrcChain = Self::ChainB,
         DstChain = Self::ChainA,
-        Error = <Self::RelayAToB as HasErrorType>::Error,
+        Error = ErrorOf<Self::RelayAToB>,
     >;
 }
 

--- a/crates/relayer/relayer-components/src/build/traits/birelay.rs
+++ b/crates/relayer/relayer-components/src/build/traits/birelay.rs
@@ -14,3 +14,5 @@ pub trait HasBiRelayType: HasErrorType {
 pub trait HasBiRelay: HasBiRelayType {
     fn birelay(&self) -> &Self::BiRelay;
 }
+
+pub type BiRelayOf<Build> = <Build as HasBiRelayType>::BiRelay;

--- a/crates/relayer/relayer-components/src/build/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/build/types/aliases.rs
@@ -3,24 +3,23 @@ use alloc::collections::BTreeMap;
 use cgp_core::HasErrorType;
 
 use crate::birelay::traits::two_way::{HasTwoChainTypes, HasTwoWayRelayTypes};
-use crate::build::traits::birelay::HasBiRelayType;
+use crate::build::traits::birelay::BiRelayOf;
 use crate::build::traits::target::chain::ChainBuildTarget;
 use crate::build::traits::target::relay::RelayBuildTarget;
 use crate::chain::traits::types::chain_id::HasChainIdType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::relay::traits::chains::HasRelayChains;
+use crate::runtime::traits::mutex::MutexOf;
 use crate::runtime::traits::runtime::HasRuntimeType;
-use crate::runtime::types::aliases::{ErrorOf, MutexOf};
+use crate::runtime::types::aliases::{ErrorOf, RuntimeOf};
 
-pub type BiRelay<Build> = <Build as HasBiRelayType>::BiRelay;
+pub type ChainA<Build> = <BiRelayOf<Build> as HasTwoChainTypes>::ChainA;
 
-pub type ChainA<Build> = <BiRelay<Build> as HasTwoChainTypes>::ChainA;
+pub type ChainB<Build> = <BiRelayOf<Build> as HasTwoChainTypes>::ChainB;
 
-pub type ChainB<Build> = <BiRelay<Build> as HasTwoChainTypes>::ChainB;
+pub type RelayAToB<Build> = <BiRelayOf<Build> as HasTwoWayRelayTypes>::RelayAToB;
 
-pub type RelayAToB<Build> = <BiRelay<Build> as HasTwoWayRelayTypes>::RelayAToB;
-
-pub type RelayBToA<Build> = <BiRelay<Build> as HasTwoWayRelayTypes>::RelayBToA;
+pub type RelayBToA<Build> = <BiRelayOf<Build> as HasTwoWayRelayTypes>::RelayBToA;
 
 pub type ChainIdA<Build> = <ChainA<Build> as HasChainIdType>::ChainId;
 
@@ -30,14 +29,14 @@ pub type ClientIdA<Build> = <ChainA<Build> as HasIbcChainTypes<ChainB<Build>>>::
 
 pub type ClientIdB<Build> = <ChainB<Build> as HasIbcChainTypes<ChainA<Build>>>::ClientId;
 
-pub type ChainACache<Build> = MutexOf<Build, BTreeMap<ChainIdA<Build>, ChainA<Build>>>;
+pub type ChainACache<Build> = MutexOf<RuntimeOf<Build>, BTreeMap<ChainIdA<Build>, ChainA<Build>>>;
 
-pub type ChainBCache<Build> = MutexOf<Build, BTreeMap<ChainIdB<Build>, ChainB<Build>>>;
+pub type ChainBCache<Build> = MutexOf<RuntimeOf<Build>, BTreeMap<ChainIdB<Build>, ChainB<Build>>>;
 
 pub type RelayError<Build> = ErrorOf<RelayAToB<Build>>;
 
 pub type RelayAToBCache<Build> = MutexOf<
-    Build,
+    RuntimeOf<Build>,
     BTreeMap<
         (
             ChainIdA<Build>,
@@ -50,7 +49,7 @@ pub type RelayAToBCache<Build> = MutexOf<
 >;
 
 pub type RelayBToACache<Build> = MutexOf<
-    Build,
+    RuntimeOf<Build>,
     BTreeMap<
         (
             ChainIdB<Build>,
@@ -81,7 +80,7 @@ pub type CounterpartyClientId<Build, Target> =
     <CounterpartyChain<Build, Target> as HasIbcChainTypes<TargetChain<Build, Target>>>::ClientId;
 
 pub type TargetChainCache<Build, Target> =
-    MutexOf<Build, BTreeMap<TargetChainId<Build, Target>, TargetChain<Build, Target>>>;
+    MutexOf<RuntimeOf<Build>, BTreeMap<TargetChainId<Build, Target>, TargetChain<Build, Target>>>;
 
 pub type TargetRelay<Build, Target> = <Target as RelayBuildTarget<Build>>::TargetRelay;
 
@@ -108,7 +107,7 @@ pub type TargetDstClientId<Build, Target> =
     <TargetDstChain<Build, Target> as HasIbcChainTypes<TargetSrcChain<Build, Target>>>::ClientId;
 
 pub type TargetRelayCache<Build, Target> = MutexOf<
-    Build,
+    RuntimeOf<Build>,
     BTreeMap<
         (
             TargetSrcChainId<Build, Target>,

--- a/crates/relayer/relayer-components/src/build/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/build/types/aliases.rs
@@ -10,7 +10,7 @@ use crate::chain::traits::types::chain_id::HasChainIdType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::runtime::traits::runtime::HasRuntimeType;
-use crate::runtime::types::aliases::Mutex;
+use crate::runtime::types::aliases::MutexOf;
 
 pub type BiRelay<Build> = <Build as HasBiRelayType>::BiRelay;
 
@@ -30,13 +30,13 @@ pub type ClientIdA<Build> = <ChainA<Build> as HasIbcChainTypes<ChainB<Build>>>::
 
 pub type ClientIdB<Build> = <ChainB<Build> as HasIbcChainTypes<ChainA<Build>>>::ClientId;
 
-pub type ChainACache<Build> = Mutex<Build, BTreeMap<ChainIdA<Build>, ChainA<Build>>>;
+pub type ChainACache<Build> = MutexOf<Build, BTreeMap<ChainIdA<Build>, ChainA<Build>>>;
 
-pub type ChainBCache<Build> = Mutex<Build, BTreeMap<ChainIdB<Build>, ChainB<Build>>>;
+pub type ChainBCache<Build> = MutexOf<Build, BTreeMap<ChainIdB<Build>, ChainB<Build>>>;
 
 pub type RelayError<Build> = <RelayAToB<Build> as HasErrorType>::Error;
 
-pub type RelayAToBCache<Build> = Mutex<
+pub type RelayAToBCache<Build> = MutexOf<
     Build,
     BTreeMap<
         (
@@ -49,7 +49,7 @@ pub type RelayAToBCache<Build> = Mutex<
     >,
 >;
 
-pub type RelayBToACache<Build> = Mutex<
+pub type RelayBToACache<Build> = MutexOf<
     Build,
     BTreeMap<
         (
@@ -81,7 +81,7 @@ pub type CounterpartyClientId<Build, Target> =
     <CounterpartyChain<Build, Target> as HasIbcChainTypes<TargetChain<Build, Target>>>::ClientId;
 
 pub type TargetChainCache<Build, Target> =
-    Mutex<Build, BTreeMap<TargetChainId<Build, Target>, TargetChain<Build, Target>>>;
+    MutexOf<Build, BTreeMap<TargetChainId<Build, Target>, TargetChain<Build, Target>>>;
 
 pub type TargetRelay<Build, Target> = <Target as RelayBuildTarget<Build>>::TargetRelay;
 
@@ -107,7 +107,7 @@ pub type TargetSrcClientId<Build, Target> =
 pub type TargetDstClientId<Build, Target> =
     <TargetDstChain<Build, Target> as HasIbcChainTypes<TargetSrcChain<Build, Target>>>::ClientId;
 
-pub type TargetRelayCache<Build, Target> = Mutex<
+pub type TargetRelayCache<Build, Target> = MutexOf<
     Build,
     BTreeMap<
         (

--- a/crates/relayer/relayer-components/src/build/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/build/types/aliases.rs
@@ -10,7 +10,7 @@ use crate::chain::traits::types::chain_id::HasChainIdType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::runtime::traits::runtime::HasRuntimeType;
-use crate::runtime::types::aliases::MutexOf;
+use crate::runtime::types::aliases::{ErrorOf, MutexOf};
 
 pub type BiRelay<Build> = <Build as HasBiRelayType>::BiRelay;
 
@@ -34,7 +34,7 @@ pub type ChainACache<Build> = MutexOf<Build, BTreeMap<ChainIdA<Build>, ChainA<Bu
 
 pub type ChainBCache<Build> = MutexOf<Build, BTreeMap<ChainIdB<Build>, ChainB<Build>>>;
 
-pub type RelayError<Build> = <RelayAToB<Build> as HasErrorType>::Error;
+pub type RelayError<Build> = ErrorOf<RelayAToB<Build>>;
 
 pub type RelayAToBCache<Build> = MutexOf<
     Build,

--- a/crates/relayer/relayer-components/src/chain/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/chain/types/aliases.rs
@@ -7,32 +7,32 @@ use crate::chain::traits::types::message::HasMessageType;
 use crate::chain::traits::types::packet::HasIbcPacketTypes;
 use crate::chain::traits::types::timestamp::HasTimestampType;
 
-pub type IncomingPacket<Chain, Counterparty> =
+pub type IncomingPacketOf<Chain, Counterparty> =
     <Chain as HasIbcPacketTypes<Counterparty>>::IncomingPacket;
 
-pub type OutgoingPacket<Chain, Counterparty> =
+pub type OutgoingPacketOf<Chain, Counterparty> =
     <Chain as HasIbcPacketTypes<Counterparty>>::OutgoingPacket;
 
-pub type ClientId<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::ClientId;
+pub type ClientIdOf<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::ClientId;
 
-pub type ConnectionId<Chain, Counterparty> =
+pub type ConnectionIdOf<Chain, Counterparty> =
     <Chain as HasIbcChainTypes<Counterparty>>::ConnectionId;
 
-pub type ChannelId<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::ChannelId;
+pub type ChannelIdOf<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::ChannelId;
 
-pub type PortId<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::PortId;
+pub type PortIdOf<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::PortId;
 
-pub type Sequence<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::Sequence;
+pub type SequenceOf<Chain, Counterparty> = <Chain as HasIbcChainTypes<Counterparty>>::Sequence;
 
-pub type ChainId<Chain> = <Chain as HasChainIdType>::ChainId;
+pub type ChainIdOf<Chain> = <Chain as HasChainIdType>::ChainId;
 
-pub type Message<Chain> = <Chain as HasMessageType>::Message;
+pub type MessageOf<Chain> = <Chain as HasMessageType>::Message;
 
-pub type Event<Chain> = <Chain as HasEventType>::Event;
+pub type EventOf<Chain> = <Chain as HasEventType>::Event;
 
-pub type Height<Chain> = <Chain as HasHeightType>::Height;
+pub type HeightOf<Chain> = <Chain as HasHeightType>::Height;
 
-pub type Timestamp<Chain> = <Chain as HasTimestampType>::Timestamp;
+pub type TimestampOf<Chain> = <Chain as HasTimestampType>::Timestamp;
 
-pub type WriteAckEvent<Chain, Counterparty> =
+pub type WriteAckEventOf<Chain, Counterparty> =
     <Chain as HasWriteAckEvent<Counterparty>>::WriteAckEvent;

--- a/crates/relayer/relayer-components/src/relay/components/event_relayers/packet_event.rs
+++ b/crates/relayer/relayer-components/src/relay/components/event_relayers/packet_event.rs
@@ -3,7 +3,7 @@ use cgp_core::async_trait;
 use crate::chain::traits::components::packet_from_write_ack_builder::CanBuildPacketFromWriteAck;
 use crate::chain::traits::types::ibc_events::send_packet::HasSendPacketEvent;
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAckEvent;
-use crate::chain::types::aliases::{Event, Height};
+use crate::chain::types::aliases::{EventOf, HeightOf};
 use crate::logger::traits::level::HasBaseLogLevels;
 use crate::relay::components::packet_filters::chain::{
     MatchPacketDestinationChain, MatchPacketSourceChain,
@@ -46,8 +46,8 @@ where
 {
     async fn relay_chain_event(
         relay: &Relay,
-        _height: &Height<Relay::SrcChain>,
-        event: &Event<Relay::SrcChain>,
+        _height: &HeightOf<Relay::SrcChain>,
+        event: &EventOf<Relay::SrcChain>,
     ) -> Result<(), Relay::Error> {
         if let Some(send_packet_event) = Relay::SrcChain::try_extract_send_packet_event(event) {
             let packet = Relay::SrcChain::extract_packet_from_send_packet_event(&send_packet_event);
@@ -75,8 +75,8 @@ where
 {
     async fn relay_chain_event(
         relay: &Relay,
-        height: &Height<Relay::DstChain>,
-        event: &Event<Relay::DstChain>,
+        height: &HeightOf<Relay::DstChain>,
+        event: &EventOf<Relay::DstChain>,
     ) -> Result<(), Relay::Error> {
         let m_ack_event = Relay::DstChain::try_extract_write_ack_event(event);
 

--- a/crates/relayer/relayer-components/src/relay/components/packet_clearers/receive_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/components/packet_clearers/receive_packet.rs
@@ -3,7 +3,7 @@ use cgp_core::async_trait;
 use crate::chain::traits::components::packet_commitments_querier::CanQueryPacketCommitments;
 use crate::chain::traits::components::send_packets_querier::CanQuerySendPackets;
 use crate::chain::traits::components::unreceived_packet_sequences_querier::CanQueryUnreceivedPacketSequences;
-use crate::chain::types::aliases::{ChannelId, PortId};
+use crate::chain::types::aliases::{ChannelIdOf, PortIdOf};
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
 use crate::relay::traits::components::packet_clearer::PacketClearer;
 use crate::relay::traits::components::packet_relayer::CanRelayPacket;
@@ -41,10 +41,10 @@ where
 {
     async fn clear_packets(
         relay: &Relay,
-        src_channel_id: &ChannelId<Relay::SrcChain, Relay::DstChain>,
-        src_port_id: &PortId<Relay::SrcChain, Relay::DstChain>,
-        dst_channel_id: &ChannelId<Relay::DstChain, Relay::SrcChain>,
-        dst_port_id: &PortId<Relay::DstChain, Relay::SrcChain>,
+        src_channel_id: &ChannelIdOf<Relay::SrcChain, Relay::DstChain>,
+        src_port_id: &PortIdOf<Relay::SrcChain, Relay::DstChain>,
+        dst_channel_id: &ChannelIdOf<Relay::DstChain, Relay::SrcChain>,
+        dst_port_id: &PortIdOf<Relay::DstChain, Relay::SrcChain>,
     ) -> Result<(), Relay::Error> {
         let dst_chain = relay.dst_chain();
         let src_chain = relay.src_chain();

--- a/crates/relayer/relayer-components/src/relay/components/packet_relayers/receive/base_receive_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/components/packet_relayers/receive/base_receive_packet.rs
@@ -4,7 +4,7 @@ use crate::chain::traits::components::client_state_querier::CanQueryClientState;
 use crate::chain::traits::components::receive_packet_message_builder::CanBuildReceivePacketMessage;
 use crate::chain::traits::components::receive_packet_payload_builder::CanBuildReceivePacketPayload;
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAckEvent;
-use crate::chain::types::aliases::Height;
+use crate::chain::types::aliases::HeightOf;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
 use crate::relay::traits::components::ibc_message_sender::{CanSendSingleIbcMessage, MainSink};
 use crate::relay::traits::components::packet_relayers::receive_packet::ReceivePacketRelayer;
@@ -26,7 +26,7 @@ where
 {
     async fn relay_receive_packet(
         relay: &Relay,
-        source_height: &Height<Relay::SrcChain>,
+        source_height: &HeightOf<Relay::SrcChain>,
         packet: &Packet<Relay>,
     ) -> Result<Option<AckEvent>, Relay::Error> {
         let src_client_state = relay

--- a/crates/relayer/relayer-components/src/relay/components/packet_relayers/receive/skip_received_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/components/packet_relayers/receive/skip_received_packet.rs
@@ -4,7 +4,7 @@ use cgp_core::async_trait;
 
 use crate::chain::traits::components::received_packet_querier::CanQueryReceivedPacket;
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAckEvent;
-use crate::chain::types::aliases::{Height, WriteAckEvent};
+use crate::chain::types::aliases::{HeightOf, WriteAckEventOf};
 use crate::relay::traits::chains::CanRaiseRelayChainErrors;
 use crate::relay::traits::components::packet_relayers::receive_packet::ReceivePacketRelayer;
 use crate::relay::traits::packet::HasRelayPacketFields;
@@ -23,9 +23,9 @@ where
 {
     async fn relay_receive_packet(
         relay: &Relay,
-        source_height: &Height<Relay::SrcChain>,
+        source_height: &HeightOf<Relay::SrcChain>,
         packet: &Relay::Packet,
-    ) -> Result<Option<WriteAckEvent<Relay::DstChain, Relay::SrcChain>>, Relay::Error> {
+    ) -> Result<Option<WriteAckEventOf<Relay::DstChain, Relay::SrcChain>>, Relay::Error> {
         let is_packet_received = relay
             .dst_chain()
             .query_is_packet_received(

--- a/crates/relayer/relayer-components/src/relay/components/packet_relayers/timeout_unordered/timeout_unordered_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/components/packet_relayers/timeout_unordered/timeout_unordered_packet.rs
@@ -4,7 +4,7 @@ use crate::chain::traits::components::client_state_querier::CanQueryClientState;
 use crate::chain::traits::components::timeout_unordered_packet_message_builder::{
     CanBuildTimeoutUnorderedPacketMessage, CanBuildTimeoutUnorderedPacketPayload,
 };
-use crate::chain::types::aliases::Height;
+use crate::chain::types::aliases::HeightOf;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
 use crate::relay::traits::components::ibc_message_sender::{CanSendSingleIbcMessage, MainSink};
 use crate::relay::traits::components::packet_relayers::timeout_unordered_packet::TimeoutUnorderedPacketRelayer;
@@ -27,7 +27,7 @@ where
 {
     async fn relay_timeout_unordered_packet(
         relay: &Relay,
-        destination_height: &Height<Relay::DstChain>,
+        destination_height: &HeightOf<Relay::DstChain>,
         packet: &Packet<Relay>,
     ) -> Result<(), Relay::Error> {
         let dst_client_state = relay

--- a/crates/relayer/relayer-components/src/relay/components/update_client/skip.rs
+++ b/crates/relayer/relayer-components/src/relay/components/update_client/skip.rs
@@ -6,7 +6,7 @@ use cgp_core::async_trait;
 use crate::chain::traits::components::consensus_state_querier::CanQueryConsensusState;
 use crate::chain::traits::types::consensus_state::HasConsensusStateType;
 use crate::chain::traits::types::height::HasHeightType;
-use crate::chain::types::aliases::Height;
+use crate::chain::types::aliases::HeightOf;
 use crate::logger::traits::level::HasBaseLogLevels;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::components::update_client_message_builder::UpdateClientMessageBuilder;
@@ -28,7 +28,7 @@ where
     async fn build_update_client_messages(
         relay: &Relay,
         target: Target,
-        height: &Height<Target::CounterpartyChain>,
+        height: &HeightOf<Target::CounterpartyChain>,
     ) -> Result<Vec<TargetChain::Message>, Relay::Error> {
         let target_chain = Target::target_chain(relay);
         let target_client_id = Target::target_client_id(relay);

--- a/crates/relayer/relayer-components/src/relay/impls/forward/create_client.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/forward/create_client.rs
@@ -2,7 +2,7 @@ use cgp_core::{CanRaiseError, HasInner};
 
 use crate::chain::traits::types::create_client::{CreateClientOptions, HasCreateClientOptionsType};
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
-use crate::chain::types::aliases::ClientId;
+use crate::chain::types::aliases::ClientIdOf;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::components::client_creator::{CanCreateClient, ClientCreator};
 use crate::relay::traits::target::ChainTarget;
@@ -24,7 +24,7 @@ where
         target_chain: &TargetChain,
         counterparty_chain: &CounterpartyChain,
         create_client_options: &CreateClientOptions<CounterpartyChain, TargetChain>,
-    ) -> Result<ClientId<TargetChain, CounterpartyChain>, Relay::Error> {
+    ) -> Result<ClientIdOf<TargetChain, CounterpartyChain>, Relay::Error> {
         Inner::create_client(
             target,
             target_chain,

--- a/crates/relayer/relayer-components/src/relay/impls/forward/types.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/forward/types.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::HasErrorType;
 use cgp_core::HasInner;
 
-use crate::chain::types::aliases::ClientId;
+use crate::chain::types::aliases::ClientIdOf;
 use crate::relay::traits::chains::{HasRelayChains, ProvideRelayChains};
 
 pub struct ForwardRelayTypes;
@@ -25,11 +25,11 @@ where
         relay.inner().dst_chain()
     }
 
-    fn src_client_id(relay: &Relay) -> &ClientId<Self::SrcChain, Self::DstChain> {
+    fn src_client_id(relay: &Relay) -> &ClientIdOf<Self::SrcChain, Self::DstChain> {
         relay.inner().src_client_id()
     }
 
-    fn dst_client_id(relay: &Relay) -> &ClientId<Self::DstChain, Self::SrcChain> {
+    fn dst_client_id(relay: &Relay) -> &ClientIdOf<Self::DstChain, Self::SrcChain> {
         relay.inner().dst_client_id()
     }
 }

--- a/crates/relayer/relayer-components/src/relay/traits/chains.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/chains.rs
@@ -3,7 +3,7 @@ use cgp_core::CanRaiseError;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::packet::HasIbcPacketTypes;
-use crate::chain::types::aliases::ClientId;
+use crate::chain::types::aliases::ClientIdOf;
 
 /**
     This covers the minimal abstract types that are used inside a relay context.
@@ -72,13 +72,13 @@ pub trait HasRelayChains: HasErrorType {
         the connection and channel IDs, because a relay context may handle
         more than one of them.
     */
-    fn src_client_id(&self) -> &ClientId<Self::SrcChain, Self::DstChain>;
+    fn src_client_id(&self) -> &ClientIdOf<Self::SrcChain, Self::DstChain>;
 
     /**
         Get the client ID on the destination chain that corresponds to the source
         chain.
     */
-    fn dst_client_id(&self) -> &ClientId<Self::DstChain, Self::SrcChain>;
+    fn dst_client_id(&self) -> &ClientIdOf<Self::DstChain, Self::SrcChain>;
 }
 
 pub trait CanRaiseRelayChainErrors:

--- a/crates/relayer/relayer-components/src/relay/traits/chains.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/chains.rs
@@ -4,6 +4,7 @@ use cgp_core::CanRaiseError;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::packet::HasIbcPacketTypes;
 use crate::chain::types::aliases::ClientIdOf;
+use crate::runtime::types::aliases::ErrorOf;
 
 /**
     This covers the minimal abstract types that are used inside a relay context.
@@ -82,15 +83,13 @@ pub trait HasRelayChains: HasErrorType {
 }
 
 pub trait CanRaiseRelayChainErrors:
-    HasRelayChains
-    + CanRaiseError<<Self::SrcChain as HasErrorType>::Error>
-    + CanRaiseError<<Self::DstChain as HasErrorType>::Error>
+    HasRelayChains + CanRaiseError<ErrorOf<Self::SrcChain>> + CanRaiseError<ErrorOf<Self::DstChain>>
 {
 }
 
 impl<Relay> CanRaiseRelayChainErrors for Relay where
     Relay: HasRelayChains
-        + CanRaiseError<<Self::SrcChain as HasErrorType>::Error>
-        + CanRaiseError<<Self::DstChain as HasErrorType>::Error>
+        + CanRaiseError<ErrorOf<Self::SrcChain>>
+        + CanRaiseError<ErrorOf<Self::DstChain>>
 {
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/client_creator.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/client_creator.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::create_client::{CreateClientOptions, HasCreateClientOptionsType};
-use crate::chain::types::aliases::ClientId;
+use crate::chain::types::aliases::ClientIdOf;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
 
@@ -29,5 +29,5 @@ where
         target_chain: &Target::TargetChain,
         counterparty_chain: &Target::CounterpartyChain,
         create_client_options: &CreateClientOptions<Target::CounterpartyChain, Target::TargetChain>,
-    ) -> Result<ClientId<Target::TargetChain, Target::CounterpartyChain>, Self::Error>;
+    ) -> Result<ClientIdOf<Target::TargetChain, Target::CounterpartyChain>, Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/event_relayer.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/event_relayer.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::event::HasEventType;
-use crate::chain::types::aliases::{Event, Height};
+use crate::chain::types::aliases::{EventOf, HeightOf};
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
 
@@ -30,7 +30,7 @@ where
     */
     async fn relay_chain_event(
         &self,
-        height: &Height<Target::TargetChain>,
-        event: &Event<Target::TargetChain>,
+        height: &HeightOf<Target::TargetChain>,
+        event: &EventOf<Target::TargetChain>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/ibc_message_sender.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/ibc_message_sender.rs
@@ -5,7 +5,7 @@ use cgp_core::prelude::*;
 
 use crate::chain::traits::components::message_sender::InjectMismatchIbcEventsCountError;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
-use crate::chain::types::aliases::{Event, Message};
+use crate::chain::types::aliases::{EventOf, MessageOf};
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
 
@@ -20,8 +20,8 @@ where
     async fn send_messages(
         &self,
         target: Target,
-        messages: Vec<Message<Target::TargetChain>>,
-    ) -> Result<Vec<Vec<Event<Target::TargetChain>>>, Self::Error>;
+        messages: Vec<MessageOf<Target::TargetChain>>,
+    ) -> Result<Vec<Vec<EventOf<Target::TargetChain>>>, Self::Error>;
 }
 
 #[async_trait]
@@ -32,8 +32,8 @@ where
     async fn send_messages_fixed<const COUNT: usize>(
         &self,
         target: Target,
-        messages: [Message<Target::TargetChain>; COUNT],
-    ) -> Result<[Vec<Event<Target::TargetChain>>; COUNT], Self::Error>;
+        messages: [MessageOf<Target::TargetChain>; COUNT],
+    ) -> Result<[Vec<EventOf<Target::TargetChain>>; COUNT], Self::Error>;
 }
 
 #[async_trait]
@@ -44,8 +44,8 @@ where
     async fn send_message(
         &self,
         target: Target,
-        message: Message<Target::TargetChain>,
-    ) -> Result<Vec<Event<Target::TargetChain>>, Self::Error>;
+        message: MessageOf<Target::TargetChain>,
+    ) -> Result<Vec<EventOf<Target::TargetChain>>, Self::Error>;
 }
 
 #[async_trait]

--- a/crates/relayer/relayer-components/src/relay/traits/components/packet_clearer.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/packet_clearer.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 
-use crate::chain::types::aliases::{ChannelId, PortId};
+use crate::chain::types::aliases::{ChannelIdOf, PortIdOf};
 use crate::relay::traits::chains::HasRelayChains;
 
 #[derive_component(PacketClearerComponent, PacketClearer<Relay>)]
@@ -8,9 +8,9 @@ use crate::relay::traits::chains::HasRelayChains;
 pub trait CanClearPackets: HasRelayChains {
     async fn clear_packets(
         &self,
-        src_channel_id: &ChannelId<Self::SrcChain, Self::DstChain>,
-        src_port_id: &PortId<Self::SrcChain, Self::DstChain>,
-        dst_channel_id: &ChannelId<Self::DstChain, Self::SrcChain>,
-        dst_port_id: &PortId<Self::DstChain, Self::SrcChain>,
+        src_channel_id: &ChannelIdOf<Self::SrcChain, Self::DstChain>,
+        src_port_id: &PortIdOf<Self::SrcChain, Self::DstChain>,
+        dst_channel_id: &ChannelIdOf<Self::DstChain, Self::SrcChain>,
+        dst_port_id: &PortIdOf<Self::DstChain, Self::SrcChain>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/packet_relayers/ack_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/packet_relayers/ack_packet.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAckEvent;
-use crate::chain::types::aliases::{Height, WriteAckEvent};
+use crate::chain::types::aliases::{HeightOf, WriteAckEventOf};
 use crate::relay::traits::chains::HasRelayChains;
 
 #[derive_component(AckPacketRelayerComponent, AckPacketRelayer<Relay>)]
@@ -12,8 +12,8 @@ where
 {
     async fn relay_ack_packet(
         &self,
-        destination_height: &Height<Self::DstChain>,
+        destination_height: &HeightOf<Self::DstChain>,
         packet: &Self::Packet,
-        ack: &WriteAckEvent<Self::DstChain, Self::SrcChain>,
+        ack: &WriteAckEventOf<Self::DstChain, Self::SrcChain>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/packet_relayers/receive_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/packet_relayers/receive_packet.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAckEvent;
-use crate::chain::types::aliases::{Height, WriteAckEvent};
+use crate::chain::types::aliases::{HeightOf, WriteAckEventOf};
 use crate::relay::traits::chains::HasRelayChains;
 
 #[derive_component(ReceivePacketRelayerComponnent, ReceivePacketRelayer<Relay>)]
@@ -12,7 +12,7 @@ where
 {
     async fn relay_receive_packet(
         &self,
-        source_height: &Height<Self::SrcChain>,
+        source_height: &HeightOf<Self::SrcChain>,
         packet: &Self::Packet,
-    ) -> Result<Option<WriteAckEvent<Self::DstChain, Self::SrcChain>>, Self::Error>;
+    ) -> Result<Option<WriteAckEventOf<Self::DstChain, Self::SrcChain>>, Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/packet_relayers/timeout_unordered_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/packet_relayers/timeout_unordered_packet.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 
-use crate::chain::types::aliases::Height;
+use crate::chain::types::aliases::HeightOf;
 use crate::relay::traits::chains::HasRelayChains;
 
 /// Encapsulates the capability of a relayer to send timeout packets over
@@ -18,7 +18,7 @@ use crate::relay::traits::chains::HasRelayChains;
 pub trait CanRelayTimeoutUnorderedPacket: HasRelayChains {
     async fn relay_timeout_unordered_packet(
         &self,
-        destination_height: &Height<Self::DstChain>,
+        destination_height: &HeightOf<Self::DstChain>,
         packet: &Self::Packet,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/components/update_client_message_builder.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/components/update_client_message_builder.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use cgp_core::prelude::*;
 
 use crate::chain::traits::components::message_sender::CanSendMessages;
-use crate::chain::types::aliases::{Height, Message};
+use crate::chain::types::aliases::{HeightOf, MessageOf};
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
 
@@ -16,8 +16,8 @@ where
     async fn build_update_client_messages(
         &self,
         _target: Target,
-        height: &Height<Target::CounterpartyChain>,
-    ) -> Result<Vec<Message<Target::TargetChain>>, Self::Error>;
+        height: &HeightOf<Target::CounterpartyChain>,
+    ) -> Result<Vec<MessageOf<Target::TargetChain>>, Self::Error>;
 }
 
 #[async_trait]
@@ -28,7 +28,7 @@ where
     async fn send_update_client_messages(
         &self,
         target: Target,
-        height: &Height<Target::CounterpartyChain>,
+        height: &HeightOf<Target::CounterpartyChain>,
     ) -> Result<(), Self::Error>;
 }
 
@@ -42,7 +42,7 @@ where
     async fn send_update_client_messages(
         &self,
         target: Target,
-        height: &Height<Target::CounterpartyChain>,
+        height: &HeightOf<Target::CounterpartyChain>,
     ) -> Result<(), Self::Error> {
         let messages = self.build_update_client_messages(target, height).await?;
 

--- a/crates/relayer/relayer-components/src/relay/traits/packet.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/packet.rs
@@ -1,7 +1,7 @@
 use cgp_core::HasErrorType;
 
 use crate::chain::traits::components::packet_fields_reader::CanReadPacketFields;
-use crate::chain::types::aliases::{ChannelId, Height, PortId, Sequence, Timestamp};
+use crate::chain::types::aliases::{ChannelIdOf, HeightOf, PortIdOf, SequenceOf, TimestampOf};
 use crate::relay::traits::chains::HasRelayChains;
 
 pub trait HasRelayPacketFields: HasRelayChains {
@@ -9,41 +9,43 @@ pub trait HasRelayPacketFields: HasRelayChains {
         The source port of a packet, which is a port ID on the source chain
         that corresponds to the destination chain.
     */
-    fn packet_src_port(packet: &Self::Packet) -> &PortId<Self::SrcChain, Self::DstChain>;
+    fn packet_src_port(packet: &Self::Packet) -> &PortIdOf<Self::SrcChain, Self::DstChain>;
 
     /**
         The source channel ID of a packet, which is a channel ID on the source chain
         that corresponds to the destination chain.
     */
-    fn packet_src_channel_id(packet: &Self::Packet) -> &ChannelId<Self::SrcChain, Self::DstChain>;
+    fn packet_src_channel_id(packet: &Self::Packet)
+        -> &ChannelIdOf<Self::SrcChain, Self::DstChain>;
 
     /**
         The destination port of a packet, which is a port ID on the destination chain
         that corresponds to the source chain.
     */
-    fn packet_dst_port(packet: &Self::Packet) -> &PortId<Self::DstChain, Self::SrcChain>;
+    fn packet_dst_port(packet: &Self::Packet) -> &PortIdOf<Self::DstChain, Self::SrcChain>;
 
     /**
         The destination channel ID of a packet, which is a channel ID on the destination chain
         that corresponds to the source chain.
     */
-    fn packet_dst_channel_id(packet: &Self::Packet) -> &ChannelId<Self::DstChain, Self::SrcChain>;
+    fn packet_dst_channel_id(packet: &Self::Packet)
+        -> &ChannelIdOf<Self::DstChain, Self::SrcChain>;
 
     /**
         The sequence a packet, which is a sequence stored on the source chain
         that corresponds to the destination chain.
     */
-    fn packet_sequence(packet: &Self::Packet) -> &Sequence<Self::SrcChain, Self::DstChain>;
+    fn packet_sequence(packet: &Self::Packet) -> &SequenceOf<Self::SrcChain, Self::DstChain>;
 
     /**
         The optional timeout height of a packet, which is a height on the destination chain.
     */
-    fn packet_timeout_height(packet: &Self::Packet) -> Option<&Height<Self::DstChain>>;
+    fn packet_timeout_height(packet: &Self::Packet) -> Option<&HeightOf<Self::DstChain>>;
 
     /**
         The timeout timestamp of a packet, which is a timestamp on the destination chain.
     */
-    fn packet_timeout_timestamp(packet: &Self::Packet) -> &Timestamp<Self::DstChain>;
+    fn packet_timeout_timestamp(packet: &Self::Packet) -> &TimestampOf<Self::DstChain>;
 }
 
 impl<Relay, SrcChain, DstChain, Packet> HasRelayPacketFields for Relay
@@ -52,31 +54,31 @@ where
     SrcChain: CanReadPacketFields<DstChain, OutgoingPacket = Packet> + HasErrorType,
     DstChain: CanReadPacketFields<SrcChain, IncomingPacket = Packet> + HasErrorType,
 {
-    fn packet_src_port(packet: &Self::Packet) -> &PortId<SrcChain, DstChain> {
+    fn packet_src_port(packet: &Self::Packet) -> &PortIdOf<SrcChain, DstChain> {
         SrcChain::outgoing_packet_src_port(packet)
     }
 
-    fn packet_src_channel_id(packet: &Self::Packet) -> &ChannelId<SrcChain, DstChain> {
+    fn packet_src_channel_id(packet: &Self::Packet) -> &ChannelIdOf<SrcChain, DstChain> {
         SrcChain::outgoing_packet_src_channel_id(packet)
     }
 
-    fn packet_dst_port(packet: &Self::Packet) -> &PortId<DstChain, SrcChain> {
+    fn packet_dst_port(packet: &Self::Packet) -> &PortIdOf<DstChain, SrcChain> {
         SrcChain::outgoing_packet_dst_port(packet)
     }
 
-    fn packet_dst_channel_id(packet: &Self::Packet) -> &ChannelId<DstChain, SrcChain> {
+    fn packet_dst_channel_id(packet: &Self::Packet) -> &ChannelIdOf<DstChain, SrcChain> {
         SrcChain::outgoing_packet_dst_channel_id(packet)
     }
 
-    fn packet_sequence(packet: &Self::Packet) -> &Sequence<SrcChain, DstChain> {
+    fn packet_sequence(packet: &Self::Packet) -> &SequenceOf<SrcChain, DstChain> {
         SrcChain::outgoing_packet_sequence(packet)
     }
 
-    fn packet_timeout_height(packet: &Self::Packet) -> Option<&Height<DstChain>> {
+    fn packet_timeout_height(packet: &Self::Packet) -> Option<&HeightOf<DstChain>> {
         SrcChain::outgoing_packet_timeout_height(packet)
     }
 
-    fn packet_timeout_timestamp(packet: &Self::Packet) -> &Timestamp<DstChain> {
+    fn packet_timeout_timestamp(packet: &Self::Packet) -> &TimestampOf<DstChain> {
         SrcChain::outgoing_packet_timeout_timestamp(packet)
     }
 }

--- a/crates/relayer/relayer-components/src/relay/traits/target.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/target.rs
@@ -3,6 +3,7 @@ use cgp_core::{Async, HasErrorType};
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::types::aliases::ClientIdOf;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
+use crate::runtime::types::aliases::ErrorOf;
 
 #[derive(Default, Clone, Copy)]
 pub struct SourceTarget;
@@ -15,11 +16,9 @@ pub trait ChainTarget<Relay: HasRelayChains>: Async + Default + Copy + private::
 
     type CounterpartyChain: HasIbcChainTypes<Self::TargetChain> + HasErrorType;
 
-    fn target_chain_error(e: <Self::TargetChain as HasErrorType>::Error) -> Relay::Error;
+    fn target_chain_error(e: ErrorOf<Self::TargetChain>) -> Relay::Error;
 
-    fn counterparty_chain_error(
-        e: <Self::CounterpartyChain as HasErrorType>::Error,
-    ) -> Relay::Error;
+    fn counterparty_chain_error(e: ErrorOf<Self::CounterpartyChain>) -> Relay::Error;
 
     fn target_chain(relay: &Relay) -> &Self::TargetChain;
 
@@ -43,13 +42,11 @@ where
 
     type CounterpartyChain = Relay::DstChain;
 
-    fn target_chain_error(e: <Self::TargetChain as HasErrorType>::Error) -> Relay::Error {
+    fn target_chain_error(e: ErrorOf<Self::TargetChain>) -> Relay::Error {
         Relay::raise_error(e)
     }
 
-    fn counterparty_chain_error(
-        e: <Self::CounterpartyChain as HasErrorType>::Error,
-    ) -> Relay::Error {
+    fn counterparty_chain_error(e: ErrorOf<Self::CounterpartyChain>) -> Relay::Error {
         Relay::raise_error(e)
     }
 
@@ -82,13 +79,11 @@ where
 
     type CounterpartyChain = Relay::SrcChain;
 
-    fn target_chain_error(e: <Self::TargetChain as HasErrorType>::Error) -> Relay::Error {
+    fn target_chain_error(e: ErrorOf<Self::TargetChain>) -> Relay::Error {
         Relay::raise_error(e)
     }
 
-    fn counterparty_chain_error(
-        e: <Self::CounterpartyChain as HasErrorType>::Error,
-    ) -> Relay::Error {
+    fn counterparty_chain_error(e: ErrorOf<Self::CounterpartyChain>) -> Relay::Error {
         Relay::raise_error(e)
     }
 

--- a/crates/relayer/relayer-components/src/relay/traits/target.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/target.rs
@@ -1,7 +1,7 @@
 use cgp_core::{Async, HasErrorType};
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
-use crate::chain::types::aliases::ClientId;
+use crate::chain::types::aliases::ClientIdOf;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
 
 #[derive(Default, Clone, Copy)]
@@ -25,11 +25,11 @@ pub trait ChainTarget<Relay: HasRelayChains>: Async + Default + Copy + private::
 
     fn counterparty_chain(relay: &Relay) -> &Self::CounterpartyChain;
 
-    fn target_client_id(relay: &Relay) -> &ClientId<Self::TargetChain, Self::CounterpartyChain>;
+    fn target_client_id(relay: &Relay) -> &ClientIdOf<Self::TargetChain, Self::CounterpartyChain>;
 
     fn counterparty_client_id(
         relay: &Relay,
-    ) -> &ClientId<Self::CounterpartyChain, Self::TargetChain>;
+    ) -> &ClientIdOf<Self::CounterpartyChain, Self::TargetChain>;
 }
 
 impl private::Sealed for SourceTarget {}
@@ -61,13 +61,15 @@ where
         context.dst_chain()
     }
 
-    fn target_client_id(context: &Relay) -> &ClientId<Self::TargetChain, Self::CounterpartyChain> {
+    fn target_client_id(
+        context: &Relay,
+    ) -> &ClientIdOf<Self::TargetChain, Self::CounterpartyChain> {
         context.src_client_id()
     }
 
     fn counterparty_client_id(
         context: &Relay,
-    ) -> &ClientId<Self::CounterpartyChain, Self::TargetChain> {
+    ) -> &ClientIdOf<Self::CounterpartyChain, Self::TargetChain> {
         context.dst_client_id()
     }
 }
@@ -98,13 +100,15 @@ where
         context.src_chain()
     }
 
-    fn target_client_id(context: &Relay) -> &ClientId<Self::TargetChain, Self::CounterpartyChain> {
+    fn target_client_id(
+        context: &Relay,
+    ) -> &ClientIdOf<Self::TargetChain, Self::CounterpartyChain> {
         context.dst_client_id()
     }
 
     fn counterparty_client_id(
         context: &Relay,
-    ) -> &ClientId<Self::CounterpartyChain, Self::TargetChain> {
+    ) -> &ClientIdOf<Self::CounterpartyChain, Self::TargetChain> {
         context.src_client_id()
     }
 }

--- a/crates/relayer/relayer-components/src/runtime/traits/mutex.rs
+++ b/crates/relayer/relayer-components/src/runtime/traits/mutex.rs
@@ -13,3 +13,7 @@ pub trait HasMutex: Async {
 
     async fn acquire_mutex<'a, T: Async>(mutex: &'a Self::Mutex<T>) -> Self::MutexGuard<'a, T>;
 }
+
+pub type MutexOf<Runtime, T> = <Runtime as HasMutex>::Mutex<T>;
+
+pub type MutexGuardOf<'a, Runtime, T> = <Runtime as HasMutex>::MutexGuard<'a, T>;

--- a/crates/relayer/relayer-components/src/runtime/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/runtime/types/aliases.rs
@@ -1,6 +1,6 @@
 use crate::runtime::traits::mutex::HasMutex;
 use crate::runtime::traits::runtime::HasRuntimeType;
 
-pub type Runtime<Context> = <Context as HasRuntimeType>::Runtime;
+pub type RuntimeOf<Context> = <Context as HasRuntimeType>::Runtime;
 
-pub type Mutex<Context, T> = <Runtime<Context> as HasMutex>::Mutex<T>;
+pub type Mutex<Context, T> = <RuntimeOf<Context> as HasMutex>::Mutex<T>;

--- a/crates/relayer/relayer-components/src/runtime/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/runtime/types/aliases.rs
@@ -1,10 +1,7 @@
 use cgp_core::HasErrorType;
 
-use crate::runtime::traits::mutex::HasMutex;
 use crate::runtime::traits::runtime::HasRuntimeType;
 
 pub type RuntimeOf<Context> = <Context as HasRuntimeType>::Runtime;
-
-pub type MutexOf<Context, T> = <RuntimeOf<Context> as HasMutex>::Mutex<T>;
 
 pub type ErrorOf<Context> = <Context as HasErrorType>::Error;

--- a/crates/relayer/relayer-components/src/runtime/types/aliases.rs
+++ b/crates/relayer/relayer-components/src/runtime/types/aliases.rs
@@ -1,6 +1,10 @@
+use cgp_core::HasErrorType;
+
 use crate::runtime::traits::mutex::HasMutex;
 use crate::runtime::traits::runtime::HasRuntimeType;
 
 pub type RuntimeOf<Context> = <Context as HasRuntimeType>::Runtime;
 
-pub type Mutex<Context, T> = <RuntimeOf<Context> as HasMutex>::Mutex<T>;
+pub type MutexOf<Context, T> = <RuntimeOf<Context> as HasMutex>::Mutex<T>;
+
+pub type ErrorOf<Context> = <Context as HasErrorType>::Error;

--- a/crates/relayer/relayer-components/src/transaction/traits/nonce/mutex.rs
+++ b/crates/relayer/relayer-components/src/transaction/traits/nonce/mutex.rs
@@ -1,4 +1,4 @@
-use crate::runtime::traits::mutex::HasMutex;
+use crate::runtime::traits::mutex::{HasMutex, MutexGuardOf, MutexOf};
 use crate::runtime::traits::runtime::HasRuntime;
 use crate::transaction::traits::nonce::guard::HasNonceGuard;
 use crate::transaction::traits::types::HasSignerType;
@@ -16,13 +16,10 @@ pub trait HasMutexForNonceAllocation: HasRuntime + HasNonceGuard + HasSignerType
 where
     Self::Runtime: HasMutex,
 {
-    fn mutex_for_nonce_allocation(
-        &self,
-        signer: &Self::Signer,
-    ) -> &<Self::Runtime as HasMutex>::Mutex<()>;
+    fn mutex_for_nonce_allocation(&self, signer: &Self::Signer) -> &MutexOf<Self::Runtime, ()>;
 
     fn mutex_to_nonce_guard<'a>(
-        mutex_guard: <Self::Runtime as HasMutex>::MutexGuard<'a, ()>,
+        mutex_guard: MutexGuardOf<'a, Self::Runtime, ()>,
         nonce: Self::Nonce,
     ) -> Self::NonceGuard<'a>;
 }

--- a/crates/runtime/async-runtime-components/src/subscription/impls/closure.rs
+++ b/crates/runtime/async-runtime-components/src/subscription/impls/closure.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 
 use cgp_core::prelude::*;
 use futures_core::stream::Stream;
-use hermes_relayer_components::runtime::traits::mutex::HasMutex;
+use hermes_relayer_components::runtime::traits::mutex::{HasMutex, MutexOf};
 
 use crate::subscription::traits::subscription::Subscription;
 
@@ -62,7 +62,7 @@ struct SubscriptionClosure<Runtime, T>
 where
     Runtime: HasMutex,
 {
-    terminated: <Runtime as HasMutex>::Mutex<bool>,
+    terminated: MutexOf<Runtime, bool>,
     subscribe: Box<
         dyn Fn() -> Pin<
                 Box<

--- a/crates/runtime/async-runtime-components/src/subscription/impls/multiplex.rs
+++ b/crates/runtime/async-runtime-components/src/subscription/impls/multiplex.rs
@@ -8,7 +8,7 @@ use core::pin::Pin;
 use cgp_core::prelude::*;
 use futures_core::stream::Stream;
 use futures_util::stream::StreamExt;
-use hermes_relayer_components::runtime::traits::mutex::HasMutex;
+use hermes_relayer_components::runtime::traits::mutex::{HasMutex, MutexOf};
 use hermes_relayer_components::runtime::traits::stream::HasStreamType;
 use hermes_relayer_components::runtime::traits::task::Task;
 use hermes_relayer_components_extra::runtime::traits::channel::{
@@ -169,8 +169,7 @@ where
 
 type StreamSender<Runtime, T> = <Runtime as HasChannelTypes>::Sender<T>;
 
-type StreamSenders<Runtime, T> =
-    Arc<<Runtime as HasMutex>::Mutex<Option<Vec<StreamSender<Runtime, T>>>>>;
+type StreamSenders<Runtime, T> = Arc<MutexOf<Runtime, Option<Vec<StreamSender<Runtime, T>>>>>;
 
 pub struct MultiplexingSubscription<Runtime, T>
 where

--- a/crates/test/test-components/src/chain_driver/traits/build/chain_id.rs
+++ b/crates/test/test-components/src/chain_driver/traits/build/chain_id.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
-use hermes_relayer_components::chain::types::aliases::ChainId;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
 
 use crate::chain_driver::traits::types::chain::HasChainType;
 
@@ -9,5 +9,5 @@ pub trait CanBuildChainIdFromString: HasChainType
 where
     Self::Chain: HasChainIdType,
 {
-    fn build_chain_id_from_string(chain_id: &str) -> ChainId<Self::Chain>;
+    fn build_chain_id_from_string(chain_id: &str) -> ChainIdOf<Self::Chain>;
 }

--- a/crates/test/test-components/src/chain_driver/traits/fields/amount.rs
+++ b/crates/test/test-components/src/chain_driver/traits/fields/amount.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, PortIdOf};
 
 use crate::chain_driver::traits::types::amount::HasAmountType;
 use crate::chain_driver::traits::types::chain::HasChainType;
@@ -33,8 +33,8 @@ where
 {
     fn ibc_transfer_amount_from(
         counterparty_amount: &CounterpartyDriver::Amount,
-        channel_id: &ChannelId<Self::Chain, CounterpartyDriver::Chain>,
-        port_id: &PortId<Self::Chain, CounterpartyDriver::Chain>,
+        channel_id: &ChannelIdOf<Self::Chain, CounterpartyDriver::Chain>,
+        port_id: &PortIdOf<Self::Chain, CounterpartyDriver::Chain>,
     ) -> Result<Self::Amount, Self::Error>;
 
     fn transmute_counterparty_amount(

--- a/crates/test/test-components/src/chain_driver/traits/fields/chain_home_dir.rs
+++ b/crates/test/test-components/src/chain_driver/traits/fields/chain_home_dir.rs
@@ -1,12 +1,12 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 
-use crate::runtime::traits::types::file_path::{FilePath, HasFilePathType};
+use crate::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
 
 #[derive_component(ChainHomeDirGetterComponent, ChainHomeDirGetter<ChainDriver>)]
 pub trait HasChainHomeDir: HasRuntime
 where
     Self::Runtime: HasFilePathType,
 {
-    fn chain_home_dir(&self) -> &FilePath<Self::Runtime>;
+    fn chain_home_dir(&self) -> &FilePathOf<Self::Runtime>;
 }

--- a/crates/test/test-components/src/chain_driver/traits/fields/timeout.rs
+++ b/crates/test/test-components/src/chain_driver/traits/fields/timeout.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::timestamp::HasTimestampType;
-use hermes_relayer_components::chain::types::aliases::{Height, Timestamp};
+use hermes_relayer_components::chain::types::aliases::{HeightOf, TimestampOf};
 
 use crate::chain_driver::traits::types::chain::HasChainType;
 
@@ -12,11 +12,11 @@ where
 {
     fn ibc_transfer_timeout_time(
         &self,
-        current_time: &Timestamp<Self::Chain>,
-    ) -> Option<Timestamp<Self::Chain>>;
+        current_time: &TimestampOf<Self::Chain>,
+    ) -> Option<TimestampOf<Self::Chain>>;
 
     fn ibc_transfer_timeout_height(
         &self,
-        current_height: &Height<Self::Chain>,
-    ) -> Option<Height<Self::Chain>>;
+        current_height: &HeightOf<Self::Chain>,
+    ) -> Option<HeightOf<Self::Chain>>;
 }

--- a/crates/test/test-components/src/chain_driver/traits/messages/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain_driver/traits/messages/ibc_transfer.rs
@@ -4,7 +4,7 @@ use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 use hermes_relayer_components::chain::traits::types::timestamp::HasTimestampType;
 use hermes_relayer_components::chain::types::aliases::{
-    ChannelId, Height, Message, PortId, Timestamp,
+    ChannelIdOf, HeightOf, MessageOf, PortIdOf, TimestampOf,
 };
 
 use crate::chain_driver::traits::types::address::HasAddressType;
@@ -25,12 +25,12 @@ where
 {
     async fn build_ibc_token_transfer_message(
         &self,
-        channel_id: &ChannelId<Self::Chain, CounterpartyDriver::Chain>,
-        port_id: &PortId<Self::Chain, CounterpartyDriver::Chain>,
+        channel_id: &ChannelIdOf<Self::Chain, CounterpartyDriver::Chain>,
+        port_id: &PortIdOf<Self::Chain, CounterpartyDriver::Chain>,
         recipient_address: &CounterpartyDriver::Address,
         amount: &Self::Amount,
         memo: &Self::Memo,
-        timeout_height: Option<&Height<Self::Chain>>,
-        timeout_time: Option<&Timestamp<Self::Chain>>,
-    ) -> Result<Message<Self::Chain>, Self::Error>;
+        timeout_height: Option<&HeightOf<Self::Chain>>,
+        timeout_time: Option<&TimestampOf<Self::Chain>>,
+    ) -> Result<MessageOf<Self::Chain>, Self::Error>;
 }

--- a/crates/test/test-components/src/chain_driver/traits/queries/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain_driver/traits/queries/ibc_transfer.rs
@@ -1,7 +1,7 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::packet::HasIbcPacketTypes;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, OutgoingPacket, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, OutgoingPacketOf, PortIdOf};
 
 use crate::chain_driver::traits::types::address::HasAddressType;
 use crate::chain_driver::traits::types::amount::HasAmountType;
@@ -19,10 +19,10 @@ where
 {
     async fn ibc_transfer_token(
         &self,
-        channel_id: &ChannelId<Self::Chain, CounterpartyDriver::Chain>,
-        port_id: &PortId<Self::Chain, CounterpartyDriver::Chain>,
+        channel_id: &ChannelIdOf<Self::Chain, CounterpartyDriver::Chain>,
+        port_id: &PortIdOf<Self::Chain, CounterpartyDriver::Chain>,
         sender_wallet: &Self::Wallet,
         recipient_address: &CounterpartyDriver::Address,
         amount: &Self::Amount,
-    ) -> Result<OutgoingPacket<Self::Chain, CounterpartyDriver::Chain>, Self::Error>;
+    ) -> Result<OutgoingPacketOf<Self::Chain, CounterpartyDriver::Chain>, Self::Error>;
 }

--- a/crates/test/test-components/src/driver/traits/channel_at.rs
+++ b/crates/test/test-components/src/driver/traits/channel_at.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, PortIdOf};
 
 use crate::driver::traits::types::chain_at::{ChainTypeAt, HasChainTypeAt};
 use crate::types::index::Twindex;
@@ -14,10 +14,10 @@ where
     fn channel_id_at(
         &self,
         index: Twindex<CHAIN, COUNTERPARTY>,
-    ) -> &ChannelId<ChainTypeAt<Self, CHAIN>, ChainTypeAt<Self, COUNTERPARTY>>;
+    ) -> &ChannelIdOf<ChainTypeAt<Self, CHAIN>, ChainTypeAt<Self, COUNTERPARTY>>;
 
     fn port_id_at(
         &self,
         index: Twindex<CHAIN, COUNTERPARTY>,
-    ) -> &PortId<ChainTypeAt<Self, CHAIN>, ChainTypeAt<Self, COUNTERPARTY>>;
+    ) -> &PortIdOf<ChainTypeAt<Self, CHAIN>, ChainTypeAt<Self, COUNTERPARTY>>;
 }

--- a/crates/test/test-components/src/runtime/traits/types/file_path.rs
+++ b/crates/test/test-components/src/runtime/traits/types/file_path.rs
@@ -13,4 +13,4 @@ pub trait HasFilePathType: Async {
     fn join_file_path(path1: &Self::FilePath, path2: &Self::FilePath) -> Self::FilePath;
 }
 
-pub type FilePath<Runtime> = <Runtime as HasFilePathType>::FilePath;
+pub type FilePathOf<Runtime> = <Runtime as HasFilePathType>::FilePath;

--- a/crates/test/test-components/src/setup/impls/birelay.rs
+++ b/crates/test/test-components/src/setup/impls/birelay.rs
@@ -1,7 +1,7 @@
 use cgp_core::CanRaiseError;
 use hermes_relayer_components::build::traits::components::birelay_from_relay_builder::CanBuildBiRelayFromRelays;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ClientId;
+use hermes_relayer_components::chain::types::aliases::ClientIdOf;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
@@ -28,8 +28,8 @@ where
         _index: Twindex<A, B>,
         chain_a: &ChainTypeAt<Setup, A>,
         chain_b: &ChainTypeAt<Setup, B>,
-        client_id_a: &ClientId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-        client_id_b: &ClientId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+        client_id_a: &ClientIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+        client_id_b: &ClientIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
     ) -> Result<BiRelayTypeAt<Setup, A, B>, Setup::Error> {
         let (relay_a_to_b, relay_b_to_a) = setup
             .setup_relays(Twindex::<A, B>, chain_a, chain_b, client_id_a, client_id_b)

--- a/crates/test/test-components/src/setup/impls/birelay.rs
+++ b/crates/test/test-components/src/setup/impls/birelay.rs
@@ -2,13 +2,13 @@ use cgp_core::CanRaiseError;
 use hermes_relayer_components::build::traits::components::birelay_from_relay_builder::CanBuildBiRelayFromRelays;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::types::aliases::ClientIdOf;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
 use crate::setup::traits::birelay::BiRelaySetup;
 use crate::setup::traits::builder_at::HasBuilderAt;
 use crate::setup::traits::relay::CanSetupRelays;
-use crate::types::error::ErrorOf;
 use crate::types::index::Twindex;
 
 pub struct SetupBiRelayWithBuilder;

--- a/crates/test/test-components/src/setup/impls/chain.rs
+++ b/crates/test/test-components/src/setup/impls/chain.rs
@@ -1,12 +1,12 @@
 use alloc::format;
 use cgp_core::CanRaiseError;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::bootstrap::traits::chain::CanBootstrapChain;
 
 use crate::driver::traits::types::chain_driver_at::ChainDriverTypeAt;
 use crate::setup::traits::bootstrap_at::HasBootstrapAt;
 use crate::setup::traits::chain::ChainSetup;
-use crate::types::error::ErrorOf;
 use crate::types::index::Index;
 
 pub struct SetupChainWithBootstrap;

--- a/crates/test/test-components/src/setup/impls/channel.rs
+++ b/crates/test/test-components/src/setup/impls/channel.rs
@@ -2,7 +2,7 @@ use cgp_core::CanRaiseError;
 use hermes_relayer_components::birelay::traits::two_way::HasTwoWayRelay;
 use hermes_relayer_components::chain::traits::types::channel::HasInitChannelOptionsType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, ConnectionId, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, ConnectionIdOf, PortIdOf};
 use hermes_relayer_components::relay::impls::channel::bootstrap::CanBootstrapChannel;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
@@ -28,20 +28,20 @@ where
     ChainTypeAt<Setup, B>: HasIbcChainTypes<ChainTypeAt<Setup, A>>,
     RelayTypeAt<Setup, A, B>: CanBootstrapChannel,
     BiRelayTypeAt<Setup, A, B>: HasTwoWayRelay,
-    PortId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>: Clone,
-    PortId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>: Clone,
+    PortIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>: Clone,
+    PortIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>: Clone,
 {
     async fn setup_channel(
         setup: &Setup,
         birelay: &BiRelayTypeAt<Setup, A, B>,
-        connection_id_a: &ConnectionId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-        connection_id_b: &ConnectionId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+        connection_id_a: &ConnectionIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+        connection_id_b: &ConnectionIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
     ) -> Result<
         (
-            ChannelId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-            ChannelId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
-            PortId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-            PortId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+            ChannelIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+            ChannelIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+            PortIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+            PortIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
         ),
         Setup::Error,
     > {

--- a/crates/test/test-components/src/setup/impls/channel.rs
+++ b/crates/test/test-components/src/setup/impls/channel.rs
@@ -4,6 +4,7 @@ use hermes_relayer_components::chain::traits::types::channel::HasInitChannelOpti
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, ConnectionIdOf, PortIdOf};
 use hermes_relayer_components::relay::impls::channel::bootstrap::CanBootstrapChannel;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
@@ -11,7 +12,6 @@ use crate::driver::traits::types::relay_at::RelayTypeAt;
 use crate::setup::traits::channel::ChannelSetup;
 use crate::setup::traits::init_channel_options_at::HasInitChannelOptionsAt;
 use crate::setup::traits::port_id_at::HasPortIdAt;
-use crate::types::error::ErrorOf;
 use crate::types::index::Twindex;
 
 pub struct SetupChannelHandshake;

--- a/crates/test/test-components/src/setup/impls/clients.rs
+++ b/crates/test/test-components/src/setup/impls/clients.rs
@@ -2,7 +2,7 @@ use cgp_core::prelude::*;
 use cgp_core::CanRaiseError;
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientOptionsType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ClientId;
+use hermes_relayer_components::chain::types::aliases::ClientIdOf;
 use hermes_relayer_components::relay::traits::chains::CanRaiseRelayChainErrors;
 use hermes_relayer_components::relay::traits::components::client_creator::CanCreateClient;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
@@ -36,8 +36,8 @@ where
         chain_b: &ChainTypeAt<Setup, B>,
     ) -> Result<
         (
-            ClientId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-            ClientId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+            ClientIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+            ClientIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
         ),
         Setup::Error,
     > {

--- a/crates/test/test-components/src/setup/impls/connection.rs
+++ b/crates/test/test-components/src/setup/impls/connection.rs
@@ -4,13 +4,13 @@ use hermes_relayer_components::chain::traits::types::connection::HasInitConnecti
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::types::aliases::ConnectionIdOf;
 use hermes_relayer_components::relay::impls::connection::bootstrap::CanBootstrapConnection;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
 use crate::driver::traits::types::relay_at::RelayTypeAt;
 use crate::setup::traits::connection::ConnectionSetup;
 use crate::setup::traits::init_connection_options_at::HasInitConnectionOptionsAt;
-use crate::types::error::ErrorOf;
 
 pub struct SetupConnectionHandshake;
 

--- a/crates/test/test-components/src/setup/impls/connection.rs
+++ b/crates/test/test-components/src/setup/impls/connection.rs
@@ -2,7 +2,7 @@ use cgp_core::CanRaiseError;
 use hermes_relayer_components::birelay::traits::two_way::HasTwoWayRelay;
 use hermes_relayer_components::chain::traits::types::connection::HasInitConnectionOptionsType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ConnectionId;
+use hermes_relayer_components::chain::types::aliases::ConnectionIdOf;
 use hermes_relayer_components::relay::impls::connection::bootstrap::CanBootstrapConnection;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
@@ -31,8 +31,8 @@ where
         birelay: &BiRelayTypeAt<Setup, A, B>,
     ) -> Result<
         (
-            ConnectionId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-            ConnectionId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+            ConnectionIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+            ConnectionIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
         ),
         Setup::Error,
     > {

--- a/crates/test/test-components/src/setup/impls/relay.rs
+++ b/crates/test/test-components/src/setup/impls/relay.rs
@@ -2,7 +2,7 @@ use cgp_core::CanRaiseError;
 use hermes_relayer_components::build::traits::components::relay_from_chains_builder::CanBuildRelayFromChains;
 use hermes_relayer_components::build::traits::target::relay::{RelayAToBTarget, RelayBToATarget};
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ClientId;
+use hermes_relayer_components::chain::types::aliases::ClientIdOf;
 
 use crate::driver::traits::types::chain_at::ChainTypeAt;
 use crate::driver::traits::types::relay_at::{HasRelayTypeAt, RelayTypeAt};
@@ -26,8 +26,8 @@ where
         _index: Twindex<A, B>,
         chain_a: &ChainTypeAt<Setup, A>,
         chain_b: &ChainTypeAt<Setup, B>,
-        client_id_a: &ClientId<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
-        client_id_b: &ClientId<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
+        client_id_a: &ClientIdOf<ChainTypeAt<Setup, A>, ChainTypeAt<Setup, B>>,
+        client_id_b: &ClientIdOf<ChainTypeAt<Setup, B>, ChainTypeAt<Setup, A>>,
     ) -> Result<(RelayTypeAt<Setup, A, B>, RelayTypeAt<Setup, B, A>), Setup::Error> {
         let build = setup.builder();
 

--- a/crates/test/test-components/src/setup/impls/relay.rs
+++ b/crates/test/test-components/src/setup/impls/relay.rs
@@ -3,12 +3,12 @@ use hermes_relayer_components::build::traits::components::relay_from_chains_buil
 use hermes_relayer_components::build::traits::target::relay::{RelayAToBTarget, RelayBToATarget};
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::types::aliases::ClientIdOf;
+use hermes_relayer_components::runtime::types::aliases::ErrorOf;
 
 use crate::driver::traits::types::chain_at::ChainTypeAt;
 use crate::driver::traits::types::relay_at::{HasRelayTypeAt, RelayTypeAt};
 use crate::setup::traits::builder_at::HasBuilderAt;
 use crate::setup::traits::relay::RelaySetup;
-use crate::types::error::ErrorOf;
 use crate::types::index::Twindex;
 
 pub struct SetupRelayWithBuilder;

--- a/crates/test/test-components/src/setup/traits/birelay.rs
+++ b/crates/test/test-components/src/setup/traits/birelay.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ClientId;
+use hermes_relayer_components::chain::types::aliases::ClientIdOf;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
@@ -19,7 +19,7 @@ where
         index: Twindex<A, B>,
         chain_a: &ChainTypeAt<Self, A>,
         chain_b: &ChainTypeAt<Self, B>,
-        client_id_a: &ClientId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-        client_id_b: &ClientId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+        client_id_a: &ClientIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+        client_id_b: &ClientIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
     ) -> Result<BiRelayTypeAt<Self, A, B>, Self::Error>;
 }

--- a/crates/test/test-components/src/setup/traits/channel.rs
+++ b/crates/test/test-components/src/setup/traits/channel.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, ConnectionId, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, ConnectionIdOf, PortIdOf};
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
@@ -16,14 +16,14 @@ where
     async fn setup_channel(
         &self,
         birelay: &BiRelayTypeAt<Self, A, B>,
-        connection_id_a: &ConnectionId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-        connection_id_b: &ConnectionId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+        connection_id_a: &ConnectionIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+        connection_id_b: &ConnectionIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
     ) -> Result<
         (
-            ChannelId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-            ChannelId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
-            PortId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-            PortId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+            ChannelIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+            ChannelIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+            PortIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+            PortIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
         ),
         Self::Error,
     >;

--- a/crates/test/test-components/src/setup/traits/clients.rs
+++ b/crates/test/test-components/src/setup/traits/clients.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ClientId;
+use hermes_relayer_components::chain::types::aliases::ClientIdOf;
 
 use crate::driver::traits::types::chain_at::{ChainTypeAt, HasChainTypeAt};
 
@@ -18,8 +18,8 @@ where
         chain_b: &ChainTypeAt<Self, B>,
     ) -> Result<
         (
-            ClientId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-            ClientId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+            ClientIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+            ClientIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
         ),
         Self::Error,
     >;

--- a/crates/test/test-components/src/setup/traits/connection.rs
+++ b/crates/test/test-components/src/setup/traits/connection.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ConnectionId;
+use hermes_relayer_components::chain::types::aliases::ConnectionIdOf;
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
@@ -18,8 +18,8 @@ where
         birelay: &BiRelayTypeAt<Self, A, B>,
     ) -> Result<
         (
-            ConnectionId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-            ConnectionId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+            ConnectionIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+            ConnectionIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
         ),
         Self::Error,
     >;

--- a/crates/test/test-components/src/setup/traits/drivers/binary_channel.rs
+++ b/crates/test/test-components/src/setup/traits/drivers/binary_channel.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::{ChannelId, ConnectionId, PortId};
+use hermes_relayer_components::chain::types::aliases::{ChannelIdOf, ConnectionIdOf, PortIdOf};
 
 use crate::driver::traits::types::birelay_at::{BiRelayTypeAt, HasBiRelayTypeAt};
 use crate::driver::traits::types::chain_at::ChainTypeAt;
@@ -24,11 +24,11 @@ where
         birelay: BiRelayTypeAt<Self, 0, 1>,
         chain_driver_a: ChainDriverTypeAt<Self, 0>,
         chain_driver_b: ChainDriverTypeAt<Self, 1>,
-        connection_id_a: ConnectionId<ChainTypeAt<Self, 0>, ChainTypeAt<Self, 1>>,
-        connection_id_b: ConnectionId<ChainTypeAt<Self, 1>, ChainTypeAt<Self, 0>>,
-        channel_id_a: ChannelId<ChainTypeAt<Self, 0>, ChainTypeAt<Self, 1>>,
-        channel_id_b: ChannelId<ChainTypeAt<Self, 1>, ChainTypeAt<Self, 0>>,
-        port_id_a: PortId<ChainTypeAt<Self, 0>, ChainTypeAt<Self, 1>>,
-        port_id_b: PortId<ChainTypeAt<Self, 1>, ChainTypeAt<Self, 0>>,
+        connection_id_a: ConnectionIdOf<ChainTypeAt<Self, 0>, ChainTypeAt<Self, 1>>,
+        connection_id_b: ConnectionIdOf<ChainTypeAt<Self, 1>, ChainTypeAt<Self, 0>>,
+        channel_id_a: ChannelIdOf<ChainTypeAt<Self, 0>, ChainTypeAt<Self, 1>>,
+        channel_id_b: ChannelIdOf<ChainTypeAt<Self, 1>, ChainTypeAt<Self, 0>>,
+        port_id_a: PortIdOf<ChainTypeAt<Self, 0>, ChainTypeAt<Self, 1>>,
+        port_id_b: PortIdOf<ChainTypeAt<Self, 1>, ChainTypeAt<Self, 0>>,
     ) -> Result<Self::TestDriver, Self::Error>;
 }

--- a/crates/test/test-components/src/setup/traits/init_channel_options_at.rs
+++ b/crates/test/test-components/src/setup/traits/init_channel_options_at.rs
@@ -3,7 +3,7 @@ use hermes_relayer_components::chain::traits::types::channel::{
     HasInitChannelOptionsType, InitChannelOptions,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ConnectionId;
+use hermes_relayer_components::chain::types::aliases::ConnectionIdOf;
 
 use crate::driver::traits::types::chain_at::{ChainTypeAt, HasChainTypeAt};
 
@@ -17,8 +17,8 @@ where
 {
     fn init_channel_options(
         &self,
-        connection_id: &ConnectionId<ChainTypeAt<Self, TARGET>, ChainTypeAt<Self, COUNTERPARTY>>,
-        counterparty_connection_id: &ConnectionId<
+        connection_id: &ConnectionIdOf<ChainTypeAt<Self, TARGET>, ChainTypeAt<Self, COUNTERPARTY>>,
+        counterparty_connection_id: &ConnectionIdOf<
             ChainTypeAt<Self, COUNTERPARTY>,
             ChainTypeAt<Self, TARGET>,
         >,

--- a/crates/test/test-components/src/setup/traits/port_id_at.rs
+++ b/crates/test/test-components/src/setup/traits/port_id_at.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::PortId;
+use hermes_relayer_components::chain::types::aliases::PortIdOf;
 
 use crate::driver::traits::types::chain_at::{ChainTypeAt, HasChainTypeAt};
 use crate::types::index::Twindex;
@@ -14,5 +14,5 @@ where
     fn port_id_at(
         &self,
         index: Twindex<CHAIN, COUNTERPARTY>,
-    ) -> &PortId<ChainTypeAt<Self, CHAIN>, ChainTypeAt<Self, COUNTERPARTY>>;
+    ) -> &PortIdOf<ChainTypeAt<Self, CHAIN>, ChainTypeAt<Self, COUNTERPARTY>>;
 }

--- a/crates/test/test-components/src/setup/traits/relay.rs
+++ b/crates/test/test-components/src/setup/traits/relay.rs
@@ -1,6 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
-use hermes_relayer_components::chain::types::aliases::ClientId;
+use hermes_relayer_components::chain::types::aliases::ClientIdOf;
 
 use crate::driver::traits::types::chain_at::ChainTypeAt;
 use crate::driver::traits::types::relay_at::{HasRelayTypeAt, RelayTypeAt};
@@ -19,7 +19,7 @@ where
         index: Twindex<A, B>,
         chain_a: &ChainTypeAt<Self, A>,
         chain_b: &ChainTypeAt<Self, B>,
-        client_id_a: &ClientId<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
-        client_id_b: &ClientId<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
+        client_id_a: &ClientIdOf<ChainTypeAt<Self, A>, ChainTypeAt<Self, B>>,
+        client_id_b: &ClientIdOf<ChainTypeAt<Self, B>, ChainTypeAt<Self, A>>,
     ) -> Result<(RelayTypeAt<Self, A, B>, RelayTypeAt<Self, B, A>), Self::Error>;
 }

--- a/crates/test/test-components/src/types/error.rs
+++ b/crates/test/test-components/src/types/error.rs
@@ -1,3 +1,0 @@
-use cgp_core::HasErrorType;
-
-pub type ErrorOf<Context> = <Context as HasErrorType>::Error;

--- a/crates/test/test-components/src/types/mod.rs
+++ b/crates/test/test-components/src/types/mod.rs
@@ -1,2 +1,1 @@
-pub mod error;
 pub mod index;


### PR DESCRIPTION
This PR adds -Of postfix to type aliases for associated types in a context. For example, the original type alias

```rust
type ChainId<Chain> = <Chain as HasChainIdType>::ChainId;
```

has been renamed to 

```rust
type ChainIdOf<Chain> = <Chain as HasChainIdType>::ChainId;
```

The use of -Of postfixes helps with IDE support for auto importing from the appropriate module. For example, when auto-importing `ChainId<Chain>`, users would have to choose between importing the type alias `ChainId` or the concrete Cosmos type `ChainId`. But after the renaming, there is no longer an ambiguity of which construct the IDE should help import.

The postfix also helps readability, so that when readers see a type like `ChainIdOf<Chain>`, they do not need to wonder whether it is an alias or a concrete type.