### PR TITLE
Update sov-rollup-starter

### DIFF
--- a/crates/sovereign/sovereign-test-components/src/bootstrap/impls/bootstrap_rollup.rs
+++ b/crates/sovereign/sovereign-test-components/src/bootstrap/impls/bootstrap_rollup.rs
@@ -63,20 +63,22 @@ where
             .await
             .map_err(Bootstrap::raise_error)?;
 
-        let rollup_node_config = bootstrap
-            .init_rollup_node_config(&rollup_home_dir, bridge_driver)
-            .await?;
-
         // TODO: Use `HasWalletAt<SequencerWallet, 0>` instead once we define a
         // `CelestiaChainDriver` context that implements that.
         let sequencer_wallet = chain_driver.wallets().get("sequencer").ok_or_else(|| {
             Bootstrap::raise_error("expected chain driver to contain sequencer wallet")
         })?;
 
+        let sequencer_address = Chain::wallet_address(sequencer_wallet);
+
+        let rollup_node_config = bootstrap
+            .init_rollup_node_config(&rollup_home_dir, bridge_driver, sequencer_address)
+            .await?;
+
         let rollup_wallets = bootstrap.generate_rollup_wallets().await?;
 
         let rollup_genesis = bootstrap
-            .generate_rollup_genesis(Chain::wallet_address(sequencer_wallet), &rollup_wallets)
+            .generate_rollup_genesis(sequencer_address, &rollup_wallets)
             .await?;
 
         bootstrap

--- a/crates/sovereign/sovereign-test-components/src/bootstrap/impls/generate_rollup_genesis.rs
+++ b/crates/sovereign/sovereign-test-components/src/bootstrap/impls/generate_rollup_genesis.rs
@@ -35,7 +35,7 @@ where
         bootstrap: &Bootstrap,
         sequencer_da_address: &Chain::Address,
         rollup_wallets: &BTreeMap<String, Rollup::Wallet>,
