### PR TITLE
Add CLI to query connection end

### DIFF
--- a/crates/cli/cli/src/commands/mod.rs
+++ b/crates/cli/cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ use crate::Result;
 pub mod channel;
 pub mod client;
 pub mod connection;
+pub mod query;
 pub mod start;
 
 #[derive(Debug, clap::Parser)]
@@ -24,6 +25,10 @@ pub enum HermesCommand {
     /// Work with channels
     #[clap(subcommand)]
     Channel(channel::ChannelCommands),
+
+    /// Queries
+    #[clap(subcommand)]
+    Query(query::QueryCommands),
 }
 
 impl Runnable for HermesCommand {
@@ -33,6 +38,7 @@ impl Runnable for HermesCommand {
             Self::Client(cmd) => cmd.run(builder).await,
             Self::Connection(cmd) => cmd.run(builder).await,
             Self::Channel(cmd) => cmd.run(builder).await,
+            Self::Query(cmd) => cmd.run(builder).await,
         }
     }
 }

--- a/crates/cli/cli/src/commands/query/connection/end.rs
+++ b/crates/cli/cli/src/commands/query/connection/end.rs
@@ -1,0 +1,95 @@
+use oneline_eyre::eyre::eyre;
+use tracing::error;
+use tracing::info;
+
+use hermes_cli_framework::command::Runnable;
+use hermes_cosmos_client_components::traits::chain_handle::HasBlockingChainHandle;
+use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
+use hermes_cosmos_relayer::types::error::BaseError as RelayerError;
+use ibc_relayer::chain::handle::ChainHandle;
+use ibc_relayer::chain::requests::QueryConnectionRequest;
+use ibc_relayer::chain::requests::{IncludeProof, QueryHeight};
+use ibc_relayer_types::core::ics03_connection::connection::State;
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
+use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
+use ibc_relayer_types::Height;
+
+use crate::Result;
+
+#[derive(Debug, clap::Parser)]
+pub struct QueryConnectionEnd {
+    #[clap(
+        long = "chain",
+        required = true,
+        value_name = "CHAIN_ID",
+        help_heading = "REQUIRED",
+        help = "Identifier of the chain to query"
+    )]
+    chain_id: ChainId,
+
+    #[clap(
+        long = "connection",
+        visible_alias = "conn",
+        required = true,
+        value_name = "CONNECTION_ID",
+        help_heading = "REQUIRED",
+        help = "Identifier of the connection to query"
+    )]
+    connection_id: ConnectionId,
+
+    #[clap(
+        long = "height",
+        value_name = "HEIGHT",
+        help = "Height of the state to query. Leave unspecified for latest height."
+    )]
+    height: Option<u64>,
+}
+
+impl Runnable for QueryConnectionEnd {
+    async fn run(&self, builder: CosmosBuilder) -> Result<()> {
+        let chain = builder.build_chain(&self.chain_id).await?;
+        let chain_id = self.chain_id.clone();
+        let connection_id = self.connection_id.clone();
+        let height = self.height;
+
+        let output = chain
+            .with_blocking_chain_handle(move |chain_handle| {
+                let query_height = if let Some(height) = height {
+                    let specified_height = Height::new(chain_handle.id().version(), height)
+                    .map_err(|e| RelayerError::generic(eyre!("Failed to create Height with revision number `{}` and revision height `{height}`. Error: {e}", chain_handle.id().version())))?;
+
+                    QueryHeight::Specific(specified_height)
+                } else {
+                    QueryHeight::Latest
+                };
+                let (connection, _) = chain_handle
+                    .query_connection(
+                        QueryConnectionRequest {
+                            connection_id: connection_id.clone(),
+                            height: query_height,
+                        },
+                        IncludeProof::No,
+                    )
+                    .map_err(|e| RelayerError::generic(eyre!("Failed to query connection with id `{connection_id}`. Error: {e}")))?;
+
+                if connection.state_matches(&State::Uninitialized) {
+                    error!("connection '{connection_id}' does not exist")
+                } else {
+                    info!(
+                        "Successfully queried connection end on chain `{}`",
+                        chain_id,
+                    );
+                    info!("{connection:#?}",);
+                }
+
+                Ok(())
+            })
+            .await;
+
+        if let Err(e) = output {
+            error!("Command failed with error: {e}");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli/cli/src/commands/query/connection/mod.rs
+++ b/crates/cli/cli/src/commands/query/connection/mod.rs
@@ -1,0 +1,21 @@
+mod end;
+pub use end::QueryConnectionEnd;
+
+use hermes_cli_framework::command::Runnable;
+use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
+
+use crate::Result;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum QueryConnection {
+    /// Create a new channel
+    End(QueryConnectionEnd),
+}
+
+impl QueryConnection {
+    pub async fn run(&self, builder: CosmosBuilder) -> Result<()> {
+        match self {
+            Self::End(cmd) => cmd.run(builder).await,
+        }
+    }
+}

--- a/crates/cli/cli/src/commands/query/connections.rs
+++ b/crates/cli/cli/src/commands/query/connections.rs
@@ -1,0 +1,103 @@
+use oneline_eyre::eyre::eyre;
+use tracing::info;
+use tracing::warn;
+
+use hermes_cli_framework::command::Runnable;
+use hermes_cosmos_client_components::traits::chain_handle::HasBlockingChainHandle;
+use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
+use ibc_relayer::chain::handle::ChainHandle;
+use ibc_relayer::chain::requests::{
+    IncludeProof, QueryClientStateRequest, QueryConnectionsRequest, QueryHeight,
+};
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
+
+use crate::Result;
+
+#[derive(Debug, clap::Parser)]
+pub struct QueryConnections {
+    #[clap(
+        long = "chain",
+        required = true,
+        value_name = "CHAIN_ID",
+        help_heading = "REQUIRED",
+        help = "Identifier of the chain to query"
+    )]
+    chain_id: ChainId,
+
+    #[clap(
+        long = "counterparty-chain",
+        value_name = "COUNTERPARTY_CHAIN_ID",
+        help = "Filter the query response by the counterparty chain"
+    )]
+    counterparty_chain_id: Option<ChainId>,
+
+    #[clap(
+        long = "verbose",
+        help = "Enable verbose output, displaying the client for each connection in the response"
+    )]
+    verbose: bool,
+}
+
+impl Runnable for QueryConnections {
+    async fn run(&self, builder: CosmosBuilder) -> Result<()> {
+        let chain = builder.build_chain(&self.chain_id).await?;
+        let chain_id = self.chain_id.clone();
+        let counterparty_chain_id = self.counterparty_chain_id.clone();
+        let verbose = self.verbose;
+
+        chain
+            .with_blocking_chain_handle(move |chain_handle| {
+                let mut connections =
+                    chain_handle.query_connections(QueryConnectionsRequest { pagination: None }).unwrap();
+
+                if let Some(filter_chain_id) = counterparty_chain_id {
+                    connections.retain(|connection| {
+                        let client_id = connection.end().client_id().to_owned();
+                        let chain_height = chain_handle.query_latest_height();
+
+                        let client_state = chain_handle.query_client_state(
+                            QueryClientStateRequest {
+                                client_id: client_id.clone(),
+                                height: QueryHeight::Specific(chain_height.unwrap()),
+                            },
+                            IncludeProof::No,
+                        );
+
+                        match client_state {
+                            Ok((client_state, _)) => {
+                                let counterparty_chain_id = client_state.chain_id();
+                                counterparty_chain_id == filter_chain_id
+                            }
+                            Err(e) => {
+                                warn!("failed to query client state for client {client_id}, skipping...");
+                                warn!("reason: {e}");
+
+                                false
+                            }
+                        }
+                    });
+                };
+
+                info!(
+                    "Successfully queried connections on host chain `{}`",
+                    chain_id,
+                );
+
+                if verbose {
+                    connections.iter().for_each(|c| {
+                        info!("{c:#?}",);
+                    });
+                } else {
+                    connections.iter().for_each(|c| {
+                        info!("{}", c.connection_id);
+                    })
+                }
+
+                Ok(())
+            })
+            .await
+            .map_err(|e| eyre!("Failed to query connections for host chain: {e}"))?;
+
+        Ok(())
+    }
+}

