### PR TITLE
Celestia bridge bootstrap improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,6 @@ dependencies = [
  "hermes-relayer-components",
  "hermes-relayer-components-extra",
  "hermes-test-components",
- "rand",
 ]
 
 [[package]]
@@ -1669,7 +1668,6 @@ dependencies = [
  "ibc-relayer",
  "ibc-relayer-types",
  "itertools 0.11.0",
- "rand",
  "serde_json",
  "toml 0.8.8",
 ]

--- a/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
@@ -182,10 +182,12 @@ impl BridgeDriverBuilder<CelestiaBootstrap> for CelestiaBootstrapComponents {
     async fn build_bridge_driver(
         _bootstrap: &CelestiaBootstrap,
         bridge_config: CelestiaBridgeConfig,
+        bridge_auth_token: String,
         bridge_process: Child,
     ) -> Result<CelestiaBridgeDriver, Error> {
         Ok(CelestiaBridgeDriver {
             bridge_config,
+            bridge_auth_token,
             bridge_process,
         })
     }

--- a/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
@@ -7,6 +7,7 @@ use cgp_core::ErrorTypeComponent;
 use eyre::Error;
 use hermes_celestia_test_components::bootstrap::components::CelestiaBootstrapComponents as BaseCelestiaBootstrapComponents;
 use hermes_celestia_test_components::bootstrap::traits::bootstrap_bridge::BridgeBootstrapperComponent;
+use hermes_celestia_test_components::bootstrap::traits::bridge_auth_token::BridgeAuthTokenGeneratorComponent;
 use hermes_celestia_test_components::bootstrap::traits::bridge_store_dir::BridgeStoreDirGetter;
 use hermes_celestia_test_components::bootstrap::traits::build_bridge_driver::BridgeDriverBuilder;
 use hermes_celestia_test_components::bootstrap::traits::import_bridge_key::BridgeKeyImporterComponent;
@@ -95,6 +96,7 @@ delegate_components! {
             BridgeKeyImporterComponent,
             BridgeConfigTypeComponent,
             BridgeConfigInitializerComponent,
+            BridgeAuthTokenGeneratorComponent,
             BridgeStarterComponent,
         ]:
             BaseCelestiaBootstrapComponents,

--- a/crates/celestia/celestia-integration-tests/src/contexts/bridge_driver.rs
+++ b/crates/celestia/celestia-integration-tests/src/contexts/bridge_driver.rs
@@ -6,6 +6,7 @@ use tokio::process::Child;
 pub struct CelestiaBridgeDriver {
     pub bridge_process: Child,
     pub bridge_config: CelestiaBridgeConfig,
+    pub bridge_auth_token: String,
 }
 
 pub struct CelestiaBridgeDriverComponents;

--- a/crates/celestia/celestia-integration-tests/src/contexts/bridge_driver.rs
+++ b/crates/celestia/celestia-integration-tests/src/contexts/bridge_driver.rs
@@ -1,7 +1,22 @@
+use cgp_core::{Async, HasComponents};
+use hermes_celestia_test_components::bridge_driver::traits::bridge_auth_token::ProvideBridgeAuthTokenType;
 use hermes_celestia_test_components::types::bridge_config::CelestiaBridgeConfig;
 use tokio::process::Child;
 
 pub struct CelestiaBridgeDriver {
     pub bridge_process: Child,
     pub bridge_config: CelestiaBridgeConfig,
+}
+
+pub struct CelestiaBridgeDriverComponents;
+
+impl HasComponents for CelestiaBridgeDriver {
+    type Components = CelestiaBridgeDriverComponents;
+}
+
+impl<BridgeDriver> ProvideBridgeAuthTokenType<BridgeDriver> for CelestiaBridgeDriverComponents
+where
+    BridgeDriver: Async,
+{
+    type BridgeAuthToken = String;
 }

--- a/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
@@ -48,8 +48,9 @@ fn test_celestia_bootstrap() -> Result<(), Error> {
     tokio_runtime.block_on(async move {
         let chain_driver = celestia_bootstrap.bootstrap_chain("private").await?;
 
-        let _bridge_driver = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
-        let _bridge_driver = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
+        // Bootstrap twice to ensure that there is no conflicts such as listening port
+        let _bridge_driver_a = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
+        let _bridge_driver_b = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
 
         <Result<(), Error>>::Ok(())
     })?;

--- a/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
@@ -49,6 +49,7 @@ fn test_celestia_bootstrap() -> Result<(), Error> {
         let chain_driver = celestia_bootstrap.bootstrap_chain("private").await?;
 
         let _bridge_driver = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
+        let _bridge_driver = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
 
         <Result<(), Error>>::Ok(())
     })?;

--- a/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
@@ -48,7 +48,7 @@ fn test_celestia_bootstrap() -> Result<(), Error> {
     tokio_runtime.block_on(async move {
         let chain_driver = celestia_bootstrap.bootstrap_chain("private").await?;
 
-        // Bootstrap twice to ensure that there is no conflicts such as listening port
+        // Bootstrap twice to ensure that there is no conflict such as listening port
         let _bridge_driver_a = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
         let _bridge_driver_b = celestia_bootstrap.bootstrap_bridge(&chain_driver).await?;
 

--- a/crates/celestia/celestia-test-components/src/bootstrap/components.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/components.rs
@@ -2,6 +2,7 @@ use cgp_core::prelude::*;
 use hermes_cosmos_test_components::bootstrap::traits::generator::generate_wallet_config::WalletConfigGeneratorComponent;
 
 use crate::bootstrap::impls::bootstrap_bridge::BootstrapCelestiaBridge;
+use crate::bootstrap::impls::bridge_auth_token::GenerateBridgeJwtToken;
 use crate::bootstrap::impls::copy_bridge_key::CopyBridgeKey;
 use crate::bootstrap::impls::generate_wallet_config::GenerateCelestiaWalletConfig;
 use crate::bootstrap::impls::init_bridge_data::InitCelestiaBridgeData;
@@ -9,6 +10,7 @@ use crate::bootstrap::impls::start_bridge::StartCelestiaBridge;
 use crate::bootstrap::impls::types::bridge_config::ProvideCelestiaBridgeConfig;
 use crate::bootstrap::impls::update_bridge_config::UpdateCelestiaBridgeConfig;
 use crate::bootstrap::traits::bootstrap_bridge::BridgeBootstrapperComponent;
+use crate::bootstrap::traits::bridge_auth_token::BridgeAuthTokenGeneratorComponent;
 use crate::bootstrap::traits::import_bridge_key::BridgeKeyImporterComponent;
 use crate::bootstrap::traits::init_bridge_config::BridgeConfigInitializerComponent;
 use crate::bootstrap::traits::init_bridge_data::BridgeDataInitializerComponent;
@@ -18,6 +20,7 @@ use crate::bootstrap::traits::types::bridge_config::BridgeConfigTypeComponent;
 pub struct CelestiaBootstrapComponents;
 
 delegate_components! {
+    #[mark_component(IsCelestiaBootstrapComponent)]
     CelestiaBootstrapComponents {
         BridgeDataInitializerComponent:
             InitCelestiaBridgeData,
@@ -31,6 +34,8 @@ delegate_components! {
             ProvideCelestiaBridgeConfig,
         BridgeConfigInitializerComponent:
             UpdateCelestiaBridgeConfig,
+        BridgeAuthTokenGeneratorComponent:
+            GenerateBridgeJwtToken,
         BridgeStarterComponent:
             StartCelestiaBridge,
     }

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
@@ -61,12 +61,16 @@ where
             .import_bridge_key(&bridge_home_dir, chain_driver)
             .await?;
 
+        let bridge_auth_token = bootstrap
+            .generate_bridge_auth_token(&bridge_home_dir, chain_id)
+            .await?;
+
         let bridge_process = bootstrap
             .start_bridge(&bridge_home_dir, chain_driver)
             .await?;
 
         let bridge_driver = bootstrap
-            .build_bridge_driver(bridge_config, bridge_process)
+            .build_bridge_driver(bridge_config, bridge_auth_token, bridge_process)
             .await?;
 
         Ok(bridge_driver)

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
@@ -7,12 +7,14 @@ use hermes_test_components::runtime::traits::types::child_process::HasChildProce
 use hermes_test_components::runtime::traits::types::file_path::HasFilePathType;
 
 use crate::bootstrap::traits::bootstrap_bridge::BridgeBootstrapper;
+use crate::bootstrap::traits::bridge_auth_token::CanGenerateBridgeAuthToken;
 use crate::bootstrap::traits::bridge_store_dir::HasBridgeStoreDir;
 use crate::bootstrap::traits::build_bridge_driver::CanBuildBridgeDriver;
 use crate::bootstrap::traits::import_bridge_key::CanImportBridgeKey;
 use crate::bootstrap::traits::init_bridge_config::CanInitBridgeConfig;
 use crate::bootstrap::traits::init_bridge_data::CanInitBridgeData;
 use crate::bootstrap::traits::start_bridge::CanStartBridge;
+use crate::bridge_driver::traits::bridge_auth_token::HasBridgeAuthTokenType;
 
 pub struct BootstrapCelestiaBridge;
 
@@ -25,12 +27,14 @@ where
         + HasBridgeStoreDir
         + CanInitBridgeData
         + CanImportBridgeKey
+        + CanGenerateBridgeAuthToken
         + CanInitBridgeConfig
         + CanStartBridge
         + CanBuildBridgeDriver,
     ChainDriver: HasChain<Chain = Chain> + HasRuntime<Runtime = Runtime>,
     Chain: HasChainId,
     Runtime: HasFilePathType + HasChildProcessType + CanGenerateRandom<u32>,
+    Bootstrap::BridgeDriver: HasBridgeAuthTokenType,
 {
     async fn bootstrap_bridge(
         bootstrap: &Bootstrap,

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
@@ -38,10 +38,11 @@ where
     ) -> Result<Bootstrap::BridgeDriver, Bootstrap::Error> {
         let chain_id = chain_driver.chain().chain_id();
         let bridge_store_dir = bootstrap.bridge_store_dir();
+        let bridge_postfix = bootstrap.runtime().generate_random().await;
 
         let bridge_home_dir = Runtime::join_file_path(
             bridge_store_dir,
-            &Runtime::file_path_from_string(&chain_id.to_string()),
+            &Runtime::file_path_from_string(&format!("{chain_id}-{bridge_postfix}")),
         );
 
         bootstrap

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/bootstrap_bridge.rs
@@ -2,6 +2,7 @@ use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
 use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::chain::{HasChain, HasChainType};
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
+use hermes_test_components::runtime::traits::random::CanGenerateRandom;
 use hermes_test_components::runtime::traits::types::child_process::HasChildProcessType;
 use hermes_test_components::runtime::traits::types::file_path::HasFilePathType;
 
@@ -29,7 +30,7 @@ where
         + CanBuildBridgeDriver,
     ChainDriver: HasChain<Chain = Chain> + HasRuntime<Runtime = Runtime>,
     Chain: HasChainId,
-    Runtime: HasFilePathType + HasChildProcessType,
+    Runtime: HasFilePathType + HasChildProcessType + CanGenerateRandom<u32>,
 {
     async fn bootstrap_bridge(
         bootstrap: &Bootstrap,

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/bridge_auth_token.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/bridge_auth_token.rs
@@ -1,0 +1,47 @@
+use cgp_core::CanRaiseError;
+use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
+use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
+use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
+use hermes_test_components::runtime::traits::exec_command::CanExecCommandWithEnvs;
+
+use crate::bootstrap::traits::bridge_auth_token::BridgeAuthTokenGenerator;
+use crate::bootstrap::traits::types::bridge_driver::HasBridgeDriverType;
+use crate::bridge_driver::traits::bridge_auth_token::HasBridgeAuthTokenType;
+
+pub struct GenerateBridgeJwtToken;
+
+impl<Bootstrap, Runtime, Chain, BridgeDriver> BridgeAuthTokenGenerator<Bootstrap>
+    for GenerateBridgeJwtToken
+where
+    Bootstrap: HasRuntime<Runtime = Runtime>
+        + HasChainType<Chain = Chain>
+        + HasBridgeDriverType<BridgeDriver = BridgeDriver>
+        + CanRaiseError<Runtime::Error>,
+    Runtime: CanExecCommandWithEnvs,
+    Chain: HasChainIdType,
+    BridgeDriver: HasBridgeAuthTokenType<BridgeAuthToken = String>,
+{
+    async fn generate_bridge_auth_token(
+        bootstrap: &Bootstrap,
+        bridge_home_dir: &Runtime::FilePath,
+        chain_id: &Chain::ChainId,
+    ) -> Result<BridgeDriver::BridgeAuthToken, Bootstrap::Error> {
+        let output = bootstrap
+            .runtime()
+            .exec_command_with_envs(
+                &Runtime::file_path_from_string("celestia"),
+                &[
+                    "bridge",
+                    "auth",
+                    "admin",
+                    "--p2p.network",
+                    &chain_id.to_string(),
+                ],
+                &[("HOME", &Runtime::file_path_to_string(bridge_home_dir))],
+            )
+            .await
+            .map_err(Bootstrap::raise_error)?;
+
+        Ok(output.stdout)
+    }
+}

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/mod.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/mod.rs
@@ -1,4 +1,5 @@
 pub mod bootstrap_bridge;
+pub mod bridge_auth_token;
 pub mod copy_bridge_key;
 pub mod generate_wallet_config;
 pub mod init_bridge_data;

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/update_bridge_config.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/update_bridge_config.rs
@@ -96,6 +96,7 @@ where
 
         let config = CelestiaBridgeConfig {
             config: bridge_config,
+            bridge_rpc_port,
         };
 
         Ok(config.into())

--- a/crates/celestia/celestia-test-components/src/bootstrap/impls/update_bridge_config.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/impls/update_bridge_config.rs
@@ -9,6 +9,7 @@ use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::types::chain::{HasChain, HasChainType};
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
 use hermes_test_components::runtime::traits::read_file::CanReadFileAsString;
+use hermes_test_components::runtime::traits::reserve_port::CanReserveTcpPort;
 use hermes_test_components::runtime::traits::write_file::CanWriteStringToFile;
 use ibc_relayer_types::core::ics02_client::error::Error as Ics02Error;
 use toml::Value;
@@ -32,7 +33,7 @@ where
         + CanRaiseError<toml::de::Error>
         + CanRaiseError<toml::ser::Error>
         + CanRaiseError<&'static str>,
-    Runtime: CanReadFileAsString + CanWriteStringToFile,
+    Runtime: CanReadFileAsString + CanWriteStringToFile + CanReserveTcpPort,
     Chain: HasChainId + HasGenesisHeight + CanQueryBlock + HasBlockHash,
     ChainDriver: HasChain<Chain = Chain> + HasRpcPort + HasGrpcPort,
     Bootstrap::BridgeConfig: From<CelestiaBridgeConfig>,
@@ -77,6 +78,13 @@ where
 
         set_chain_grpc_port(&mut bridge_config, chain_driver.grpc_port())
             .map_err(Bootstrap::raise_error)?;
+
+        let bridge_rpc_port = runtime
+            .reserve_tcp_port()
+            .await
+            .map_err(Bootstrap::raise_error)?;
+
+        set_bridge_rpc_port(&mut bridge_config, bridge_rpc_port).map_err(Bootstrap::raise_error)?;
 
         runtime
             .write_string_to_file(
@@ -123,6 +131,17 @@ pub fn set_chain_grpc_port(config: &mut Value, grpc_port: u16) -> Result<(), &'s
         .as_table_mut()
         .ok_or("expect object")?
         .insert("GRPCPort".to_string(), grpc_port.to_string().into());
+
+    Ok(())
+}
+
+pub fn set_bridge_rpc_port(config: &mut Value, rpc_port: u16) -> Result<(), &'static str> {
+    config
+        .get_mut("RPC")
+        .ok_or("expect rpc section")?
+        .as_table_mut()
+        .ok_or("expect object")?
+        .insert("Port".to_string(), rpc_port.to_string().into());
 
     Ok(())
 }

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/bridge_auth_token.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/bridge_auth_token.rs
@@ -1,0 +1,25 @@
+use cgp_core::prelude::*;
+use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
+use hermes_relayer_components::chain::types::aliases::ChainIdOf;
+use hermes_relayer_components::runtime::traits::runtime::HasRuntimeType;
+use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
+use hermes_test_components::runtime::traits::types::file_path::{FilePathOf, HasFilePathType};
+
+use crate::bootstrap::traits::types::bridge_driver::HasBridgeDriverType;
+use crate::bridge_driver::traits::bridge_auth_token::{BridgeAuthTokenOf, HasBridgeAuthTokenType};
+
+#[derive_component(BridgeAuthTokenGeneratorComponent, BridgeAuthTokenGenerator<Bootstrap>)]
+#[async_trait]
+pub trait CanGenerateBridgeAuthToken:
+    HasRuntimeType + HasChainType + HasBridgeDriverType + HasErrorType
+where
+    Self::Runtime: HasFilePathType,
+    Self::Chain: HasChainIdType,
+    Self::BridgeDriver: HasBridgeAuthTokenType,
+{
+    async fn generate_bridge_auth_token(
+        &self,
+        bridge_home_dir: &FilePathOf<Self::Runtime>,
+        chain_id: &ChainIdOf<Self::Chain>,
+    ) -> Result<BridgeAuthTokenOf<Self::BridgeDriver>, Self::Error>;
+}

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/build_bridge_driver.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/build_bridge_driver.rs
@@ -6,6 +6,7 @@ use hermes_test_components::runtime::traits::types::child_process::{
 
 use crate::bootstrap::traits::types::bridge_config::HasBridgeConfigType;
 use crate::bootstrap::traits::types::bridge_driver::HasBridgeDriverType;
+use crate::bridge_driver::traits::bridge_auth_token::{BridgeAuthTokenOf, HasBridgeAuthTokenType};
 
 #[derive_component(BridgeDriverBuilderComponent, BridgeDriverBuilder<Bootstrap>)]
 #[async_trait]
@@ -13,10 +14,12 @@ pub trait CanBuildBridgeDriver:
     HasBridgeDriverType + HasBridgeConfigType + HasRuntime + HasErrorType
 where
     Self::Runtime: HasChildProcessType,
+    Self::BridgeDriver: HasBridgeAuthTokenType,
 {
     async fn build_bridge_driver(
         &self,
         bridge_config: Self::BridgeConfig,
+        bridge_auth_token: BridgeAuthTokenOf<Self::BridgeDriver>,
         bridge_process: ChildProcess<Self::Runtime>,
     ) -> Result<Self::BridgeDriver, Self::Error>;
 }

--- a/crates/celestia/celestia-test-components/src/bootstrap/traits/mod.rs
+++ b/crates/celestia/celestia-test-components/src/bootstrap/traits/mod.rs
@@ -1,4 +1,5 @@
 pub mod bootstrap_bridge;
+pub mod bridge_auth_token;
 pub mod bridge_store_dir;
 pub mod build_bridge_driver;
 pub mod import_bridge_key;

--- a/crates/celestia/celestia-test-components/src/bridge_driver/mod.rs
+++ b/crates/celestia/celestia-test-components/src/bridge_driver/mod.rs
@@ -1,0 +1,1 @@
+pub mod traits;

--- a/crates/celestia/celestia-test-components/src/bridge_driver/traits/bridge_auth_token.rs
+++ b/crates/celestia/celestia-test-components/src/bridge_driver/traits/bridge_auth_token.rs
@@ -1,0 +1,14 @@
+use cgp_core::prelude::*;
+
+#[derive_component(BridgeAuthTokenTypeComponent, ProvideBridgeAuthTokenType<BridgeDriver>)]
+pub trait HasBridgeAuthTokenType: Async {
+    type BridgeAuthToken: Async;
+}
+
+pub type BridgeAuthTokenOf<BridgeDriver> =
+    <BridgeDriver as HasBridgeAuthTokenType>::BridgeAuthToken;
+
+#[derive_component(BridgeAuthTokenGetterComponent, BridgeAuthTokenGetter<BridgeDriver>)]
+pub trait HasBridgeAuthToken: HasBridgeAuthTokenType {
+    fn bridge_auth_token(&self) -> &Self::BridgeAuthToken;
+}

--- a/crates/celestia/celestia-test-components/src/bridge_driver/traits/mod.rs
+++ b/crates/celestia/celestia-test-components/src/bridge_driver/traits/mod.rs
@@ -1,0 +1,1 @@
+pub mod bridge_auth_token;

--- a/crates/celestia/celestia-test-components/src/lib.rs
+++ b/crates/celestia/celestia-test-components/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod bootstrap;
+pub mod bridge_driver;
 pub mod types;

--- a/crates/celestia/celestia-test-components/src/types/bridge_config.rs
+++ b/crates/celestia/celestia-test-components/src/types/bridge_config.rs
@@ -1,3 +1,4 @@
 pub struct CelestiaBridgeConfig {
     pub config: toml::Value,
+    pub bridge_rpc_port: u16,
 }

--- a/crates/cosmos/cosmos-test-components/Cargo.toml
+++ b/crates/cosmos/cosmos-test-components/Cargo.toml
@@ -25,4 +25,3 @@ serde_json      = { workspace = true }
 toml            = { workspace = true }
 
 hdpath      = "0.6.3"
-rand        = "0.8.5"

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk.rs
@@ -17,6 +17,7 @@ use hermes_test_components::driver::traits::types::chain_driver::ProvideChainDri
 use hermes_test_components::runtime::traits::child_process::CanStartChildProcess;
 use hermes_test_components::runtime::traits::create_dir::CanCreateDir;
 use hermes_test_components::runtime::traits::exec_command::CanExecCommand;
+use hermes_test_components::runtime::traits::random::CanGenerateRandom;
 use hermes_test_components::runtime::traits::read_file::CanReadFileAsString;
 use hermes_test_components::runtime::traits::reserve_port::CanReserveTcpPort;
 use hermes_test_components::runtime::traits::write_file::CanWriteStringToFile;
@@ -120,7 +121,8 @@ where
         + CanReadFileAsString
         + CanWriteStringToFile
         + CanCreateDir
-        + CanReserveTcpPort,
+        + CanReserveTcpPort
+        + CanGenerateRandom<u32>,
     Chain: HasChainIdType,
     ChainDriver: HasChainType<Chain = Chain>
         + HasWalletType<Wallet = CosmosTestWallet>

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk_legacy.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk_legacy.rs
@@ -17,6 +17,7 @@ use hermes_test_components::driver::traits::types::chain_driver::ProvideChainDri
 use hermes_test_components::runtime::traits::child_process::CanStartChildProcess;
 use hermes_test_components::runtime::traits::create_dir::CanCreateDir;
 use hermes_test_components::runtime::traits::exec_command::CanExecCommand;
+use hermes_test_components::runtime::traits::random::CanGenerateRandom;
 use hermes_test_components::runtime::traits::read_file::CanReadFileAsString;
 use hermes_test_components::runtime::traits::reserve_port::CanReserveTcpPort;
 use hermes_test_components::runtime::traits::write_file::CanWriteStringToFile;
@@ -115,7 +116,8 @@ where
         + CanReadFileAsString
         + CanWriteStringToFile
         + CanCreateDir
-        + CanReserveTcpPort,
+        + CanReserveTcpPort
+        + CanGenerateRandom<u32>,
     Chain: HasChainIdType,
     ChainDriver: HasChainType<Chain = Chain>
         + HasWalletType<Wallet = CosmosTestWallet>

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/impls/generator/random_chain_id.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/impls/generator/random_chain_id.rs
@@ -1,8 +1,9 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
+use hermes_relayer_components::runtime::traits::runtime::HasRuntime;
 use hermes_test_components::chain_driver::traits::build::chain_id::CanBuildChainIdFromString;
 use hermes_test_components::driver::traits::types::chain_driver::HasChainDriverType;
-use rand::prelude::*;
+use hermes_test_components::runtime::traits::random::CanGenerateRandom;
 
 use crate::bootstrap::traits::fields::random_id::HasRandomIdFlag;
 use crate::bootstrap::traits::generator::generate_chain_id::ChainIdGenerator;
@@ -10,18 +11,18 @@ use crate::bootstrap::traits::generator::generate_chain_id::ChainIdGenerator;
 pub struct GenerateRandomChainId;
 
 #[async_trait]
-impl<Bootstrap, Chain, ChainDriver> ChainIdGenerator<Bootstrap> for GenerateRandomChainId
+impl<Bootstrap, Chain, ChainDriver, Runtime> ChainIdGenerator<Bootstrap> for GenerateRandomChainId
 where
-    Bootstrap: HasChainDriverType<Chain = Chain, ChainDriver = ChainDriver> + HasRandomIdFlag,
+    Bootstrap: HasChainDriverType<Chain = Chain, ChainDriver = ChainDriver>
+        + HasRuntime<Runtime = Runtime>
+        + HasRandomIdFlag,
     ChainDriver: CanBuildChainIdFromString<Chain = Chain>,
     Chain: HasChainIdType,
+    Runtime: CanGenerateRandom<u32>,
 {
     async fn generate_chain_id(bootstrap: &Bootstrap, chain_id_prefix: &str) -> Chain::ChainId {
         if bootstrap.should_randomize_identifiers() {
-            let postfix: u32 = {
-                let mut rng = thread_rng();
-                rng.gen()
-            };
+            let postfix = bootstrap.runtime().generate_random().await;
 
             let chain_id = format!("{chain_id_prefix}-{postfix}");
 

--- a/crates/cosmos/cosmos-test-components/src/chain_driver/impls/amount.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain_driver/impls/amount.rs
@@ -74,7 +74,7 @@ where
             .await;
 
         Amount {
-            quantity: quantity as u128,
+            quantity,
             denom: max.denom.clone(),
         }
     }

--- a/crates/runtime/async-runtime-components/Cargo.toml
+++ b/crates/runtime/async-runtime-components/Cargo.toml
@@ -22,5 +22,3 @@ futures-core        = { workspace = true }
 futures-util        = { workspace = true, features = ["io"] }
 futures-channel     = { workspace = true, features = ["std"] }
 async-trait         = { workspace = true }
-
-rand                = { version = "0.8.5" }

--- a/crates/runtime/tokio-runtime-components/src/components/concurrent.rs
+++ b/crates/runtime/tokio-runtime-components/src/components/concurrent.rs
@@ -22,6 +22,7 @@ use hermes_test_components::runtime::traits::create_dir::DirCreatorComponent;
 use hermes_test_components::runtime::traits::exec_command::{
     CommandExecutorComponent, CommandWithEnvsExecutorComponent,
 };
+use hermes_test_components::runtime::traits::random::RandomGeneratorComponent;
 use hermes_test_components::runtime::traits::read_file::FileAsStringReaderComponent;
 use hermes_test_components::runtime::traits::reserve_port::TcpPortReserverComponent;
 use hermes_test_components::runtime::traits::types::child_process::ChildProcessTypeComponent;
@@ -63,6 +64,7 @@ delegate_components! {
             CommandWithEnvsExecutorComponent,
             StringToFileWriterComponent,
             TcpPortReserverComponent,
+            RandomGeneratorComponent,
         ]:
             TokioParallelRuntimeComponents,
     }

--- a/crates/runtime/tokio-runtime-components/src/components/parallel.rs
+++ b/crates/runtime/tokio-runtime-components/src/components/parallel.rs
@@ -28,6 +28,7 @@ use hermes_test_components::runtime::traits::create_dir::DirCreatorComponent;
 use hermes_test_components::runtime::traits::exec_command::{
     CommandExecutorComponent, CommandWithEnvsExecutorComponent,
 };
+use hermes_test_components::runtime::traits::random::RandomGeneratorComponent;
 use hermes_test_components::runtime::traits::read_file::FileAsStringReaderComponent;
 use hermes_test_components::runtime::traits::reserve_port::TcpPortReserverComponent;
 use hermes_test_components::runtime::traits::types::child_process::ChildProcessTypeComponent;
@@ -39,6 +40,7 @@ use crate::impls::copy_file::TokioCopyFile;
 use crate::impls::create_dir::TokioCreateDir;
 use crate::impls::exec_command::TokioExecCommand;
 use crate::impls::parallel_task::TokioRunParallelTasks;
+use crate::impls::random::ThreadRandomGenerator;
 use crate::impls::read_file::TokioReadFileAsString;
 use crate::impls::reserve_port::TokioReserveTcpPort;
 use crate::impls::sleep::TokioSleep;
@@ -85,5 +87,6 @@ delegate_components! {
         CommandExecutorComponent: ExecCommandWithNoEnv,
         StringToFileWriterComponent: TokioWriteStringToFile,
         TcpPortReserverComponent: TokioReserveTcpPort,
+        RandomGeneratorComponent: ThreadRandomGenerator,
     }
 }

--- a/crates/runtime/tokio-runtime-components/src/impls/mod.rs
+++ b/crates/runtime/tokio-runtime-components/src/impls/mod.rs
@@ -4,6 +4,7 @@ pub mod copy_file;
 pub mod create_dir;
 pub mod exec_command;
 pub mod parallel_task;
+pub mod random;
 pub mod read_file;
 pub mod reserve_port;
 pub mod sleep;

--- a/crates/runtime/tokio-runtime-components/src/impls/random.rs
+++ b/crates/runtime/tokio-runtime-components/src/impls/random.rs
@@ -1,0 +1,24 @@
+use cgp_core::Async;
+use hermes_test_components::runtime::traits::random::RandomGenerator;
+use rand::distributions::uniform::SampleUniform;
+use rand::distributions::Standard;
+use rand::prelude::*;
+
+pub struct ThreadRandomGenerator;
+
+impl<Runtime, T> RandomGenerator<Runtime, T> for ThreadRandomGenerator
+where
+    Runtime: Async,
+    Standard: Distribution<T>,
+    T: Async + SampleUniform + PartialOrd,
+{
+    async fn generate_random(_runtime: &Runtime) -> T {
+        let mut rng = thread_rng();
+        rng.gen()
+    }
+
+    async fn random_range(_runtime: &Runtime, min: T, max: T) -> T {
+        let mut rng = thread_rng();
+        rng.gen_range(min..max)
+    }
+}

--- a/crates/test/test-components/src/chain_driver/traits/fields/amount.rs
+++ b/crates/test/test-components/src/chain_driver/traits/fields/amount.rs
@@ -7,8 +7,9 @@ use crate::chain_driver::traits::types::chain::HasChainType;
 use crate::chain_driver::traits::types::denom::HasDenomType;
 
 #[derive_component(RandomAmountGeneratorComponent, RandomAmountGenerator<Chain>)]
+#[async_trait]
 pub trait CanGenerateRandomAmount: HasDenomType + HasAmountType {
-    fn random_amount(min: usize, max: &Self::Amount) -> Self::Amount;
+    async fn random_amount(&self, min: usize, max: &Self::Amount) -> Self::Amount;
 }
 
 #[derive_component(AmountMethodsComponent, ProvideAmountMethods<Chain>)]

--- a/crates/test/test-components/src/runtime/traits/mod.rs
+++ b/crates/test/test-components/src/runtime/traits/mod.rs
@@ -2,6 +2,7 @@ pub mod child_process;
 pub mod copy_file;
 pub mod create_dir;
 pub mod exec_command;
+pub mod random;
 pub mod read_file;
 pub mod reserve_port;
 pub mod types;

--- a/crates/test/test-components/src/runtime/traits/random.rs
+++ b/crates/test/test-components/src/runtime/traits/random.rs
@@ -1,0 +1,9 @@
+use cgp_core::prelude::*;
+
+#[derive_component(RandomGeneratorComponent, RandomGenerator<Runtime>)]
+#[async_trait]
+pub trait CanGenerateRandom<T: Async>: Async {
+    async fn generate_random(&self) -> T;
+
+    async fn random_range(&self, min: T, max: T) -> T;
+}

--- a/crates/test/test-suite/src/tests/transfer.rs
+++ b/crates/test/test-suite/src/tests/transfer.rs
@@ -87,7 +87,7 @@ where
 
         let balance_a1 = chain_driver_a.query_balance(address_a1, denom_a).await?;
 
-        let a_to_b_amount = ChainDriverA::random_amount(1000, &balance_a1);
+        let a_to_b_amount = chain_driver_a.random_amount(1000, &balance_a1).await;
 
         let channel_id_a = driver.channel_id_at(Twindex::<0, 1>);
 
@@ -136,7 +136,7 @@ where
 
         let address_a2 = ChainDriverA::wallet_address(wallet_a2);
 
-        let b_to_a_amount = ChainDriverB::random_amount(500, &balance_b1);
+        let b_to_a_amount = chain_driver_b.random_amount(500, &balance_b1).await;
 
         driver.log_info(&format!(
             "Sending IBC transfer from chain {} to chain {} with amount of {}",

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
           celestia-app
           celestia-node
         ;
+
+        sovereign-rollup = sovereign-nix.rollup;
       };
     });
 }


### PR DESCRIPTION
- Implement generation of JWT bridge auth token to be used by rollup sequencer node.
- Add `CanGenerateRandom` runtime trait for generating random values.
- Configure random port for bridge RPC.
- Use random postfix when initializing bridge home directory.
