### PR TITLE
Add `query client status` CLI for Cosmos chains

### DIFF
--- a/crates/cli/cli/src/commands/query/client/mod.rs
+++ b/crates/cli/cli/src/commands/query/client/mod.rs
@@ -1,8 +1,11 @@
 mod state;
-use hermes_cli_framework::output::Output;
 pub use state::QueryClientState;
 
+mod status;
+pub use status::QueryClientStatus;
+
 use hermes_cli_framework::command::CommandRunner;
+use hermes_cli_framework::output::Output;
 use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
 
 use crate::Result;
@@ -11,12 +14,16 @@ use crate::Result;
 pub enum ClientCommands {
     /// Query the state of a client
     State(QueryClientState),
+
+    /// Query the status of a client
+    Status(QueryClientStatus),
 }
 
 impl CommandRunner<CosmosBuilder> for ClientCommands {
     async fn run(&self, builder: &CosmosBuilder) -> Result<Output> {
         match self {
             Self::State(cmd) => cmd.run(builder).await,
+            Self::Status(cmd) => cmd.run(builder).await,
         }
     }
 }

--- a/crates/cli/cli/src/commands/query/client/state.rs
+++ b/crates/cli/cli/src/commands/query/client/state.rs
@@ -1,5 +1,8 @@
-use core::fmt::Debug;
 use std::error::Error as StdError;
+use std::fmt::Debug;
+
+use serde::Serialize;
+use tracing::info;
 
 use hermes_cli_framework::command::CommandRunner;
 use hermes_cli_framework::output::Output;
@@ -14,8 +17,6 @@ use hermes_relayer_components::chain::traits::types::client_state::HasClientStat
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_relayer_types::core::ics02_client::height::Height;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
-use serde::Serialize;
-use tracing::info;
 
 use crate::Result;
 

--- a/crates/cli/cli/src/commands/query/client/status.rs
+++ b/crates/cli/cli/src/commands/query/client/status.rs
@@ -10,14 +10,9 @@ use hermes_cosmos_relayer::types::error::BaseError;
 use hermes_relayer_components::birelay::traits::two_way::HasTwoWayRelayTypes;
 use hermes_relayer_components::build::traits::components::chain_builder::CanBuildChain;
 use hermes_relayer_components::build::traits::target::chain::ChainATarget;
-use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
-use hermes_relayer_components::chain::traits::queries::client_state::{
-    CanQueryClientState, CanQueryClientStateWithHeight,
-};
 use hermes_relayer_components::chain::traits::queries::client_status::{
     CanQueryClientStatus, ClientStatus,
 };
-use hermes_relayer_components::chain::traits::queries::consensus_state::CanQueryConsensusState;
 use hermes_relayer_components::chain::traits::types::client_state::{
     HasClientStateFields, HasClientStateType,
 };
@@ -56,10 +51,7 @@ where
     Build: CanBuildChain<ChainATarget>,
     Build::BiRelay: HasTwoWayRelayTypes<ChainA = Chain, ChainB = Counterparty>,
     Chain: HasIbcChainTypes<Counterparty, ChainId = ChainId, ClientId = ClientId, Height = Height>
-        + CanQueryClientState<Counterparty>
-        + CanQueryClientStateWithHeight<Counterparty>
-        + CanQueryChainStatus
-        + CanQueryConsensusState<Counterparty>,
+        + CanQueryClientStatus<Counterparty>,
     Counterparty: HasIbcChainTypes<Chain>
         + HasClientStateType<Chain>
         + HasClientStateFields<Chain>
@@ -67,7 +59,6 @@ where
         + HasConsensusStateFields<Chain>,
     Chain::Error: From<BaseError> + StdError,
     Build::Error: From<BaseError> + StdError,
