### PR TITLE
Connection Init between Sovereign and Cosmos on Cosmos side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,8 @@ dependencies = [
  "stable-eyre",
  "tokio",
  "toml 0.8.10",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/sovereign/sovereign-client-components/src/cosmos/impls/connection_handshake_message.rs
+++ b/crates/sovereign/sovereign-client-components/src/cosmos/impls/connection_handshake_message.rs
@@ -1,11 +1,13 @@
 use cgp_core::HasErrorType;
-use hermes_cosmos_client_components::traits::message::CosmosMessage;
+use hermes_cosmos_client_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_client_components::types::connection::CosmosInitConnectionOptions;
+use hermes_cosmos_client_components::types::messages::connection::open_init::CosmosConnectionOpenInitMessage;
 use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
 use hermes_relayer_components::chain::traits::types::connection::{
     HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use ibc_relayer_types::core::ics03_connection::version::Version;
 use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 
 use crate::sovereign::types::payloads::connection::{
@@ -38,12 +40,26 @@ where
 {
     async fn build_connection_open_init_message(
         _chain: &Chain,
-        _client_id: &Chain::ClientId,
-        _counterparty_client_id: &Counterparty::ClientId,
-        _init_connection_options: &Chain::InitConnectionOptions,
-        _counterparty_payload: SovereignConnectionOpenInitPayload,
+        client_id: &Chain::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        init_connection_options: &Chain::InitConnectionOptions,
+        counterparty_payload: SovereignConnectionOpenInitPayload,
     ) -> Result<CosmosMessage, Chain::Error> {
-        todo!()
+        // TODO: Retrieve version and delay period
+        let version = Version::default();
+        let delay_period = init_connection_options.delay_period;
+
+        let counterparty_commitment_prefix = counterparty_payload.commitment_prefix;
+
+        let message = CosmosConnectionOpenInitMessage {
+            client_id: client_id.clone(),
+            counterparty_client_id: counterparty_client_id.clone(),
+            counterparty_commitment_prefix,
+            version,
+            delay_period,
+        };
+
+        Ok(message.to_cosmos_message())
     }
 
     async fn build_connection_open_try_message(

--- a/crates/sovereign/sovereign-client-components/src/sovereign/components/chain.rs
+++ b/crates/sovereign/sovereign-client-components/src/sovereign/components/chain.rs
@@ -1,6 +1,7 @@
 use cgp_core::prelude::*;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::UpdateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
@@ -30,6 +31,7 @@ use crate::sovereign::impls::client::create_client_message::BuildCreateCosmosCli
 use crate::sovereign::impls::client::create_client_payload::BuildSovereignCreateClientPayload;
 use crate::sovereign::impls::client::update_client_message::BuildUpdateCosmosClientMessageOnSovereign;
 use crate::sovereign::impls::client::update_client_payload::BuildSovereignUpdateClientPayload;
+use crate::sovereign::impls::connection::connection_handshake_payload::BuildSovereignConnectionHandshakePayload;
 use crate::sovereign::impls::types::chain::ProvideSovereignChainTypes;
 use crate::sovereign::impls::types::client_state::ProvideSovereignClientState;
 use crate::sovereign::impls::types::payload::ProvideSovereignPayloadTypes;
@@ -79,5 +81,7 @@ delegate_components! {
             BuildSovereignUpdateClientPayload,
         UpdateClientMessageBuilderComponent:
             BuildUpdateCosmosClientMessageOnSovereign,
+        ConnectionHandshakePayloadBuilderComponent:
+            BuildSovereignConnectionHandshakePayload,
     }
 }

--- a/crates/sovereign/sovereign-client-components/src/sovereign/impls/connection/connection_handshake_payload.rs
+++ b/crates/sovereign/sovereign-client-components/src/sovereign/impls/connection/connection_handshake_payload.rs
@@ -3,6 +3,7 @@ use hermes_relayer_components::chain::traits::payload_builders::connection_hands
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
 use hermes_relayer_components::chain::traits::types::connection::HasConnectionHandshakePayloadTypes;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 
 use crate::sovereign::types::height::RollupHeight;
@@ -34,7 +35,10 @@ where
         _chain: &Chain,
         _client_state: &Chain::ClientState,
     ) -> Result<Chain::ConnectionOpenInitPayload, Chain::Error> {
-        todo!()
+        // TODO: retrieve commimtment prefix
+        let commitment_prefix =
+            CommitmentPrefix::try_from("ibc".to_string().as_bytes().to_vec()).unwrap();
+        Ok(SovereignConnectionOpenInitPayload { commitment_prefix })
     }
 
     async fn build_connection_open_try_payload(

--- a/crates/sovereign/sovereign-client-components/src/sovereign/types/payloads/connection.rs
+++ b/crates/sovereign/sovereign-client-components/src/sovereign/types/payloads/connection.rs
@@ -1,9 +1,11 @@
+use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
+
 pub struct SovereignInitConnectionOptions {
     // TODO: fill in fields
 }
 
 pub struct SovereignConnectionOpenInitPayload {
-    // TODO: fill in fields
+    pub commitment_prefix: CommitmentPrefix,
 }
 
 pub struct SovereignConnectionOpenTryPayload {

--- a/crates/sovereign/sovereign-cosmos-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-cosmos-relayer/src/contexts/sovereign_chain.rs
@@ -2,12 +2,15 @@ use cgp_core::prelude::*;
 use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_client_components::impls::queries::client_state::CosmosQueryClientStateComponents;
+use hermes_cosmos_relayer::chain::impls::connection_handshake_message::DelegateCosmosConnectionHandshakeBuilder;
 use hermes_cosmos_relayer::chain::impls::create_client_message::DelegateCosmosCreateClientMessageBuilder;
 use hermes_cosmos_relayer::chain::impls::update_client_message::DelegateCosmosUpdateClientMessageBuilder;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_components::chain::impls::queries::client_state::QueryAndDecodeClientStateVia;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::message_builders::update_client::CanBuildUpdateClientMessage;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::queries::client_state::CanQueryClientState;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
@@ -29,6 +32,7 @@ use hermes_relayer_runtime::impls::types::runtime::ProvideTokioRuntimeType;
 use hermes_relayer_runtime::types::runtime::HermesRuntime;
 use hermes_sovereign_client_components::cosmos::impls::client::create_client_message::BuildCreateSovereignClientMessageOnCosmos;
 use hermes_sovereign_client_components::cosmos::impls::client::update_client_message::BuildUpdateSovereignClientMessageOnCosmos;
+use hermes_sovereign_client_components::cosmos::impls::connection_handshake_message::BuildSovereignConnectionHandshakeMessageOnCosmos;
 use hermes_sovereign_client_components::sovereign::components::chain::{
     IsSovereignChainClientComponent, SovereignChainClientComponents,
 };
@@ -116,6 +120,12 @@ delegate_components! {
     }
 }
 
+delegate_components! {
+    DelegateCosmosConnectionHandshakeBuilder {
+        SovereignChain: BuildSovereignConnectionHandshakeMessageOnCosmos,
+    }
+}
+
 impl ProvideRuntime<SovereignChain> for SovereignChainComponents {
     fn runtime(chain: &SovereignChain) -> &HermesRuntime {
         &chain.runtime
@@ -129,6 +139,7 @@ pub trait CheckSovereignChainImpls:
     + HasClientStateType<CosmosChain, ClientState = SovereignClientState>
     + CanBuildUpdateClientPayload<CosmosChain>
     + HasEncoding<Encoding = SovereignEncoding>
+    + CanBuildConnectionHandshakePayloads<CosmosChain>
 {
 }
 
@@ -138,6 +149,7 @@ pub trait CheckCosmosChainImpls:
     CanQueryClientState<SovereignChain>
     + CanBuildCreateClientMessage<SovereignChain>
     + CanBuildUpdateClientMessage<SovereignChain>
+    + CanBuildConnectionHandshakeMessages<SovereignChain>
 {
 }
 

--- a/crates/sovereign/sovereign-integration-tests/Cargo.toml
+++ b/crates/sovereign/sovereign-integration-tests/Cargo.toml
@@ -31,14 +31,16 @@ hermes-sovereign-cosmos-relayer     = { workspace = true }
 hermes-wasm-client-components       = { workspace = true }
 ibc-proto-new                       = { workspace = true }
 
-eyre            = { workspace = true }
-tokio           = { workspace = true }
-serde           = { workspace = true }
-serde_json      = { workspace = true }
-toml            = { workspace = true }
-rand            = { workspace = true }
-stable-eyre     = { version = "0.2.2" }
-jsonrpsee       = { workspace = true, features = ["http-client"] }
-borsh           = { workspace = true }
-sha2            = { version = "0.10.8" }
-hex             = { version = "0.4.3" }
+eyre               = { workspace = true }
+tokio              = { workspace = true }
+serde              = { workspace = true }
+serde_json         = { workspace = true }
+toml               = { workspace = true }
+rand               = { workspace = true }
+stable-eyre        = { version = "0.2.2" }
+jsonrpsee          = { workspace = true, features = ["http-client"] }
+borsh              = { workspace = true }
+sha2               = { version = "0.10.8" }
+hex                = { version = "0.4.3" }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
@@ -1,28 +1,35 @@
 #![recursion_limit = "256"]
+use core::time::Duration;
 use eyre::eyre;
+use serde_json::Value as JsonValue;
+use std::env::var;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::runtime::Builder;
+use tokio::time::sleep;
+use toml::Value as TomlValue;
+use tracing::info;
+
 use hermes_celestia_integration_tests::contexts::bootstrap::CelestiaBootstrap;
 use hermes_cosmos_client_components::methods::event::try_extract_create_client_event;
+use hermes_cosmos_client_components::types::connection::CosmosInitConnectionOptions;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
 use hermes_relayer_components::chain::traits::message_builders::update_client::CanBuildUpdateClientMessage;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
 use hermes_sovereign_client_components::sovereign::types::height::RollupHeight;
 use hermes_wasm_client_components::contexts::wasm_counterparty::WasmCounterparty;
+use ibc_relayer_types::core::ics03_connection::version::Version;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::time::sleep;
 
-use core::time::Duration;
 use hermes_cosmos_test_components::chain_driver::traits::deposit_proposal::CanDepositProposal;
 use hermes_cosmos_test_components::chain_driver::traits::proposal_status::CanQueryGovernanceProposalStatus;
 use hermes_cosmos_test_components::chain_driver::traits::vote_proposal::CanVoteProposal;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
 use hermes_relayer_components::chain::traits::send_message::CanSendSingleMessage;
-use serde_json::Value as JsonValue;
-use std::env::var;
-use std::str::FromStr;
-use std::sync::Arc;
-use toml::Value as TomlValue;
 
 use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
 use hermes_cosmos_integration_tests::contexts::chain_driver::CosmosChainDriver;
@@ -37,10 +44,14 @@ use hermes_test_components::chain_driver::traits::types::chain::HasChain;
 use ibc_relayer::chain::client::ClientSettings;
 use ibc_relayer::chain::cosmos::client::Settings;
 use ibc_relayer_types::core::ics02_client::trust_threshold::TrustThreshold;
-use tokio::runtime::Builder;
 
+#[tracing::instrument]
 #[test]
 pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
     let _ = stable_eyre::install();
 
     let tokio_runtime = Arc::new(Builder::new_multi_thread().enable_all().build()?);
@@ -237,6 +248,37 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
         for update_message in update_client_messages.into_iter() {
             let _events = cosmos_chain.send_message(update_message).await?;
         }
+
+        let sovereign_client_state = <CosmosChain as CanQueryClientStateWithLatestHeight<SovereignChain>>::query_client_state_with_latest_height(cosmos_chain, &wasm_client_id).await?;
+
+        let connection_init_payload = <SovereignChain as CanBuildConnectionHandshakePayloads<CosmosChain>>::build_connection_open_init_payload(&sovereign_chain, &sovereign_client_state).await?;
+
+        let options = CosmosInitConnectionOptions {
+            delay_period: Duration::from_secs(0),
+            connection_version: Version::default(),
+        };
+
+        // Placeholder for Sovereign client ID
+        let sovereign_client_id = ClientId::from_str("sovereign-1").unwrap();
+
+        // Assert that the connection Init fails with an invalid client
+        {
+            let connection_init_payload = <SovereignChain as CanBuildConnectionHandshakePayloads<CosmosChain>>::build_connection_open_init_payload(&sovereign_chain, &sovereign_client_state).await?;
+
+            let wrong_wasm_client_id = ClientId::from_str("08-wasm-12").map_err(|e| eyre!("Failed to create a Client ID from string '08-wasm-0': {e}"))?;
+
+            let connection_init_message = <CosmosChain as CanBuildConnectionHandshakeMessages<SovereignChain>>::build_connection_open_init_message(cosmos_chain, &wrong_wasm_client_id, &sovereign_client_id, &options, connection_init_payload).await?;
+
+            let connection_init_event = cosmos_chain.send_message(connection_init_message).await;
+
+            assert!(connection_init_event.is_err());
+        }
+
+        let connection_init_message = <CosmosChain as CanBuildConnectionHandshakeMessages<SovereignChain>>::build_connection_open_init_message(cosmos_chain, &wasm_client_id, &sovereign_client_id, &options, connection_init_payload).await?;
+
+        let connection_init_event = cosmos_chain.send_message(connection_init_message).await?;
+
+        info!("{:#?}", connection_init_event);
 
         <Result<(), Error>>::Ok(())
     })?;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #212

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR builds the `SovereignConnectionOpenInitPayload` and the `build_connection_open_init_message` method to build a `CosmosMessage`.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