--- a/crates/cli/cli/src/commands/query/connections.rs
+++ b/crates/cli/cli/src/commands/query/connections.rs
@@ -78,20 +78,15 @@ impl Runnable for QueryConnections {
                     });
                 };
 
-                info!(
-                    "Successfully queried connections on host chain `{}`",
-                    chain_id,
-                );
+                info!("Successfully queried connections on chain `{chain_id}`");
 
-                if verbose {
-                    connections.iter().for_each(|c| {
-                        info!("{c:#?}",);
-                    });
-                } else {
-                    connections.iter().for_each(|c| {
-                        info!("{}", c.connection_id);
-                    })
-                }
+                connections.iter().for_each(|connection| {
+                    if verbose {
+                        info!("{connection:#?}",);
+                    } else {
+                        info!("{}", connection.connection_id);
+                    }
+                });
 
                 Ok(())
             })

--- a/crates/cli/cli/src/commands/query/mod.rs
+++ b/crates/cli/cli/src/commands/query/mod.rs
@@ -8,7 +8,7 @@ use crate::Result;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum QueryCommands {
-    /// Create a new channel
+    /// Query all connections
     Connections(QueryConnections),
 }
 

--- a/crates/cli/cli/src/commands/query/mod.rs
+++ b/crates/cli/cli/src/commands/query/mod.rs
@@ -1,4 +1,6 @@
+mod connection;
 mod connections;
+pub use connection::QueryConnection;
 pub use connections::QueryConnections;
 
 use hermes_cli_framework::command::Runnable;
@@ -10,12 +12,17 @@ use crate::Result;
 pub enum QueryCommands {
     /// Query all connections
     Connections(QueryConnections),
+
+    /// Query connection information
+    #[clap(subcommand)]
+    Connection(QueryConnection),
 }
 
 impl QueryCommands {
     pub async fn run(&self, builder: CosmosBuilder) -> Result<()> {
         match self {
             Self::Connections(cmd) => cmd.run(builder).await,
+            Self::Connection(cmd) => cmd.run(builder).await,
         }
     }
 }

--- a/crates/cli/cli/src/commands/query/mod.rs
+++ b/crates/cli/cli/src/commands/query/mod.rs
@@ -1,0 +1,21 @@
+mod connections;
+pub use connections::QueryConnections;
+
+use hermes_cli_framework::command::Runnable;
+use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
+
+use crate::Result;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum QueryCommands {
+    /// Create a new channel
+    Connections(QueryConnections),
+}
+
+impl QueryCommands {
+    pub async fn run(&self, builder: CosmosBuilder) -> Result<()> {
+        match self {
+            Self::Connections(cmd) => cmd.run(builder).await,
+        }
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #134

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR adds the CLI `query connection end` which queries the connection end on a given chain with a given connection id.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