-    Counterparty::ClientState: Serialize,
 {
     async fn run(&self, builder: &Build) -> Result<Output> {
         let chain = builder.build_chain(ChainATarget, &self.chain_id).await?;

--- a/crates/cli/cli/src/commands/query/client/status.rs
+++ b/crates/cli/cli/src/commands/query/client/status.rs
@@ -1,14 +1,8 @@
 use std::error::Error as StdError;
 use std::fmt::Debug;
 
-use hermes_relayer_components::chain::traits::types::consensus_state::{
-    HasConsensusStateFields, HasConsensusStateType,
-};
-use oneline_eyre::eyre::Context;
 use serde::Serialize;
-
-use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
-use hermes_relayer_components::chain::traits::queries::consensus_state::CanQueryConsensusState;
+use tracing::info;
 
 use hermes_cli_framework::command::CommandRunner;
 use hermes_cli_framework::output::Output;
@@ -16,16 +10,23 @@ use hermes_cosmos_relayer::types::error::BaseError;
 use hermes_relayer_components::birelay::traits::two_way::HasTwoWayRelayTypes;
 use hermes_relayer_components::build::traits::components::chain_builder::CanBuildChain;
 use hermes_relayer_components::build::traits::target::chain::ChainATarget;
+use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::queries::client_state::{
     CanQueryClientState, CanQueryClientStateWithHeight,
 };
+use hermes_relayer_components::chain::traits::queries::client_status::{
+    CanQueryClientStatus, ClientStatus,
+};
+use hermes_relayer_components::chain::traits::queries::consensus_state::CanQueryConsensusState;
 use hermes_relayer_components::chain::traits::types::client_state::{
     HasClientStateFields, HasClientStateType,
+};
+use hermes_relayer_components::chain::traits::types::consensus_state::{
+    HasConsensusStateFields, HasConsensusStateType,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_relayer_types::core::ics02_client::height::Height;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
-use tracing::info;
 
 use crate::Result;
 
@@ -70,21 +71,21 @@ where
 {
     async fn run(&self, builder: &Build) -> Result<Output> {
         let chain = builder.build_chain(ChainATarget, &self.chain_id).await?;
-        let client_status = query_client_status(&chain, &self.client_id).await?;
+        let client_status = chain.query_client_status(&self.client_id).await?;
 
         match client_status {
-            Status::Frozen => {
+            ClientStatus::Frozen => {
                 info!("Client `{}` is frozen", self.client_id);
             }
-            Status::Expired => {
+            ClientStatus::Expired => {
                 info!("Client `{}` has expired", self.client_id);
             }
-            Status::Active => {
+            ClientStatus::Active => {
                 info!("Client `{}` is active", self.client_id);
             }
         }
 
-        Ok(Output::success(client_status))
+        Ok(Output::success(Status::from(client_status)))
     }
 }
 
@@ -96,63 +97,12 @@ enum Status {
     Active,
 }
 
-async fn query_client_status<Chain, Counterparty>(
-    chain: &Chain,
-    client_id: &ClientId,
-) -> Result<Status>
-where
-    Chain: HasIbcChainTypes<Counterparty, ChainId = ChainId, ClientId = ClientId, Height = Height>
-        + CanQueryClientState<Counterparty>
-        + CanQueryClientStateWithHeight<Counterparty>
-        + CanQueryChainStatus
-        + CanQueryConsensusState<Counterparty>,
-    Counterparty: HasIbcChainTypes<Chain>
-        + HasClientStateType<Chain>
-        + HasClientStateFields<Chain>
-        + HasConsensusStateType<Chain>
-        + HasConsensusStateFields<Chain>,
-    Chain::Error: From<BaseError> + StdError,
-{
-    let client_state = chain
-        .query_client_state(client_id)
-        .await
-        .wrap_err_with(|| "Failed to query client state for client `{client_id}`")?;
-
-    if Counterparty::client_state_is_frozen(&client_state) {
-        return Ok(Status::Frozen);
-    }
-
-    let client_latest_height = Counterparty::client_state_latest_height(&client_state);
-
-    let latest_consensus_state = chain
-        .query_consensus_state(client_id, client_latest_height)
-        .await
-        .wrap_err_with(|| {
-            format!("Failed to query consensus state at height {client_latest_height}")
-        })?;
-
-    let latest_consensus_state_timestamp =
-        Counterparty::consensus_state_timestamp(&latest_consensus_state);
-
-    let chain_status = chain
-        .query_chain_status()
-        .await
-        .wrap_err("Failed to query chain status")?;
-
-    let current_network_time = Chain::chain_status_timestamp(&chain_status);
-
-    let elapsed = Chain::timestamp_duration_since(
-        latest_consensus_state_timestamp.as_ref(),
-        current_network_time,
-    );
-
-    let has_expired = elapsed.map_or(false, |elapsed| {
-        Counterparty::client_state_has_expired(&client_state, elapsed)
-    });
-
-    if has_expired {
-        Ok(Status::Expired)
-    } else {
-        Ok(Status::Active)
+impl From<ClientStatus> for Status {
+    fn from(status: ClientStatus) -> Self {
+        match status {
+            ClientStatus::Frozen => Status::Frozen,
+            ClientStatus::Expired => Status::Expired,
+            ClientStatus::Active => Status::Active,
+        }
     }
 }

--- a/crates/cli/cli/src/commands/query/client/status.rs
+++ b/crates/cli/cli/src/commands/query/client/status.rs
@@ -1,0 +1,133 @@
+use std::error::Error as StdError;
+use std::fmt::Debug;
+
+use hermes_relayer_components::chain::traits::types::consensus_state::{
+    HasConsensusStateFields, HasConsensusStateType,
+};
+use serde::Serialize;
+
+use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
+use hermes_relayer_components::chain::traits::queries::consensus_state::CanQueryConsensusState;
+
+use hermes_cli_framework::command::CommandRunner;
+use hermes_cli_framework::output::Output;
+use hermes_cosmos_relayer::types::error::BaseError;
+use hermes_relayer_components::birelay::traits::two_way::HasTwoWayRelayTypes;
+use hermes_relayer_components::build::traits::components::chain_builder::CanBuildChain;
+use hermes_relayer_components::build::traits::target::chain::ChainATarget;
+use hermes_relayer_components::chain::traits::queries::client_state::{
+    CanQueryClientState, CanQueryClientStateWithHeight,
+};
+use hermes_relayer_components::chain::traits::types::client_state::{
+    HasClientStateFields, HasClientStateType,
+};
+use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use ibc_relayer_types::core::ics02_client::height::Height;
+use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
+
+use crate::Result;
+
+#[derive(Debug, clap::Parser)]
+pub struct QueryClientStatus {
+    /// Identifier of the host chain
+    #[clap(
+        long = "chain",
+        required = true,
+        value_name = "CHAIN_ID",
+        help_heading = "REQUIRED"
+    )]
+    chain_id: ChainId,
+
+    /// Identifier of the client on the host chain
+    #[clap(
+        long = "client",
+        required = true,
+        value_name = "CLIENT_ID",
+        help_heading = "REQUIRED"
+    )]
+    client_id: ClientId,
+}
+
+impl<Build, Chain, Counterparty> CommandRunner<Build> for QueryClientStatus
+where
+    Build: CanBuildChain<ChainATarget>,
+    Build::BiRelay: HasTwoWayRelayTypes<ChainA = Chain, ChainB = Counterparty>,
+    Chain: HasIbcChainTypes<Counterparty, ChainId = ChainId, ClientId = ClientId, Height = Height>
+        + CanQueryClientState<Counterparty>
+        + CanQueryClientStateWithHeight<Counterparty>
+        + CanQueryChainStatus
+        + CanQueryConsensusState<Counterparty>,
+    Counterparty: HasIbcChainTypes<Chain>
+        + HasClientStateType<Chain>
+        + HasClientStateFields<Chain>
+        + HasConsensusStateType<Chain>
+        + HasConsensusStateFields<Chain>,
+    Chain::Error: From<BaseError> + StdError,
+    Build::Error: From<BaseError> + StdError,
+    Counterparty::ClientState: Serialize,
+{
+    async fn run(&self, builder: &Build) -> Result<Output> {
+        let chain = builder.build_chain(ChainATarget, &self.chain_id).await?;
+        let client_status = query_client_status(&chain, &self.client_id).await?;
+
+        Ok(Output::success(client_status))
+    }
+}
+
+#[derive(Debug, Serialize)]
+enum Status {
+    Frozen,
+    Expired,
+    Active,
+}
+
+async fn query_client_status<Chain, Counterparty>(
+    chain: &Chain,
+    client_id: &ClientId,
+) -> Result<Status>
+where
+    Chain: HasIbcChainTypes<Counterparty, ChainId = ChainId, ClientId = ClientId, Height = Height>
+        + CanQueryClientState<Counterparty>
+        + CanQueryClientStateWithHeight<Counterparty>
+        + CanQueryChainStatus
+        + CanQueryConsensusState<Counterparty>,
+    Counterparty: HasIbcChainTypes<Chain>
+        + HasClientStateType<Chain>
+        + HasClientStateFields<Chain>
+        + HasConsensusStateType<Chain>
+        + HasConsensusStateFields<Chain>,
+    Chain::Error: From<BaseError> + StdError,
+{
+    let client_state = chain.query_client_state(client_id).await?;
+
+    if Counterparty::client_state_is_frozen(&client_state) {
+        return Ok(Status::Frozen);
+    }
+
+    let client_latest_height = Counterparty::client_state_latest_height(&client_state);
+
+    let latest_consensus_state = chain
+        .query_consensus_state(client_id, client_latest_height)
+        .await?;
+
+    let latest_consensus_state_timestamp =
+        Counterparty::consensus_state_timestamp(&latest_consensus_state);
+
+    let chain_status = chain.query_chain_status().await?;
+    let current_network_time = Chain::chain_status_timestamp(&chain_status);
+
+    let elapsed = Chain::timestamp_duration_since(
+        latest_consensus_state_timestamp.as_ref(),
+        &current_network_time,
+    );
+
+    let has_expired = elapsed.map_or(false, |elapsed| {
+        Counterparty::client_state_has_expired(&client_state, elapsed)
+    });
+
+    if has_expired {
+        Ok(Status::Expired)
+    } else {
+        Ok(Status::Active)
+    }
+}

--- a/crates/cli/cli/src/commands/query/client/status.rs
+++ b/crates/cli/cli/src/commands/query/client/status.rs
@@ -84,9 +84,7 @@ where
             }
         }
 
-        Ok(Output::success(serde_json::json!({
-            "status": client_status
-        })))
+        Ok(Output::success(client_status))
     }
 }
 