-    ) -> Result<Bootstrap::RollupGenesisConfig, Bootstrap::Error> {
+    ) -> Result<SovereignGenesisConfig, Bootstrap::Error> {
         let sequencer_wallet = rollup_wallets
             .get("sequencer")
             .ok_or_else(|| Bootstrap::raise_error("expect sequencer wallet to be present"))?;
@@ -62,12 +62,14 @@ where
                 tokens: vec![
                     TokenGenesis {
                         token_name: "stake".to_owned(),
+                        token_address: staking_token_address.address.clone(),
                         address_and_balances: address_and_balances.clone(),
                         authorized_minters: vec![],
                         salt: 0,
                     },
                     TokenGenesis {
                         token_name: "coin".to_owned(),
+                        token_address: transfer_token_address.address.clone(),
                         address_and_balances,
                         authorized_minters: vec![],
                         salt: 0,

--- a/crates/sovereign/sovereign-test-components/src/bootstrap/impls/start_rollup.rs
+++ b/crates/sovereign/sovereign-test-components/src/bootstrap/impls/start_rollup.rs
@@ -1,8 +1,8 @@
 use cgp_core::CanRaiseError;
 use hermes_runtime_components::traits::fs::file_path::HasFilePathType;
 use hermes_runtime_components::traits::os::child_process::CanStartChildProcess;
-use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_runtime_components::traits::os::reserve_port::CanReserveTcpPort;
+use hermes_runtime_components::traits::runtime::HasRuntime;
 
 use crate::bootstrap::traits::rollup_command_path::HasRollupCommandPath;
 use crate::bootstrap::traits::start_rollup::RollupStarter;
@@ -43,7 +43,9 @@ where
 
         let runtime = bootstrap.runtime();
 
-        let metrics_port = runtime.reserve_tcp_port().await
+        let metrics_port = runtime
+            .reserve_tcp_port()
+            .await
             .map_err(Bootstrap::raise_error)?;
 
         let child = bootstrap

--- a/crates/sovereign/sovereign-test-components/src/bootstrap/impls/start_rollup.rs
+++ b/crates/sovereign/sovereign-test-components/src/bootstrap/impls/start_rollup.rs
@@ -2,6 +2,7 @@ use cgp_core::CanRaiseError;
 use hermes_runtime_components::traits::fs::file_path::HasFilePathType;
 use hermes_runtime_components::traits::os::child_process::CanStartChildProcess;
 use hermes_runtime_components::traits::runtime::HasRuntime;
+use hermes_runtime_components::traits::os::reserve_port::CanReserveTcpPort;
 
 use crate::bootstrap::traits::rollup_command_path::HasRollupCommandPath;
 use crate::bootstrap::traits::start_rollup::RollupStarter;
@@ -11,7 +12,7 @@ pub struct StartSovereignRollup;
 impl<Bootstrap, Runtime> RollupStarter<Bootstrap> for StartSovereignRollup
 where
     Bootstrap: HasRuntime<Runtime = Runtime> + HasRollupCommandPath + CanRaiseError<Runtime::Error>,
-    Runtime: HasFilePathType + CanStartChildProcess,
+    Runtime: HasFilePathType + CanStartChildProcess + CanReserveTcpPort,
 {
     async fn start_rollup(
         bootstrap: &Bootstrap,
@@ -40,6 +41,11 @@ where
             &Runtime::file_path_from_string("stderr.log"),
         );
 
+        let runtime = bootstrap.runtime();
+
+        let metrics_port = runtime.reserve_tcp_port().await
+            .map_err(Bootstrap::raise_error)?;
+
         let child = bootstrap
             .runtime()
             .start_child_process(
@@ -51,6 +57,8 @@ where
                     &Runtime::file_path_to_string(&rollup_genesis_path),
                     "--kernel-genesis-paths",
                     &Runtime::file_path_to_string(&rollup_chain_state_path),
+                    "--metrics",
+                    &metrics_port.to_string(),
                 ],
                 &[("RUST_BACKTRACE", "full")],
                 Some(&stdout_path),

--- a/crates/sovereign/sovereign-test-components/src/bootstrap/traits/init_rollup_node_config.rs
+++ b/crates/sovereign/sovereign-test-components/src/bootstrap/traits/init_rollup_node_config.rs
@@ -2,19 +2,23 @@ use cgp_core::prelude::*;
 use hermes_celestia_test_components::bootstrap::traits::types::bridge_driver::HasBridgeDriverType;
 use hermes_runtime_components::traits::fs::file_path::{FilePathOf, HasFilePathType};
 use hermes_runtime_components::traits::runtime::HasRuntimeType;
+use hermes_test_components::chain::traits::types::address::{AddressOf, HasAddressType};
+use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
 
 use crate::bootstrap::traits::types::rollup_node_config::HasRollupNodeConfigType;
 
 #[derive_component(RollupNodeConfigInitializerComponent, RollupNodeConfigInitializer<Bootstrap>)]
 #[async_trait]
 pub trait CanInitRollupNodeConfig:
-    HasRuntimeType + HasBridgeDriverType + HasRollupNodeConfigType + HasErrorType
+    HasRuntimeType + HasChainType + HasBridgeDriverType + HasRollupNodeConfigType + HasErrorType
 where
     Self::Runtime: HasFilePathType,
+    Self::Chain: HasAddressType,
 {
     async fn init_rollup_node_config(
         &self,
         rollup_home_dir: &FilePathOf<Self::Runtime>,
         bridge_driver: &Self::BridgeDriver,
+        sequencer_da_address: &AddressOf<Self::Chain>,
     ) -> Result<Self::RollupNodeConfig, Self::Error>;
 }

--- a/crates/sovereign/sovereign-test-components/src/types/rollup_genesis_config.rs
+++ b/crates/sovereign/sovereign-test-components/src/types/rollup_genesis_config.rs
@@ -23,6 +23,7 @@ pub struct BankGenesis {
 #[derive(Serialize)]
 pub struct TokenGenesis {
     pub token_name: String,
+    pub token_address: String,
     pub address_and_balances: Vec<(String, u128)>,
     pub authorized_minters: Vec<String>,
     pub salt: u128,

--- a/crates/sovereign/sovereign-test-components/src/types/rollup_node_config.rs
+++ b/crates/sovereign/sovereign-test-components/src/types/rollup_node_config.rs
@@ -14,6 +14,7 @@ pub struct SovereignDaConfig {
     pub celestia_rpc_address: String,
     pub max_celestia_response_body_size: u64,
     pub celestia_rpc_timeout_seconds: u64,
+    pub own_celestia_address: String,
 }
 
 #[derive(Serialize)]
@@ -23,7 +24,7 @@ pub struct SovereignStorageConfig {
 
 #[derive(Serialize)]
 pub struct SovereignRunnerConfig {
-    pub start_height: u64,
+    pub genesis_height: u64,
     pub rpc_config: SovereignRpcConfig,
     pub da_polling_interval_ms: u64,
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2894,23 +2894,6 @@
         "type": "github"
       }
     },
-    "risc0-cycle-macros-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1707815844,
-        "narHash": "sha256-tl6TvAUghcJvlnbD1iYH4mHjgSEtNKsAYN9ZZP69pyc=",
-        "owner": "Sovereign-Labs",
-        "repo": "risc0-cycle-macros",
-        "rev": "98948b8ee0e3edffcee7f3bd95a9d93c5c0941af",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Sovereign-Labs",
-        "repo": "risc0-cycle-macros",
-        "rev": "98948b8ee0e3edffcee7f3bd95a9d93c5c0941af",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "cosmos-nix": "cosmos-nix",
@@ -3156,37 +3139,36 @@
         "flake-utils": "flake-utils_12",
         "gaia-src": "gaia-src",
         "nixpkgs": "nixpkgs_12",
-        "risc0-cycle-macros-src": "risc0-cycle-macros-src",
         "rust-overlay": "rust-overlay_3",
         "sovereign-sdk-src": "sovereign-sdk-src"
       },
       "locked": {
-        "lastModified": 1709935770,
-        "narHash": "sha256-Yj5zfVZ7qEAPZIqeMDKeSUav+wc7qvy/NY87Eczt1hw=",
+        "lastModified": 1711476538,
+        "narHash": "sha256-dAC2TX+73sO6Xd6le7n82s4Wq73LHC/Aqmes3gfRydg=",
         "owner": "informalsystems",
         "repo": "sov-rollup-starter",
-        "rev": "0ca6b94f9275be5efc5a685b164101e9e831b130",
+        "rev": "94f06e8b8100b97a8c7807f8b7f49b2e02e364a0",
         "type": "github"
       },
       "original": {
         "owner": "informalsystems",
+        "ref": "ibc-rollup",
         "repo": "sov-rollup-starter",
-        "rev": "0ca6b94f9275be5efc5a685b164101e9e831b130",
         "type": "github"
       }
     },
     "sovereign-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1708644201,
-        "narHash": "sha256-NN1uomkyqAxRyXkAvOl809gUhwXJON0WPFe1WZAinMI=",
-        "rev": "5a144d60eefaf9ce166bbfd66324b959aa4ae82b",
-        "revCount": 818,
+        "lastModified": 1711047242,
+        "narHash": "sha256-mL/226hWuFEpnaiK/NhnCnjGwqpxT0MejQAz4M4fFe0=",
+        "rev": "cf048cd59789209bb9c37effddd20efe19375bca",
+        "revCount": 886,
         "type": "git",
         "url": "ssh://git@github.com/informalsystems/sovereign-sdk-wip"
       },
       "original": {
-        "rev": "5a144d60eefaf9ce166bbfd66324b959aa4ae82b",
+        "rev": "cf048cd59789209bb9c37effddd20efe19375bca",
         "type": "git",
         "url": "ssh://git@github.com/informalsystems/sovereign-sdk-wip"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     flake-utils.url = github:numtide/flake-utils;
     cosmos-nix.url = github:informalsystems/cosmos.nix;
     cosmos-nix-wasm.url = github:informalsystems/cosmos.nix/jonathan/ibc-go-wasm;
-    sovereign-nix.url = github:informalsystems/sov-rollup-starter?rev=0ca6b94f9275be5efc5a685b164101e9e831b130;
+    sovereign-nix.url = github:informalsystems/sov-rollup-starter/ibc-rollup;
   };
 
   outputs = inputs: let


### PR DESCRIPTION
Update the Sovereign integration tests to run on the latest starter from https://github.com/informalsystems/sov-rollup-starter/pull/8.