### PR TITLE
Update sovereign-rollup-starter to version that includes IBC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,7 @@ dependencies = [
  "ibc-relayer",
  "ibc-relayer-types",
  "jsonrpsee",
+ "rand",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "hermes-test-components",
  "hermes-wasm-client-components",
  "hex 0.4.3",
+ "ibc-proto 0.41.0",
  "ibc-relayer",
  "ibc-relayer-types",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ tracing-subscriber  = { version = "0.3.18" }
 jsonrpsee           = { version = "0.21.0", default-features = false }
 hdpath              = { version = "0.6.3" }
 borsh               = { version = "0.10.3" }
+rand                = { version = "0.8.5" }
 
 hermes-cli                          = { version = "0.1.0", path = "./crates/cli/cli" }
 hermes-cli-components               = { version = "0.1.0", path = "./crates/cli/cli-components" }

--- a/crates/runtime/tokio-runtime-components/Cargo.toml
+++ b/crates/runtime/tokio-runtime-components/Cargo.toml
@@ -23,4 +23,4 @@ tokio       = { workspace = true, features = ["full"] }
 futures     = { workspace = true }
 
 tokio-stream    = { version = "0.1" }
-rand            = { version = "0.8.5" }
+rand            = { workspace = true }

--- a/crates/sovereign/sovereign-client-components/src/sovereign/types/message.rs
+++ b/crates/sovereign/sovereign-client-components/src/sovereign/types/message.rs
@@ -1,9 +1,11 @@
 use borsh::BorshSerialize;
 
 use crate::sovereign::types::messages::bank::BankMessage;
+use crate::sovereign::types::messages::ibc::IbcMessage;
 
 #[derive(BorshSerialize)]
 pub enum SovereignMessage {
     Accounts,
     Bank(BankMessage),
+    Ibc(IbcMessage),
 }

--- a/crates/sovereign/sovereign-client-components/src/sovereign/types/messages/ibc.rs
+++ b/crates/sovereign/sovereign-client-components/src/sovereign/types/messages/ibc.rs
@@ -1,0 +1,7 @@
+use borsh::BorshSerialize;
+use ibc_proto_new::google::protobuf::Any;
+
+#[derive(BorshSerialize)]
+pub enum IbcMessage {
+    Core(Any),
+}

--- a/crates/sovereign/sovereign-client-components/src/sovereign/types/messages/mod.rs
+++ b/crates/sovereign/sovereign-client-components/src/sovereign/types/messages/mod.rs
@@ -1,1 +1,2 @@
 pub mod bank;
+pub mod ibc;

--- a/crates/sovereign/sovereign-integration-tests/Cargo.toml
+++ b/crates/sovereign/sovereign-integration-tests/Cargo.toml
@@ -29,6 +29,7 @@ hermes-sovereign-test-components    = { workspace = true }
 hermes-sovereign-client-components  = { workspace = true }
 hermes-sovereign-cosmos-relayer     = { workspace = true }
 hermes-wasm-client-components       = { workspace = true }
+ibc-proto-new                       = { git = "https://github.com/cosmos/ibc-proto-rs.git", rev = "d1daaab", package = "ibc-proto" }
 
 eyre            = { workspace = true }
 tokio           = { workspace = true }

--- a/crates/sovereign/sovereign-integration-tests/Cargo.toml
+++ b/crates/sovereign/sovereign-integration-tests/Cargo.toml
@@ -29,7 +29,7 @@ hermes-sovereign-test-components    = { workspace = true }
 hermes-sovereign-client-components  = { workspace = true }
 hermes-sovereign-cosmos-relayer     = { workspace = true }
 hermes-wasm-client-components       = { workspace = true }
-ibc-proto-new                       = { git = "https://github.com/cosmos/ibc-proto-rs.git", rev = "d1daaab", package = "ibc-proto" }
+ibc-proto-new                       = { git = "https://github.com/cosmos/ibc-proto-rs.git", rev = "1b1d7a9", package = "ibc-proto" }
 
 eyre            = { workspace = true }
 tokio           = { workspace = true }

--- a/crates/sovereign/sovereign-integration-tests/Cargo.toml
+++ b/crates/sovereign/sovereign-integration-tests/Cargo.toml
@@ -36,6 +36,7 @@ tokio           = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
 toml            = { workspace = true }
+rand            = { workspace = true }
 stable-eyre     = { version = "0.2.2" }
 jsonrpsee       = { workspace = true, features = ["http-client"] }
 borsh           = { workspace = true }

--- a/crates/sovereign/sovereign-integration-tests/tests/bootstrap.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/bootstrap.rs
@@ -40,7 +40,11 @@ fn test_sovereign_bootstrap() -> Result<(), Error> {
 
     let builder = Arc::new(CosmosBuilder::new_with_default(runtime.clone()));
 
-    let store_postfix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let store_postfix = format!(
+        "{}-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+        rand::random::<u64>()
+    );
 
     let store_dir = std::env::current_dir()?.join(format!("test-data/{store_postfix}"));
 

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -97,14 +97,14 @@ fn test_cosmos_to_sovereign() -> Result<(), Error> {
         sleep(Duration::from_secs(2)).await;
 
         let create_client_payload = <CosmosChain as CanBuildCreateClientPayload<SovereignChain>>::build_create_client_payload(
-            &cosmos_chain,
+            cosmos_chain,
             &create_client_settings,
         ).await?;
 
         println!("create client payload: {:?}", create_client_payload);
 
         let create_client_message = <CosmosChain as CanBuildCreateClientMessage<CosmosChain>>::build_create_client_message(
-            &cosmos_chain,
+            cosmos_chain,
             create_client_payload
         ).await?;
 

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -43,7 +43,11 @@ fn test_cosmos_to_sovereign() -> Result<(), Error> {
 
     let builder = Arc::new(CosmosBuilder::new_with_default(runtime.clone()));
 
-    let store_postfix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let store_postfix = format!(
+        "{}-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+        rand::random::<u64>()
+    );
 
     let store_dir = std::env::current_dir()?.join(format!("test-data/{store_postfix}"));
 

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -4,26 +4,37 @@ use core::time::Duration;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use borsh::BorshSerialize;
+use eyre::eyre;
 use hermes_celestia_integration_tests::contexts::bootstrap::CelestiaBootstrap;
 use hermes_celestia_test_components::bootstrap::traits::bootstrap_bridge::CanBootstrapBridge;
 use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
 use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_relayer::types::error::Error;
+use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
+use hermes_sovereign_client_components::sovereign::traits::chain::rollup::HasRollup;
+use hermes_sovereign_client_components::sovereign::types::message::SovereignMessage;
+use hermes_sovereign_client_components::sovereign::types::messages::ibc::IbcMessage;
+use hermes_sovereign_client_components::sovereign::types::rpc::tx_hash::TxHash;
+use hermes_sovereign_client_components::sovereign::utils::encode_tx::encode_and_sign_sovereign_tx;
 use hermes_sovereign_cosmos_relayer::contexts::sovereign_chain::SovereignChain;
 use hermes_sovereign_integration_tests::contexts::bootstrap::SovereignBootstrap;
 use hermes_sovereign_test_components::bootstrap::traits::bootstrap_rollup::CanBootstrapRollup;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
 use hermes_test_components::chain_driver::traits::types::chain::HasChain;
+use ibc_proto_new::google::protobuf::Any;
 use ibc_relayer::chain::client::ClientSettings;
 use ibc_relayer::chain::cosmos::client::Settings;
 use ibc_relayer_types::core::ics02_client::trust_threshold::TrustThreshold;
+use ibc_relayer_types::signer::Signer;
 use tokio::runtime::Builder;
+use tokio::time::sleep;
 
 #[test]
-fn test_sovereign_ibc() -> Result<(), Error> {
+fn test_cosmos_to_sovereign() -> Result<(), Error> {
     let _ = stable_eyre::install();
 
     let tokio_runtime = Arc::new(Builder::new_multi_thread().enable_all().build()?);
@@ -70,11 +81,12 @@ fn test_sovereign_ibc() -> Result<(), Error> {
 
         let bridge_driver = celestia_bootstrap.bootstrap_bridge(&celestia_chain_driver).await?;
 
-        let _rollup_driver = sovereign_bootstrap
+        let rollup_driver = sovereign_bootstrap
             .bootstrap_rollup(&celestia_chain_driver, &bridge_driver, "test-rollup")
             .await?;
 
         let cosmos_chain = cosmos_chain_driver.chain();
+        let _rollup = rollup_driver.rollup();
 
         let create_client_settings = ClientSettings::Tendermint(Settings {
             max_clock_drift: Duration::from_secs(40),
@@ -82,10 +94,58 @@ fn test_sovereign_ibc() -> Result<(), Error> {
             trust_threshold: TrustThreshold::ONE_THIRD,
         });
 
-        let _create_client_payload = <CosmosChain as CanBuildCreateClientPayload<SovereignChain>>::build_create_client_payload(
+        sleep(Duration::from_secs(2)).await;
+
+        let create_client_payload = <CosmosChain as CanBuildCreateClientPayload<SovereignChain>>::build_create_client_payload(
             &cosmos_chain,
             &create_client_settings,
         ).await?;
+
+        println!("create client payload: {:?}", create_client_payload);
+
+        let create_client_message = <CosmosChain as CanBuildCreateClientMessage<CosmosChain>>::build_create_client_message(
+            &cosmos_chain,
+            create_client_payload
+        ).await?;
+
+        let any_message = create_client_message.message.encode_protobuf(
+            &Signer::dummy(),
+        )?;
+
+        let message = SovereignMessage::Ibc(IbcMessage::Core(Any {
+            type_url: any_message.type_url,
+            value: any_message.value,
+        }));
+
+        let wallet_a = rollup_driver
+            .wallets
+            .get("user-a")
+            .ok_or_else(|| eyre!("expect user-a wallet"))?;
+
+        let tx_bytes = encode_and_sign_sovereign_tx(
+            &wallet_a.signing_key,
+            message.try_to_vec()?,
+            0,
+            0,
+            0,
+            0,
+        )?;
+
+        let _tx_hash = TxHash::from_signed_tx_bytes(&tx_bytes);
+
+        // TODO: publishing a create client message currently fails, because
+        // ibc-rs expects the absence of frozen height to be encoded as `None`,
+        // but ibc-relayer-types encode it as a zero height here:
+        // https://github.com/informalsystems/hermes/blob/master/crates/relayer-types/src/clients/ics07_tendermint/client_state.rs#L308-L313
+
+        // rollup.publish_transaction_batch(&[tx_bytes]).await?;
+        // sleep(Duration::from_secs(2)).await;
+
+        // {
+        //     let response = rollup.query_tx_response(&tx_hash).await?;
+
+        //     println!("querty tx hash {} response: {:?}", tx_hash, response);
+        // }
 
         <Result<(), Error>>::Ok(())
     })?;

--- a/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
@@ -125,7 +125,11 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
         }),
     });
 
-    let store_postfix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let store_postfix = format!(
+        "{}-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+        rand::random::<u64>()
+    );
 
     let celestia_bootstrap = CelestiaBootstrap {
         runtime: runtime.clone(),

--- a/crates/sovereign/sovereign-integration-tests/tests/ibc.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/ibc.rs
@@ -1,0 +1,94 @@
+#![recursion_limit = "256"]
+
+use core::time::Duration;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hermes_celestia_integration_tests::contexts::bootstrap::CelestiaBootstrap;
+use hermes_celestia_test_components::bootstrap::traits::bootstrap_bridge::CanBootstrapBridge;
+use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
+use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
+use hermes_cosmos_relayer::contexts::chain::CosmosChain;
+use hermes_cosmos_relayer::types::error::Error;
+use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
+use hermes_relayer_runtime::types::runtime::HermesRuntime;
+use hermes_sovereign_cosmos_relayer::contexts::sovereign_chain::SovereignChain;
+use hermes_sovereign_integration_tests::contexts::bootstrap::SovereignBootstrap;
+use hermes_sovereign_test_components::bootstrap::traits::bootstrap_rollup::CanBootstrapRollup;
+use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
+use hermes_test_components::chain_driver::traits::types::chain::HasChain;
+use ibc_relayer::chain::client::ClientSettings;
+use ibc_relayer::chain::cosmos::client::Settings;
+use ibc_relayer_types::core::ics02_client::trust_threshold::TrustThreshold;
+use tokio::runtime::Builder;
+
+#[test]
+fn test_sovereign_ibc() -> Result<(), Error> {
+    let _ = stable_eyre::install();
+
+    let tokio_runtime = Arc::new(Builder::new_multi_thread().enable_all().build()?);
+
+    let runtime = HermesRuntime::new(tokio_runtime.clone());
+
+    let builder = Arc::new(CosmosBuilder::new_with_default(runtime.clone()));
+
+    let store_postfix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+
+    let store_dir = std::env::current_dir()?.join(format!("test-data/{store_postfix}"));
+
+    let cosmos_bootstrap = Arc::new(CosmosBootstrap {
+        runtime: runtime.clone(),
+        builder: builder.clone(),
+        should_randomize_identifiers: true,
+        chain_store_dir: store_dir.join("chains"),
+        chain_command_path: "simd".into(),
+        account_prefix: "cosmos".into(),
+        staking_denom: "stake".into(),
+        transfer_denom: "coin".into(),
+        genesis_config_modifier: Box::new(|_| Ok(())),
+        comet_config_modifier: Box::new(|_| Ok(())),
+    });
+
+    let celestia_bootstrap = CelestiaBootstrap {
+        runtime: runtime.clone(),
+        builder: builder.clone(),
+        chain_store_dir: store_dir.join("chains"),
+        bridge_store_dir: store_dir.join("bridges"),
+    };
+
+    let sovereign_bootstrap = SovereignBootstrap {
+        runtime: runtime.clone(),
+        rollup_store_dir: store_dir.join("rollups"),
+        rollup_command_path: "node".into(),
+        account_prefix: "sov".into(),
+    };
+
+    tokio_runtime.block_on(async move {
+        let cosmos_chain_driver = cosmos_bootstrap.bootstrap_chain("cosmos").await?;
+
+        let celestia_chain_driver = celestia_bootstrap.bootstrap_chain("private").await?;
+
+        let bridge_driver = celestia_bootstrap.bootstrap_bridge(&celestia_chain_driver).await?;
+
+        let _rollup_driver = sovereign_bootstrap
+            .bootstrap_rollup(&celestia_chain_driver, &bridge_driver, "test-rollup")
+            .await?;
+
+        let cosmos_chain = cosmos_chain_driver.chain();
+
+        let create_client_settings = ClientSettings::Tendermint(Settings {
+            max_clock_drift: Duration::from_secs(40),
+            trusting_period: None,
+            trust_threshold: TrustThreshold::ONE_THIRD,
+        });
+
+        let _create_client_payload = <CosmosChain as CanBuildCreateClientPayload<SovereignChain>>::build_create_client_payload(
+            &cosmos_chain,
+            &create_client_settings,
+        ).await?;
+
+        <Result<(), Error>>::Ok(())
+    })?;
+
+    Ok(())
+}

--- a/crates/sovereign/sovereign-test-components/Cargo.toml
+++ b/crates/sovereign/sovereign-test-components/Cargo.toml
@@ -28,6 +28,6 @@ serde_json      = { workspace = true }
 toml            = { workspace = true }
 ed25519-dalek   = { version = "2.1.1" }
 sha2            = { version = "0.10.8" }
-rand            = { version = "0.8.5" }
+rand            = { workspace = true }
 bech32          = { version = "0.9.1" }
 jsonrpsee       = { workspace = true, features = ["http-client"] }

--- a/flake.lock
+++ b/flake.lock
@@ -3143,11 +3143,11 @@
         "sovereign-sdk-src": "sovereign-sdk-src"
       },
       "locked": {
-        "lastModified": 1708719293,
-        "narHash": "sha256-Fu2LQtPg12X3GTUGrBq9nDe8/v5naON0eET9PVeb0GU=",
+        "lastModified": 1709134386,
+        "narHash": "sha256-/O9TNbsJZ/2U/tJC4sF5Avk8dSYdqz0ybnu3R3QQfJU=",
         "owner": "informalsystems",
         "repo": "sov-rollup-starter",
-        "rev": "4ab031d6defe5d38eebc7f0108cc3af995123995",
+        "rev": "e3ee5c99c976fc76957e048a8672c4d18cdaa595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The sovereign integration tests are now using a new version of sov-rollup-starter that includes sovereign-ibc. The test for sending CreateClient message to sovereign-ibc is currently partially working. However publishing a create client message currently fails, because ibc-rs expects the absence of frozen height to be encoded as `None`, but `ibc-relayer-types` encode it as a zero height here: https://github.com/informalsystems/hermes/blob/master/crates/relayer-types/src/clients/ics07_tendermint/client_state.rs#L308-L313

A fix for the test will be done in a separate PR, with proper refactoring on how to handle decoding and encoding of protobuf.