--- a/crates/cosmos/cosmos-client-components/src/impls/types/chain.rs
+++ b/crates/cosmos/cosmos-client-components/src/impls/types/chain.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use core::time::Duration;
 
 use cgp_core::{Async, HasErrorType};
 use hermes_relayer_components::chain::traits::types::block::{
@@ -61,6 +62,14 @@ where
     Chain: Async,
 {
     type Timestamp = Timestamp;
+
+    fn timestamp_from_nanos(nanos: u64) -> Self::Timestamp {
+        Timestamp::from_nanoseconds(nanos).expect("Timestamp::from_nanoseconds is infallible")
+    }
+
+    fn timestamp_duration_since(earlier: &Timestamp, later: &Timestamp) -> Option<Duration> {
+        later.duration_since(earlier)
+    }
 }
 
 impl<Chain> ProvideMessageType<Chain> for ProvideCosmosChainTypes

--- a/crates/cosmos/cosmos-relayer/src/chain/impls/fields.rs
+++ b/crates/cosmos/cosmos-relayer/src/chain/impls/fields.rs
@@ -1,4 +1,6 @@
+use alloc::borrow::Cow;
 use alloc::sync::Arc;
+use core::time::Duration;
 
 use hermes_async_runtime_components::subscription::traits::subscription::Subscription;
 use hermes_cosmos_client_components::traits::message::CosmosMessage;
@@ -6,9 +8,12 @@ use hermes_cosmos_client_components::types::tendermint::TendermintClientState;
 use hermes_relayer_components::chain::traits::event_subscription::HasEventSubscription;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdGetter;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateFields;
+use hermes_relayer_components::chain::traits::types::consensus_state::HasConsensusStateFields;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::ibc::HasCounterpartyMessageHeight;
 use hermes_relayer_components::chain::traits::types::message::CanEstimateMessageSize;
+use hermes_relayer_components::chain::traits::types::timestamp::HasTimestampType;
+use ibc_relayer_types::core::ics02_client::client_state::ClientState;
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
@@ -56,5 +61,27 @@ where
 impl<Counterparty> HasClientStateFields<Counterparty> for CosmosChain {
     fn client_state_latest_height(client_state: &TendermintClientState) -> &Height {
         &client_state.latest_height
+    }
+
+    fn client_state_is_frozen(client_state: &TendermintClientState) -> bool {
+        client_state.is_frozen()
+    }
+
+    fn client_state_has_expired(client_state: &TendermintClientState, elapsed: Duration) -> bool {
+        elapsed > client_state.trusting_period
+    }
+}
+
+impl<Counterparty> HasConsensusStateFields<Counterparty> for CosmosChain
+where
+    Counterparty: HasTimestampType,
+{
+    fn consensus_state_timestamp(
+        consensus_state: &Self::ConsensusState,
+    ) -> Cow<'_, Counterparty::Timestamp> {
+        // FIXME(romac): This is a temporary workaround until we have a proper conversion,
+        // and can blow out if the timestamp is later than July 21st, 2554.
+        let nanos = consensus_state.timestamp.unix_timestamp_nanos() as u64;
+        Cow::Owned(Counterparty::timestamp_from_nanos(nanos))
     }
 }

--- a/crates/mock/mock-cosmos-relayer/src/impls/chain.rs
+++ b/crates/mock/mock-cosmos-relayer/src/impls/chain.rs
@@ -144,6 +144,14 @@ impl<Chain: BasecoinEndpoint> ProvideTimestampType<MockCosmosContext<Chain>>
     for MockCosmosChainComponents
 {
     type Timestamp = Timestamp;
+
+    fn timestamp_from_nanos(nanos: u64) -> Self::Timestamp {
+        Timestamp::from_nanoseconds(nanos).expect("Timestamp::from_nanoseconds is infallible")
+    }
+
+    fn timestamp_duration_since(earlier: &Timestamp, later: &Timestamp) -> Option<Duration> {
+        later.duration_since(earlier)
+    }
 }
 
 impl<Chain: BasecoinEndpoint> ProvideMessageType<MockCosmosContext<Chain>>
@@ -284,6 +292,14 @@ where
 {
     fn client_state_latest_height(client_state: &TmClientState) -> &Self::Height {
         &client_state.latest_height
+    }
+
+    fn client_state_is_frozen(client_state: &TmClientState) -> bool {
+        client_state.is_frozen()
+    }
+
+    fn client_state_has_expired(client_state: &TmClientState, elapsed: Duration) -> bool {
+        elapsed > client_state.trusting_period
     }
 }
 

--- a/crates/mock/mock-relayer/src/relayer_mock/base/impls/chain.rs
+++ b/crates/mock/mock-relayer/src/relayer_mock/base/impls/chain.rs
@@ -8,6 +8,8 @@
 //!   have been sent, received, acknowledged, and timed out.
 //! * The ChainStatus is a ConsensusState with a Height and a Timestamp.
 
+use core::time::Duration;
+
 use cgp_core::prelude::*;
 use cgp_core::ErrorRaiserComponent;
 use cgp_core::ErrorTypeComponent;
@@ -101,6 +103,17 @@ impl ProvideEventType<MockChainContext> for MockChainComponents {
 
 impl ProvideTimestampType<MockChainContext> for MockChainComponents {
     type Timestamp = MockTimestamp;
+
+    fn timestamp_from_nanos(nanos: u64) -> Self::Timestamp {
+        MockTimestamp(u128::from(nanos))
+    }
+
+    fn timestamp_duration_since(
+        earlier: &MockTimestamp,
+        later: &MockTimestamp,
+    ) -> Option<Duration> {
+        later.duration_since(earlier)
+    }
 }
 
 impl ProvideMessageType<MockChainContext> for MockChainComponents {

--- a/crates/mock/mock-relayer/src/relayer_mock/base/types/aliases.rs
+++ b/crates/mock/mock-relayer/src/relayer_mock/base/types/aliases.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::convert::From;
 use std::fmt::{self, Display};
+use std::time::Duration;
 
 use super::height::Height;
 use crate::relayer_mock::base::types::chain::MockChainStatus;
@@ -18,6 +19,12 @@ pub type StateStore = HashMap<Height, ChainState>;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub struct MockTimestamp(pub u128);
+
+impl MockTimestamp {
+    pub fn duration_since(&self, earlier: &MockTimestamp) -> Option<Duration> {
+        Some(Duration::from_millis((self.0 - earlier.0) as u64))
+    }
+}
 
 impl Display for MockTimestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/relayer/relayer-components/src/chain/traits/queries/client_status.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/queries/client_status.rs
@@ -1,0 +1,99 @@
+use cgp_core::prelude::*;
+
+use crate::chain::traits::types::client_state::{HasClientStateFields, HasClientStateType};
+use crate::chain::traits::types::consensus_state::{
+    HasConsensusStateFields, HasConsensusStateType,
+};
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+
+use super::chain_status::CanQueryChainStatus;
+use super::client_state::{CanQueryClientState, CanQueryClientStateWithHeight};
+use super::consensus_state::CanQueryConsensusState;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ClientStatus {
+    Frozen,
+    Expired,
+    Active,
+}
+
+#[async_trait]
+pub trait CanQueryClientStatus<Counterparty>:
+    HasIbcChainTypes<Counterparty>
+    + HasErrorType
+    + CanQueryClientState<Counterparty>
+    + CanQueryClientStateWithHeight<Counterparty>
+    + CanQueryChainStatus
+    + CanQueryConsensusState<Counterparty>
+where
+    Counterparty: HasIbcChainTypes<Self>
+        + HasClientStateType<Self>
+        + HasClientStateFields<Self>
+        + HasConsensusStateType<Self>
+        + HasConsensusStateFields<Self>,
+{
+    async fn query_client_status(
+        &self,
+        client_id: &Self::ClientId,
+    ) -> Result<ClientStatus, Self::Error>;
+}
+
+#[async_trait]
+impl<Chain, Counterparty> CanQueryClientStatus<Counterparty> for Chain
+where
+    Chain: HasIbcChainTypes<Counterparty>
+        + HasErrorType
+        + CanQueryClientState<Counterparty>
+        + CanQueryClientStateWithHeight<Counterparty>
+        + CanQueryChainStatus
+        + CanQueryConsensusState<Counterparty>,
+    Counterparty: HasIbcChainTypes<Chain>
+        + HasClientStateType<Chain>
+        + HasClientStateFields<Chain>
+        + HasConsensusStateType<Chain>
+        + HasConsensusStateFields<Chain>,
+{
+    async fn query_client_status(
+        &self,
+        client_id: &Self::ClientId,
+    ) -> Result<ClientStatus, Self::Error> {
+        let client_state = self.query_client_state(client_id).await?;
+        // .wrap_err_with(|e| "Failed to query client state for client `{client_id}`")?;
+
+        if Counterparty::client_state_is_frozen(&client_state) {
+            return Ok(ClientStatus::Frozen);
+        }
+
+        let client_latest_height = Counterparty::client_state_latest_height(&client_state);
+
+        let latest_consensus_state = self
+            .query_consensus_state(client_id, client_latest_height)
+            .await?;
+        // .wrap_err_with(|| {
+        //     format!("Failed to query consensus state at height {client_latest_height}")
+        // })?;
+
+        let latest_consensus_state_timestamp =
+            Counterparty::consensus_state_timestamp(&latest_consensus_state);
+
+        let chain_status = self.query_chain_status().await?;
+        // .wrap_err("Failed to query chain status")?;
+
+        let current_network_time = Self::chain_status_timestamp(&chain_status);
+
+        let elapsed = Self::timestamp_duration_since(
+            latest_consensus_state_timestamp.as_ref(),
+            current_network_time,
+        );
+
+        let has_expired = elapsed.map_or(false, |elapsed| {
+            Counterparty::client_state_has_expired(&client_state, elapsed)
+        });
+
+        if has_expired {
+            Ok(ClientStatus::Expired)
+        } else {
+            Ok(ClientStatus::Active)
+        }
+    }
+}

--- a/crates/relayer/relayer-components/src/chain/traits/queries/mod.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/queries/mod.rs
@@ -1,6 +1,7 @@
 pub mod block;
 pub mod chain_status;
 pub mod client_state;
+pub mod client_status;
 pub mod consensus_state;
 pub mod consensus_state_height;
 pub mod counterparty_chain_id;

--- a/crates/relayer/relayer-components/src/chain/traits/types/client_state.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/client_state.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 use cgp_core::Async;
 
 use crate::chain::traits::types::height::HasHeightType;
@@ -12,5 +14,13 @@ pub trait HasClientStateType<Counterparty>: Async {
 pub trait HasClientStateFields<Counterparty>:
     HasHeightType + HasClientStateType<Counterparty>
 {
+    /// The latest height of the client
     fn client_state_latest_height(client_state: &Self::ClientState) -> &Self::Height;
+
+    /// Whether or not the client is frozen
+    fn client_state_is_frozen(client_state: &Self::ClientState) -> bool;
+
+    /// Check if the client state will expired when `elapsed` time has passed
+    /// since the latest consensus state
+    fn client_state_has_expired(client_state: &Self::ClientState, elapsed: Duration) -> bool;
 }

--- a/crates/relayer/relayer-components/src/chain/traits/types/consensus_state.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/consensus_state.rs
@@ -1,8 +1,21 @@
+use alloc::borrow::Cow;
+
 use cgp_core::Async;
+
+use super::timestamp::HasTimestampType;
 
 pub trait HasConsensusStateType<Counterparty>: Async {
     /**
         The consensus state of the `Self` chain's client on the `Counterparty` chain
     */
     type ConsensusState: Async;
+}
+
+pub trait HasConsensusStateFields<Counterparty>: HasConsensusStateType<Counterparty>
+where
+    Counterparty: HasTimestampType,
+{
+    fn consensus_state_timestamp(
+        consensus_state: &Self::ConsensusState,
+    ) -> Cow<'_, Counterparty::Timestamp>;
 }

--- a/crates/relayer/relayer-components/src/chain/traits/types/timestamp.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/timestamp.rs
@@ -2,7 +2,9 @@
    Trait definition for [`HasTimestampType`].
 */
 
+use alloc::borrow::ToOwned;
 use core::fmt::Display;
+use core::time::Duration;
 
 use cgp_core::prelude::*;
 
@@ -30,5 +32,19 @@ pub trait HasTimestampType: Async {
        concrete context implementers to decide which exact time type
        they would like to use.
     */
-    type Timestamp: Ord + Display + Async;
+    type Timestamp: Ord + Display + ToOwned<Owned = Self::Timestamp> + Async;
+
+    /**
+       Build a timestamp from the given nanoseconds since the Unix epoch.
+    */
+    fn timestamp_from_nanos(nanos: u64) -> Self::Timestamp;
+
+    /**
+       Returns the amount of time elapsed from an `earlier` instant to a `later` one,
+       or `None` if the supposedly `earlier` instant is later than the `later` one.
+    */
+    fn timestamp_duration_since(
+        earlier: &Self::Timestamp,
+        later: &Self::Timestamp,
+    ) -> Option<Duration>;
 }

--- a/crates/relayer/relayer-components/src/relay/types/relay_to_chain.rs
+++ b/crates/relayer/relayer-components/src/relay/types/relay_to_chain.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+use core::time::Duration;
 
 use cgp_core::{async_trait, HasErrorType};
 
@@ -97,6 +98,17 @@ where
     Target: ChainTarget<Relay>,
 {
     type Timestamp = <Target::TargetChain as HasTimestampType>::Timestamp;
+
+    fn timestamp_from_nanos(nanos: u64) -> Self::Timestamp {
+        Target::TargetChain::timestamp_from_nanos(nanos)
+    }
+
+    fn timestamp_duration_since(
+        earlier: &Self::Timestamp,
+        later: &Self::Timestamp,
+    ) -> Option<Duration> {
+        Target::TargetChain::timestamp_duration_since(earlier, later)
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #155 

## Description


```
❯ cargo run -p hermes-cli -- query client status --chain ibc0 --client 07-tendermint-1
2024-02-13T11:58:35.236844Z  INFO Client `07-tendermint-1` is active
2024-02-13T11:58:35.236990Z  INFO Active
```

```
❯ cargo run -p hermes-cli -- --json query client status --chain ibc0 --client 07-tendermint-1
{"timestamp":"2024-02-13T11:58:02.701839Z","level":"INFO","fields":{"message":"Client `07-tendermint-1` is active"}}
{"result":"active","status":"success"}
```
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).

