### PR TITLE
Improvements for create Cosmos client on Sovereign

### DIFF
--- a/crates/cosmos/cosmos-chain-components/src/encoding/convert.rs
+++ b/crates/cosmos/cosmos-chain-components/src/encoding/convert.rs
@@ -1,5 +1,9 @@
 use cgp_core::prelude::*;
 use hermes_encoding_components::impls::convert::{ConvertFrom, TryConvertFrom};
+use hermes_protobuf_encoding_components::impls::any::{DecodeAsAnyProtobuf, EncodeAsAnyProtobuf};
+use hermes_protobuf_encoding_components::impls::from_context::EncodeFromContext;
+use hermes_protobuf_encoding_components::types::Protobuf;
+use prost_types::Any;
 
 use crate::types::tendermint::{
     ProtoTendermintClientState, ProtoTendermintConsensusState, TendermintClientState,
@@ -14,5 +18,9 @@ delegate_components! {
         (ProtoTendermintClientState, TendermintClientState): TryConvertFrom,
         (TendermintConsensusState, ProtoTendermintConsensusState): ConvertFrom,
         (ProtoTendermintConsensusState, TendermintConsensusState): TryConvertFrom,
+        (TendermintClientState, Any): EncodeAsAnyProtobuf<Protobuf, EncodeFromContext>,
+        (Any, TendermintClientState): DecodeAsAnyProtobuf<Protobuf, EncodeFromContext>,
+        (TendermintConsensusState, Any): EncodeAsAnyProtobuf<Protobuf, EncodeFromContext>,
+        (Any, TendermintConsensusState): DecodeAsAnyProtobuf<Protobuf, EncodeFromContext>,
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/client/create_client_message.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/client/create_client_message.rs
@@ -1,21 +1,15 @@
-use core::fmt::Display;
-use core::marker::PhantomData;
-
 use cgp_core::CanRaiseError;
-use hermes_encoding_components::traits::encoded::HasEncodedType;
-use hermes_encoding_components::traits::encoder::CanEncode;
+use hermes_encoding_components::traits::convert::CanConvert;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
-use hermes_encoding_components::traits::schema::HasSchema;
-use hermes_protobuf_encoding_components::types::Protobuf;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayloadType;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
-use ibc_proto::google::protobuf::Any;
+use prost_types::Any;
 
 use crate::traits::message::{CosmosMessage, ToCosmosMessage};
 use crate::types::messages::client::create::CosmosCreateClientMessage;
 use crate::types::payloads::client::CosmosCreateClientPayload;
-use crate::types::tendermint::TendermintClientState;
+use crate::types::tendermint::{TendermintClientState, TendermintConsensusState};
 
 pub struct BuildCosmosCreateClientMessage;
 
@@ -27,10 +21,7 @@ where
         + CanRaiseError<Encoding::Error>,
     Counterparty:
         HasCreateClientPayloadType<Chain, CreateClientPayload = CosmosCreateClientPayload>,
-    Encoding: HasEncodedType<Encoded = Vec<u8>>
-        + CanEncode<Protobuf, TendermintClientState>
-        + HasSchema<TendermintClientState>,
-    Encoding::Schema: Display,
+    Encoding: CanConvert<TendermintClientState, Any> + CanConvert<TendermintConsensusState, Any>,
 {
     async fn build_create_client_message(
         chain: &Chain,
@@ -38,18 +29,17 @@ where
     ) -> Result<CosmosMessage, Chain::Error> {
         let encoding = chain.encoding();
 
-        let client_state_bytes = encoding
-            .encode(&payload.client_state)
+        let client_state = encoding
+            .convert(&payload.client_state)
             .map_err(Chain::raise_error)?;
 
-        let client_state_any = Any {
-            type_url: encoding.schema(PhantomData).to_string(),
-            value: client_state_bytes,
-        };
+        let consensus_state = encoding
+            .convert(&payload.consensus_state)
+            .map_err(Chain::raise_error)?;
 
         let message = CosmosCreateClientMessage {
-            client_state: client_state_any,
-            consensus_state: payload.consensus_state.into(),
+            client_state,
+            consensus_state,
         };
 
         Ok(message.to_cosmos_message())

--- a/crates/cosmos/cosmos-chain-components/src/impls/transaction/encode_tx.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/transaction/encode_tx.rs
@@ -50,8 +50,7 @@ where
         let raw_messages = messages
             .iter()
             .map(|message| message.message.encode_protobuf(&signer))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Chain::raise_error)?;
+            .collect::<Vec<_>>();
 
         let memo = Memo::default();
         let chain_id = chain.chain_id();

--- a/crates/cosmos/cosmos-chain-components/src/impls/types/chain.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/types/chain.rs
@@ -90,10 +90,7 @@ where
     Chain: HasMessageType<Message = CosmosMessage> + CanRaiseError<EncodeError>,
 {
     fn estimate_message_size(message: &CosmosMessage) -> Result<usize, Chain::Error> {
-        let raw = message
-            .message
-            .encode_protobuf(&Signer::dummy())
-            .map_err(Chain::raise_error)?;
+        let raw = message.message.encode_protobuf(&Signer::dummy());
 
         Ok(raw.encoded_len())
     }

--- a/crates/cosmos/cosmos-chain-components/src/methods/encode.rs
+++ b/crates/cosmos/cosmos-chain-components/src/methods/encode.rs
@@ -1,41 +1,36 @@
 //! Helper functions for encoding protobuf messages into bytes.
 
 use ibc_proto::google::protobuf::Any;
-use prost::{EncodeError, Message as ProstMessage};
+use prost::Message as ProstMessage;
 
-pub fn encode_protobuf<Message>(message: &Message) -> Result<Vec<u8>, EncodeError>
+pub fn encode_protobuf<Message>(message: &Message) -> Vec<u8>
 where
     Message: ProstMessage,
 {
-    let mut buf = Vec::new();
-    Message::encode(message, &mut buf)?;
-    Ok(buf)
+    Message::encode_to_vec(message)
 }
 
-pub fn encode_to_any<Message>(type_url: &str, message: &Message) -> Result<Any, EncodeError>
+pub fn encode_to_any<Message>(type_url: &str, message: &Message) -> Any
 where
     Message: ProstMessage,
 {
-    let encoded_message = encode_protobuf(message)?;
+    let encoded_message = Message::encode_to_vec(message);
 
     let any_message = Any {
         type_url: type_url.to_string(),
         value: encoded_message,
     };
 
-    Ok(any_message)
+    any_message
 }
 
-pub fn encode_any_to_bytes<Message>(
-    type_url: &str,
-    message: &Message,
-) -> Result<Vec<u8>, EncodeError>
+pub fn encode_any_to_bytes<Message>(type_url: &str, message: &Message) -> Vec<u8>
 where
     Message: ProstMessage,
 {
-    let any = encode_to_any(type_url, message)?;
+    let any = encode_to_any(type_url, message);
 
-    let bytes = encode_protobuf(&any)?;
+    let bytes = encode_protobuf(&any);
 
-    Ok(bytes)
+    bytes
 }

--- a/crates/cosmos/cosmos-chain-components/src/traits/message.rs
+++ b/crates/cosmos/cosmos-chain-components/src/traits/message.rs
@@ -4,7 +4,6 @@ use core::fmt::Debug;
 use ibc_proto::google::protobuf::Any;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 #[derive(Debug, Clone)]
 pub struct CosmosMessage {
@@ -28,7 +27,7 @@ pub trait DynCosmosMessage: Debug + Send + Sync + 'static {
         None
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError>;
+    fn encode_protobuf(&self, signer: &Signer) -> Any;
 }
 
 pub trait ToCosmosMessage {

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_ack.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_ack.rs
@@ -5,7 +5,6 @@ use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -27,7 +26,7 @@ impl DynCosmosMessage for CosmosChannelOpenAckMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgChannelOpenAck {
             port_id: self.port_id.to_string(),
             channel_id: self.channel_id.to_string(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_confirm.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_confirm.rs
@@ -4,7 +4,6 @@ use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -24,7 +23,7 @@ impl DynCosmosMessage for CosmosChannelOpenConfirmMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgChannelOpenConfirm {
             port_id: self.port_id.to_string(),
             channel_id: self.channel_id.to_string(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_init.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_init.rs
@@ -3,7 +3,6 @@ use ibc_proto::ibc::core::channel::v1::MsgChannelOpenInit as ProtoMsgChannelOpen
 use ibc_relayer_types::core::ics04_channel::channel::ChannelEnd;
 use ibc_relayer_types::core::ics24_host::identifier::PortId;
 use ibc_relayer_types::signer::Signer;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -17,7 +16,7 @@ pub struct CosmosChannelOpenInitMessage {
 }
 
 impl DynCosmosMessage for CosmosChannelOpenInitMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgChannelOpenInit {
             port_id: self.port_id.to_string(),
             channel: Some(self.channel.clone().into()),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_try.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/channel/open_try.rs
@@ -6,7 +6,6 @@ use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::core::ics24_host::identifier::PortId;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -27,7 +26,7 @@ impl DynCosmosMessage for CosmosChannelOpenTryMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         #[allow(deprecated)]
         let proto_message = ProtoMsgChannelOpenTry {
             port_id: self.port_id.to_string(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
@@ -1,5 +1,6 @@
 use ibc_proto::google::protobuf::Any as IbcProtoAny;
 use ibc_relayer_types::signer::Signer;
+use prost::Message;
 use prost_types::Any;
 
 use crate::methods::encode::encode_to_any;
@@ -13,7 +14,7 @@ pub struct CosmosCreateClientMessage {
     pub consensus_state: Any,
 }
 
-#[derive(::prost::Message)]
+#[derive(Message)]
 pub struct ProtoMsgCreateClient {
     /// light client state
     #[prost(message, optional, tag = "1")]

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
@@ -1,7 +1,8 @@
-use ibc_proto::google::protobuf::Any;
+use ibc_proto::google::protobuf::Any as IbcProtoAny;
 use ibc_proto::ibc::core::client::v1::MsgCreateClient as ProtoMsgCreateClient;
 use ibc_relayer_types::signer::Signer;
 use prost::EncodeError;
+use prost_types::Any;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -15,10 +16,16 @@ pub struct CosmosCreateClientMessage {
 }
 
 impl DynCosmosMessage for CosmosCreateClientMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Result<IbcProtoAny, EncodeError> {
         let proto_message = ProtoMsgCreateClient {
-            client_state: Some(self.client_state.clone()),
-            consensus_state: Some(self.consensus_state.clone()),
+            client_state: Some(IbcProtoAny {
+                type_url: self.client_state.type_url.clone(),
+                value: self.client_state.value.clone(),
+            }),
+            consensus_state: Some(IbcProtoAny {
+                type_url: self.consensus_state.type_url.clone(),
+                value: self.consensus_state.value.clone(),
+            }),
             signer: signer.to_string(),
         };
 

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
@@ -17,7 +17,7 @@ pub struct CosmosCreateClientMessage {
 
 impl DynCosmosMessage for CosmosCreateClientMessage {
     fn encode_protobuf(&self, signer: &Signer) -> Result<IbcProtoAny, EncodeError> {
-        let proto_message = ProtoMsgCreateClient {
+        let proto_message: ProtoMsgCreateClient = ProtoMsgCreateClient {
             client_state: Some(IbcProtoAny {
                 type_url: self.client_state.type_url.clone(),
                 value: self.client_state.value.clone(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/create.rs
@@ -1,13 +1,11 @@
 use ibc_proto::google::protobuf::Any as IbcProtoAny;
-use ibc_proto::ibc::core::client::v1::MsgCreateClient as ProtoMsgCreateClient;
 use ibc_relayer_types::signer::Signer;
-use prost::EncodeError;
 use prost_types::Any;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
 
-const TYPE_URL: &str = "/ibc.core.client.v1.MsgCreateClient";
+pub const TYPE_URL: &str = "/ibc.core.client.v1.MsgCreateClient";
 
 #[derive(Debug)]
 pub struct CosmosCreateClientMessage {
@@ -15,17 +13,25 @@ pub struct CosmosCreateClientMessage {
     pub consensus_state: Any,
 }
 
+#[derive(::prost::Message)]
+pub struct ProtoMsgCreateClient {
+    /// light client state
+    #[prost(message, optional, tag = "1")]
+    pub client_state: Option<Any>,
+    /// consensus state associated with the client that corresponds to a given
+    /// height.
+    #[prost(message, optional, tag = "2")]
+    pub consensus_state: Option<Any>,
+    /// signer address
+    #[prost(string, tag = "3")]
+    pub signer: String,
+}
+
 impl DynCosmosMessage for CosmosCreateClientMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Result<IbcProtoAny, EncodeError> {
-        let proto_message: ProtoMsgCreateClient = ProtoMsgCreateClient {
-            client_state: Some(IbcProtoAny {
-                type_url: self.client_state.type_url.clone(),
-                value: self.client_state.value.clone(),
-            }),
-            consensus_state: Some(IbcProtoAny {
-                type_url: self.consensus_state.type_url.clone(),
-                value: self.consensus_state.value.clone(),
-            }),
+    fn encode_protobuf(&self, signer: &Signer) -> IbcProtoAny {
+        let proto_message = ProtoMsgCreateClient {
+            client_state: Some(self.client_state.clone()),
+            consensus_state: Some(self.consensus_state.clone()),
             signer: signer.to_string(),
         };
 

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/update.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/update.rs
@@ -2,7 +2,6 @@ use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::MsgUpdateClient as ProtoMsgUpdateClient;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 use ibc_relayer_types::signer::Signer;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -16,7 +15,7 @@ pub struct CosmosUpdateClientMessage {
 }
 
 impl DynCosmosMessage for CosmosUpdateClientMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgUpdateClient {
             client_id: self.client_id.to_string(),
             client_message: Some(self.header.clone()),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/update.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/update.rs
@@ -1,7 +1,7 @@
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::ibc::core::client::v1::MsgUpdateClient as ProtoMsgUpdateClient;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 use ibc_relayer_types::signer::Signer;
+use prost::Message;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -12,6 +12,19 @@ pub const TYPE_URL: &str = "/ibc.core.client.v1.MsgUpdateClient";
 pub struct CosmosUpdateClientMessage {
     pub client_id: ClientId,
     pub header: Any,
+}
+
+#[derive(Message)]
+pub struct ProtoMsgUpdateClient {
+    /// client unique identifier
+    #[prost(string, tag = "1")]
+    pub client_id: String,
+    /// client message to update the light client
+    #[prost(message, optional, tag = "2")]
+    pub client_message: Option<Any>,
+    /// signer address
+    #[prost(string, tag = "3")]
+    pub signer: String,
 }
 
 impl DynCosmosMessage for CosmosUpdateClientMessage {

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_ack.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_ack.rs
@@ -6,7 +6,6 @@ use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
 use ibc_relayer_types::proofs::ConsensusProof;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -30,7 +29,7 @@ impl DynCosmosMessage for CosmosConnectionOpenAckMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgConnectionOpenAck {
             connection_id: self.connection_id.as_str().to_string(),
             counterparty_connection_id: self.counterparty_connection_id.as_str().to_string(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_confirm.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_confirm.rs
@@ -4,7 +4,6 @@ use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -23,7 +22,7 @@ impl DynCosmosMessage for CosmosConnectionOpenConfirmMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgConnectionOpenConfirm {
             connection_id: self.connection_id.as_str().to_string(),
             proof_height: Some(self.update_height.into()),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_init.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_init.rs
@@ -9,7 +9,6 @@ use ibc_relayer_types::core::ics03_connection::version::Version;
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 use ibc_relayer_types::signer::Signer;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -26,7 +25,7 @@ pub struct CosmosConnectionOpenInitMessage {
 }
 
 impl DynCosmosMessage for CosmosConnectionOpenInitMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let counterparty = Counterparty {
             client_id: self.counterparty_client_id.as_str().to_string(),
             prefix: Some(MerklePrefix {

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_try.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/connection/open_try.rs
@@ -13,7 +13,6 @@ use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 use ibc_relayer_types::proofs::ConsensusProof;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -40,7 +39,7 @@ impl DynCosmosMessage for CosmosConnectionOpenTryMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let counterparty = Counterparty {
             client_id: self.counterparty_client_id.as_str().to_string(),
             prefix: Some(MerklePrefix {

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/packet/ack.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/packet/ack.rs
@@ -4,7 +4,6 @@ use ibc_relayer_types::core::ics04_channel::packet::Packet;
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -24,7 +23,7 @@ impl DynCosmosMessage for CosmosAckPacketMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgAcknowledgement {
             packet: Some(self.packet.clone().into()),
             acknowledgement: self.acknowledgement.clone(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/packet/receive.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/packet/receive.rs
@@ -4,7 +4,6 @@ use ibc_relayer_types::core::ics04_channel::packet::Packet;
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -23,7 +22,7 @@ impl DynCosmosMessage for CosmosReceivePacketMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgRecvPacket {
             packet: Some(self.packet.clone().into()),
             proof_commitment: self.proof_commitment.clone().into(),

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/packet/timeout.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/packet/timeout.rs
@@ -4,7 +4,6 @@ use ibc_relayer_types::core::ics04_channel::packet::{Packet, Sequence};
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -24,7 +23,7 @@ impl DynCosmosMessage for CosmosTimeoutPacketMessage {
         Some(self.update_height)
     }
 
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let proto_message = ProtoMsgTimeout {
             packet: Some(self.packet.clone().into()),
             next_sequence_recv: self.next_sequence_recv.into(),

--- a/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
@@ -5,7 +5,7 @@ use hermes_cosmos_chain_components::encoding::components::{
 };
 use hermes_cosmos_chain_components::types::tendermint::TendermintConsensusState;
 use hermes_encoding_components::impls::default_encoding::GetDefaultEncoding;
-use hermes_encoding_components::traits::convert::CanConvert;
+use hermes_encoding_components::traits::convert::CanConvertBothWays;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
 use hermes_encoding_components::traits::encoded::HasEncodedType;
 use hermes_encoding_components::traits::has_encoding::{
@@ -71,10 +71,8 @@ pub trait CheckCosmosEncoding:
     + CanEncodeAndDecode<Any, TendermintClientState>
     + CanEncodeAndDecode<Protobuf, TendermintConsensusState>
     + CanEncodeAndDecode<Any, TendermintConsensusState>
-    + CanConvert<Any, TendermintClientState>
-    + CanConvert<TendermintClientState, Any>
-    + CanConvert<Any, TendermintConsensusState>
-    + CanConvert<TendermintConsensusState, Any>
+    + CanConvertBothWays<Any, TendermintClientState>
+    + CanConvertBothWays<Any, TendermintConsensusState>
 {
 }
 

--- a/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
@@ -5,6 +5,7 @@ use hermes_cosmos_chain_components::encoding::components::{
 };
 use hermes_cosmos_chain_components::types::tendermint::TendermintConsensusState;
 use hermes_encoding_components::impls::default_encoding::GetDefaultEncoding;
+use hermes_encoding_components::traits::convert::CanConvert;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
 use hermes_encoding_components::traits::encoded::HasEncodedType;
 use hermes_encoding_components::traits::has_encoding::{
@@ -70,6 +71,10 @@ pub trait CheckCosmosEncoding:
     + CanEncodeAndDecode<Any, TendermintClientState>
     + CanEncodeAndDecode<Protobuf, TendermintConsensusState>
     + CanEncodeAndDecode<Any, TendermintConsensusState>
+    + CanConvert<Any, TendermintClientState>
+    + CanConvert<TendermintClientState, Any>
+    + CanConvert<Any, TendermintConsensusState>
+    + CanConvert<TendermintConsensusState, Any>
 {
 }
 

--- a/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
@@ -11,8 +11,9 @@ use hermes_relayer_components::error::impls::retry::ReturnMaxRetry;
 use hermes_relayer_components::error::traits::retry::{
     MaxErrorRetryGetterComponent, RetryableErrorComponent,
 };
-use hermes_relayer_components::relay::impls::packet_lock::PacketMutexGetter;
-use hermes_relayer_components::relay::impls::packet_lock::ProvidePacketLockWithMutex;
+use hermes_relayer_components::relay::impls::packet_lock::{
+    PacketMutexGetter, ProvidePacketLockWithMutex,
+};
 use hermes_relayer_components::relay::traits::chains::ProvideRelayChains;
 use hermes_relayer_components::relay::traits::packet_filter::PacketFilter;
 use hermes_relayer_components::relay::traits::packet_lock::PacketLockComponent;
@@ -24,20 +25,16 @@ use hermes_relayer_components_extra::components::extra::relay::{
 };
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
-use hermes_runtime_components::traits::runtime::RuntimeGetter;
-use hermes_runtime_components::traits::runtime::RuntimeTypeComponent;
+use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
 use ibc_relayer::config::filter::PacketFilter as PacketFilterConfig;
-use ibc_relayer_types::core::ics04_channel::packet::Packet;
-use ibc_relayer_types::core::ics04_channel::packet::Sequence;
+use ibc_relayer_types::core::ics04_channel::packet::{Packet, Sequence};
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ClientId, PortId};
 
-use crate::types::error::Error;
-
+use crate::contexts::chain::CosmosChain;
 use crate::contexts::logger::ProvideCosmosLogger;
 use crate::impls::error::HandleCosmosError;
-
-use crate::contexts::chain::CosmosChain;
 use crate::types::batch::CosmosBatchSender;
+use crate::types::error::Error;
 
 #[derive(Clone)]
 pub struct CosmosRelay {

--- a/crates/cosmos/cosmos-relayer/src/impls/error.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/error.rs
@@ -1,11 +1,6 @@
 use alloc::string::FromUtf8Error;
 use core::convert::Infallible;
 use core::num::ParseIntError;
-use hermes_relayer_components::relay::impls::channel::open_init::MissingChannelInitEventError;
-use hermes_relayer_components::relay::impls::channel::open_try::MissingChannelTryEventError;
-use hermes_relayer_components::relay::impls::connection::open_init::MissingConnectionInitEventError;
-use hermes_relayer_components::relay::impls::connection::open_try::MissingConnectionTryEventError;
-use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 
 use cgp_core::prelude::*;
 use cgp_core::{ErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
@@ -20,7 +15,12 @@ use hermes_relayer_components::error::impls::error::{
     MaxRetryExceededError, UnwrapMaxRetryExceededError,
 };
 use hermes_relayer_components::error::traits::retry::ProvideRetryableError;
+use hermes_relayer_components::relay::impls::channel::open_init::MissingChannelInitEventError;
+use hermes_relayer_components::relay::impls::channel::open_try::MissingChannelTryEventError;
+use hermes_relayer_components::relay::impls::connection::open_init::MissingConnectionInitEventError;
+use hermes_relayer_components::relay::impls::connection::open_try::MissingConnectionTryEventError;
 use hermes_relayer_components::relay::impls::create_client::MissingCreateClientEventError;
+use hermes_relayer_components::relay::traits::chains::HasRelayChains;
 use hermes_relayer_components::transaction::impls::poll_tx_response::TxNoResponseError;
 use hermes_relayer_components::transaction::traits::types::tx_hash::HasTransactionHashType;
 use hermes_runtime::types::error::TokioRuntimeError;

--- a/crates/cosmos/cosmos-test-components/src/chain/types/messages/token_transfer.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/types/messages/token_transfer.rs
@@ -7,7 +7,6 @@ use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::timestamp::Timestamp;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 
 use crate::chain::types::amount::Amount;
 
@@ -23,7 +22,7 @@ pub struct TokenTransferMessage {
 }
 
 impl DynCosmosMessage for TokenTransferMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Result<Any, EncodeError> {
+    fn encode_protobuf(&self, signer: &Signer) -> Any {
         let timeout_timestamp = self.timeout_time.unwrap_or_default().nanoseconds();
 
         let message = MsgTransfer {

--- a/crates/relayer/relayer-components/src/relay/impls/packet_lock.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/packet_lock.rs
@@ -2,9 +2,8 @@ use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 
 use cgp_core::prelude::*;
-use hermes_runtime_components::traits::channel_once::CanUseChannelsOnce;
 use hermes_runtime_components::traits::channel_once::{
-    CanCreateChannelsOnce, HasChannelOnceTypes, ReceiverOnce, SenderOnceOf,
+    CanCreateChannelsOnce, CanUseChannelsOnce, HasChannelOnceTypes, ReceiverOnce, SenderOnceOf,
 };
 use hermes_runtime_components::traits::mutex::{HasMutex, MutexOf};
 use hermes_runtime_components::traits::runtime::{HasRuntime, RuntimeOf};

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/connection_handshake_message.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/connection_handshake_message.rs
@@ -56,16 +56,13 @@ where
     ) -> Result<CosmosMessage, Error> {
         let counterparty_commitment_prefix = Vec::from(payload.commitment_prefix).try_into()?;
 
-        let proof_init: ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes = timestamped_sign_data_to_bytes(&payload.proof_init).unwrap()
+        let proof_init: ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes = timestamped_sign_data_to_bytes(&payload.proof_init)
             .try_into()?;
 
-        let proof_client = timestamped_sign_data_to_bytes(&payload.proof_client)
-            .unwrap()
-            .try_into()?;
+        let proof_client = timestamped_sign_data_to_bytes(&payload.proof_client).try_into()?;
 
-        let consensus_signature = timestamped_sign_data_to_bytes(&payload.proof_consensus)
-            .unwrap()
-            .try_into()?;
+        let consensus_signature =
+            timestamped_sign_data_to_bytes(&payload.proof_consensus).try_into()?;
 
         let proof_consensus = ConsensusProof::new(consensus_signature, payload.update_height)?;
 

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/create_client_message.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/create_client_message.rs
@@ -2,6 +2,7 @@ use cgp_core::HasErrorType;
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::messages::client::create::CosmosCreateClientMessage;
 use hermes_cosmos_relayer::types::error::Error;
+use hermes_protobuf_encoding_components::types::Any;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayloadType;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
@@ -22,20 +23,19 @@ where
         _chain: &Chain,
         counterparty_payload: SolomachineCreateClientPayload,
     ) -> Result<CosmosMessage, Error> {
-        /*let client_state = encode_client_state(&counterparty_payload.client_state)
-        .map_err(CosmosBaseError::encode)?;*/
-
         let client_state = counterparty_payload.client_state.clone().to_any();
-
-        /*let consensus_state =
-        encode_consensus_state(&counterparty_payload.client_state.consensus_state)
-            .map_err(CosmosBaseError::encode)?;*/
 
         let consensus_state = counterparty_payload.client_state.consensus_state.to_any();
 
         let message = CosmosCreateClientMessage {
-            client_state,
-            consensus_state,
+            client_state: Any {
+                type_url: client_state.type_url,
+                value: client_state.value,
+            },
+            consensus_state: Any {
+                type_url: consensus_state.type_url,
+                value: consensus_state.value,
+            },
         };
 
         Ok(message.to_cosmos_message())

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/update_client_message.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/update_client_message.rs
@@ -27,7 +27,7 @@ where
         client_id: &ClientId,
         payload: SolomachineUpdateClientPayload,
     ) -> Result<Vec<CosmosMessage>, Error> {
-        let header = encode_header(&payload.header)?;
+        let header = encode_header(&payload.header);
 
         let message = CosmosUpdateClientMessage {
             client_id: client_id.clone(),

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/channel_handshake_payload.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/channel_handshake_payload.rs
@@ -50,8 +50,7 @@ where
 
         let secret_key = chain.chain.secret_key();
 
-        let channel_proof =
-            sign_with_data(secret_key, &channel_state_data).map_err(Chain::encode_error)?;
+        let channel_proof = sign_with_data(secret_key, &channel_state_data);
 
         let payload = SolomachineChannelOpenTryPayload {
             ordering,
@@ -90,8 +89,7 @@ where
 
         let secret_key = chain.chain.secret_key();
 
-        let channel_proof =
-            sign_with_data(secret_key, &channel_state_data).map_err(Chain::encode_error)?;
+        let channel_proof = sign_with_data(secret_key, &channel_state_data);
 
         let payload = SolomachineChannelOpenAckPayload {
             version,
@@ -126,8 +124,7 @@ where
 
         let secret_key = chain.chain.secret_key();
 
-        let channel_proof =
-            sign_with_data(secret_key, &channel_state_data).map_err(Chain::encode_error)?;
+        let channel_proof = sign_with_data(secret_key, &channel_state_data);
 
         let payload = SolomachineChannelOpenConfirmPayload {
             update_height: *height,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/connection_handshake_payload.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/connection_handshake_payload.rs
@@ -68,8 +68,7 @@ where
             commitment_prefix,
             connection_id,
             connection,
-        )
-        .map_err(Chain::encode_error)?;
+        );
 
         let cosmos_client_state = chain.chain.query_client_state(client_id).await?;
 
@@ -80,8 +79,7 @@ where
             commitment_prefix,
             client_id,
             &cosmos_client_state,
-        )
-        .map_err(Chain::encode_error)?;
+        );
 
         let cosmos_consensus_state = chain
             .chain
@@ -95,8 +93,7 @@ where
             client_id,
             *height,
             &cosmos_consensus_state,
-        )
-        .map_err(Chain::encode_error)?;
+        );
 
         let payload = SolomachineConnectionOpenTryPayload {
             commitment_prefix: commitment_prefix.to_string(),
@@ -148,8 +145,7 @@ where
             commitment_prefix,
             client_id,
             &cosmos_client_state,
-        )
-        .map_err(Chain::encode_error)?;
+        );
 
         let connection_proof: crate::types::sign_data::SolomachineTimestampedSignData =
             connection_proof_data(
@@ -159,8 +155,7 @@ where
                 commitment_prefix,
                 connection_id,
                 connection,
-            )
-            .map_err(Chain::encode_error)?;
+            );
 
         let cosmos_consensus_state = chain
             .chain
@@ -174,8 +169,7 @@ where
             client_id,
             *height,
             &cosmos_consensus_state,
-        )
-        .map_err(Chain::encode_error)?;
+        );
 
         let payload = SolomachineConnectionOpenAckPayload {
             client_state: cosmos_client_state,
@@ -219,8 +213,7 @@ where
                 commitment_prefix,
                 connection_id,
                 connection,
-            )
-            .map_err(Chain::encode_error)?;
+            );
 
         let payload = SolomachineConnectionOpenConfirmPayload {
             update_height: *height,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/receive_packet_payload.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/receive_packet_payload.rs
@@ -43,8 +43,7 @@ where
             commitment: commitment_bytes,
         };
 
-        let packet_commitment_data_bytes =
-            encode_protobuf(&packet_commitment_data).map_err(Chain::encode_error)?;
+        let packet_commitment_data_bytes = encode_protobuf(&packet_commitment_data);
 
         let new_diversifier = chain.chain.current_diversifier();
         let secret_key = chain.chain.secret_key();
@@ -58,7 +57,7 @@ where
             path: commitment_path.into_bytes(),
         };
 
-        let proof = sign_with_data(secret_key, &sign_data).map_err(Chain::encode_error)?;
+        let proof = sign_with_data(secret_key, &sign_data);
 
         let payload = SolomachineReceivePacketPayload {
             update_height: *height,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/timeout_packet_payload.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/timeout_packet_payload.rs
@@ -44,8 +44,7 @@ where
             commitment: commitment_bytes,
         };
 
-        let packet_commitment_data_bytes =
-            encode_protobuf(&packet_commitment_data).map_err(Chain::encode_error)?;
+        let packet_commitment_data_bytes = encode_protobuf(&packet_commitment_data);
 
         let new_diversifier = chain.chain.current_diversifier();
         let secret_key = chain.chain.secret_key();
@@ -59,7 +58,7 @@ where
             path: commitment_path.into_bytes(),
         };
 
-        let proof = sign_with_data(secret_key, &sign_data).map_err(Chain::encode_error)?;
+        let proof = sign_with_data(secret_key, &sign_data);
 
         let payload = SolomachineTimeoutUnorderedPacketPayload {
             update_height: *height,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/update_client_payload.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/update_client_payload.rs
@@ -48,7 +48,7 @@ where
 
         let secret_key = chain.chain.secret_key();
 
-        let signature = sign_header_data(secret_key, &sign_data).map_err(Chain::encode_error)?;
+        let signature = sign_header_data(secret_key, &sign_data);
 
         let header = SolomachineHeader {
             timestamp,

--- a/crates/solomachine/solomachine-relayer/src/methods/encode/client_state.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/encode/client_state.rs
@@ -2,7 +2,7 @@
 
 use hermes_cosmos_chain_components::methods::encode::encode_to_any;
 use ibc_proto::google::protobuf::Any;
-use prost::{EncodeError, Message};
+use prost::Message;
 
 use crate::methods::encode::consensus_state::{to_proto_consensus_state, ProtoConsensusState};
 use crate::types::client_state::SolomachineClientState;
@@ -19,7 +19,7 @@ pub struct ProtoClientState {
     pub consensus_state: Option<ProtoConsensusState>,
 }
 
-pub fn encode_client_state(client_state: &SolomachineClientState) -> Result<Any, EncodeError> {
+pub fn encode_client_state(client_state: &SolomachineClientState) -> Any {
     let proto_consensus_state = to_proto_consensus_state(&client_state.consensus_state);
 
     let proto_client_state = ProtoClientState {

--- a/crates/solomachine/solomachine-relayer/src/methods/encode/consensus_state.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/encode/consensus_state.rs
@@ -2,7 +2,7 @@
 
 use hermes_cosmos_chain_components::methods::encode::encode_to_any;
 use ibc_proto::google::protobuf::Any;
-use prost::{EncodeError, Message};
+use prost::Message;
 
 use super::public_key::encode_public_key;
 use crate::types::consensus_state::SolomachineConsensusState;
@@ -34,9 +34,7 @@ pub fn to_proto_consensus_state(
     }
 }
 
-pub fn encode_consensus_state(
-    consensus_state: &SolomachineConsensusState,
-) -> Result<Any, EncodeError> {
+pub fn encode_consensus_state(consensus_state: &SolomachineConsensusState) -> Any {
     let proto_consensus_state = to_proto_consensus_state(consensus_state);
     encode_to_any(TYPE_URL, &proto_consensus_state)
 }

--- a/crates/solomachine/solomachine-relayer/src/methods/encode/header.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/encode/header.rs
@@ -2,7 +2,7 @@
 
 use hermes_cosmos_chain_components::methods::encode::encode_to_any;
 use ibc_proto::google::protobuf::Any;
-use prost::{EncodeError, Message};
+use prost::Message;
 use secp256k1::SecretKey;
 
 use crate::methods::encode::header_data::sign_header_data;
@@ -23,7 +23,7 @@ pub struct ProtoHeader {
     pub new_diversifier: ::prost::alloc::string::String,
 }
 
-pub fn encode_header(header: &SolomachineHeader) -> Result<Any, EncodeError> {
+pub fn encode_header(header: &SolomachineHeader) -> Any {
     let new_public_key = encode_public_key(&header.header_data.new_public_key);
 
     let proto_header = ProtoHeader {
@@ -39,8 +39,8 @@ pub fn encode_header(header: &SolomachineHeader) -> Result<Any, EncodeError> {
 pub fn sign_and_create_header(
     secret_key: &SecretKey,
     header_data: &SolomachineSignHeaderData,
-) -> Result<SolomachineHeader, EncodeError> {
-    let signature = sign_header_data(secret_key, header_data)?;
+) -> SolomachineHeader {
+    let signature = sign_header_data(secret_key, header_data);
 
     let header = SolomachineHeader {
         timestamp: header_data.timestamp,
@@ -48,5 +48,5 @@ pub fn sign_and_create_header(
         header_data: header_data.header_data.clone(),
     };
 
-    Ok(header)
+    header
 }

--- a/crates/solomachine/solomachine-relayer/src/methods/encode/header_data.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/encode/header_data.rs
@@ -2,7 +2,7 @@
 
 use hermes_cosmos_chain_components::methods::encode::{encode_protobuf, encode_to_any};
 use ibc_proto::google::protobuf::Any;
-use prost::{EncodeError, Message};
+use prost::Message;
 use secp256k1::ecdsa::Signature;
 use secp256k1::SecretKey;
 
@@ -21,7 +21,7 @@ pub struct ProtoHeaderData {
     pub new_diversifier: String,
 }
 
-pub fn encode_header_data(header_data: &SolomachineHeaderData) -> Result<Any, EncodeError> {
+pub fn encode_header_data(header_data: &SolomachineHeaderData) -> Any {
     let encoded_public_key = encode_public_key(&header_data.new_public_key);
 
     let proto_header_data = ProtoHeaderData {
@@ -35,10 +35,10 @@ pub fn encode_header_data(header_data: &SolomachineHeaderData) -> Result<Any, En
 pub fn sign_header_data(
     secret_key: &SecretKey,
     header_data: &SolomachineSignHeaderData,
-) -> Result<Signature, EncodeError> {
-    let any_header_data = encode_header_data(&header_data.header_data)?;
+) -> Signature {
+    let any_header_data = encode_header_data(&header_data.header_data);
 
-    let header_bytes = encode_protobuf(&any_header_data)?;
+    let header_bytes = encode_protobuf(&any_header_data);
 
     let sign_data = SolomachineSignData {
         sequence: header_data.sequence,

--- a/crates/solomachine/solomachine-relayer/src/methods/encode/public_key.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/encode/public_key.rs
@@ -47,7 +47,7 @@ const TYPE_URL: &str = "/cosmos.crypto.secp256k1.PubKey";
 pub fn encode_public_key(public_key: &PublicKey) -> Any {
     let key = PubKey::from(public_key);
 
-    encode_to_any(TYPE_URL, &key).unwrap()
+    encode_to_any(TYPE_URL, &key)
 }
 
 impl Protobuf<PubKey> for PublicKey {}

--- a/crates/solomachine/solomachine-relayer/src/methods/encode/sign_data.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/encode/sign_data.rs
@@ -6,7 +6,7 @@ use hermes_cosmos_chain_components::methods::encode::{
 use ibc_proto::cosmos::tx::signing::v1beta1::signature_descriptor::data::{Single, Sum};
 use ibc_proto::cosmos::tx::signing::v1beta1::signature_descriptor::Data;
 use ibc_proto::google::protobuf::Any;
-use prost::{EncodeError, Message};
+use prost::Message;
 use secp256k1::ecdsa::Signature;
 use secp256k1::SecretKey;
 
@@ -40,35 +40,32 @@ pub fn to_proto_sign_bytes(sign_data: &SolomachineSignData) -> ProtoSignBytes {
     }
 }
 
-pub fn sign_data_to_any(sign_data: &SolomachineSignData) -> Result<Any, EncodeError> {
+pub fn sign_data_to_any(sign_data: &SolomachineSignData) -> Any {
     let proto_sign_bytes = to_proto_sign_bytes(sign_data);
 
     encode_to_any(TYPE_URL, &proto_sign_bytes)
 }
 
-pub fn sign_data_to_bytes(sign_data: &SolomachineSignData) -> Result<Vec<u8>, EncodeError> {
+pub fn sign_data_to_bytes(sign_data: &SolomachineSignData) -> Vec<u8> {
     let proto_sign_bytes = to_proto_sign_bytes(sign_data);
 
     encode_any_to_bytes(TYPE_URL, &proto_sign_bytes)
 }
 
-pub fn sign_with_data(
-    secret_key: &SecretKey,
-    sign_data: &SolomachineSignData,
-) -> Result<Signature, EncodeError> {
+pub fn sign_with_data(secret_key: &SecretKey, sign_data: &SolomachineSignData) -> Signature {
     let proto_sign_bytes = to_proto_sign_bytes(sign_data);
-    let sign_bytes = encode_protobuf(&proto_sign_bytes)?;
+    let sign_bytes = encode_protobuf(&proto_sign_bytes);
 
     let signature = sign_sha256(secret_key, &sign_bytes);
 
-    Ok(signature)
+    signature
 }
 
 pub fn timestamped_sign_with_data(
     sign_data: &SolomachineSignData,
     _public_key: PublicKey,
-) -> Result<SolomachineTimestampedSignData, EncodeError> {
-    let signature = sign_data_to_bytes(sign_data)?;
+) -> SolomachineTimestampedSignData {
+    let signature = sign_data_to_bytes(sign_data);
 
     let data = Data {
         sum: Some(Sum::Single(Single {
@@ -79,12 +76,12 @@ pub fn timestamped_sign_with_data(
         })),
     };
 
-    let bytes_data = encode_protobuf(&data).unwrap();
+    let bytes_data = encode_protobuf(&data);
 
-    Ok(SolomachineTimestampedSignData {
+    SolomachineTimestampedSignData {
         signature_data: bytes_data,
         timestamp: sign_data.timestamp,
-    })
+    }
 }
 
 /// TimestampedSignatureData contains the signature data and the timestamp of the
@@ -106,9 +103,7 @@ pub fn to_proto_timestamped_sign_bytes(
     }
 }
 
-pub fn timestamped_sign_data_to_bytes(
-    sign_data: &SolomachineTimestampedSignData,
-) -> Result<Vec<u8>, EncodeError> {
+pub fn timestamped_sign_data_to_bytes(sign_data: &SolomachineTimestampedSignData) -> Vec<u8> {
     let proto_sign_bytes = to_proto_timestamped_sign_bytes(sign_data);
 
     encode_protobuf(&proto_sign_bytes)

--- a/crates/solomachine/solomachine-relayer/src/methods/proofs/channel.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/proofs/channel.rs
@@ -17,7 +17,7 @@ pub fn channel_proof_data(
 ) -> Result<SolomachineSignData, EncodeError> {
     let proto_channel_end: ProtoChannelEnd = channel_end.into();
 
-    let channel_end_bytes = encode_protobuf(&proto_channel_end)?;
+    let channel_end_bytes = encode_protobuf(&proto_channel_end);
 
     let path = format!("{commitment_prefix}channel/{channel_id}");
 

--- a/crates/solomachine/solomachine-relayer/src/methods/proofs/client_state.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/proofs/client_state.rs
@@ -4,7 +4,6 @@ use ibc_proto::cosmos::tx::signing::v1beta1::signature_descriptor::data::{Single
 use ibc_proto::cosmos::tx::signing::v1beta1::signature_descriptor::Data;
 use ibc_proto::ibc::lightclients::tendermint::v1::ClientState as ProtoClientState;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
-use prost::EncodeError;
 use secp256k1::SecretKey;
 
 use crate::methods::encode::public_key::PublicKey;
@@ -21,10 +20,10 @@ pub fn client_state_proof_data(
     commitment_prefix: &str,
     client_id: &ClientId,
     cosmos_client_state: &TendermintClientState,
-) -> Result<SolomachineTimestampedSignData, EncodeError> {
+) -> SolomachineTimestampedSignData {
     let proto_client_state: ProtoClientState = cosmos_client_state.clone().into();
 
-    let client_state_bytes = encode_protobuf(&proto_client_state)?;
+    let client_state_bytes = encode_protobuf(&proto_client_state);
 
     let path = format!("{commitment_prefix}clients/{client_id}/clientState");
 
@@ -38,7 +37,7 @@ pub fn client_state_proof_data(
     };
 
     // Sign data using Secret Key
-    let signed_data = sign_with_data(secret_key, &sign_data)?;
+    let signed_data = sign_with_data(secret_key, &sign_data);
 
     let data = Data {
         sum: Some(Sum::Single(Single {
@@ -47,7 +46,7 @@ pub fn client_state_proof_data(
         })),
     };
 
-    let bytes_data = encode_protobuf(&data).unwrap();
+    let bytes_data = encode_protobuf(&data);
 
     // Create Timestamped signed data
     let timestamped_signed_data = SolomachineTimestampedSignData {
@@ -55,5 +54,5 @@ pub fn client_state_proof_data(
         timestamp: solo_client_state.consensus_state.timestamp,
     };
 
-    Ok(timestamped_signed_data)
+    timestamped_signed_data
 }

--- a/crates/solomachine/solomachine-relayer/src/methods/proofs/connection.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/proofs/connection.rs
@@ -4,7 +4,6 @@ use ibc_proto::cosmos::tx::signing::v1beta1::signature_descriptor::Data;
 use ibc_proto::ibc::core::connection::v1::ConnectionEnd as ProtoConnectionEnd;
 use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
 use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
-use prost::EncodeError;
 use secp256k1::hashes::sha256;
 use secp256k1::{Message, Secp256k1, SecretKey};
 
@@ -22,10 +21,10 @@ pub fn connection_proof_data(
     commitment_prefix: &str,
     connection_id: &ConnectionId,
     connection_end: ConnectionEnd,
-) -> Result<SolomachineTimestampedSignData, EncodeError> {
+) -> SolomachineTimestampedSignData {
     let proto_connection_end: ProtoConnectionEnd = connection_end.into();
 
-    let connection_end_bytes = encode_protobuf(&proto_connection_end)?;
+    let connection_end_bytes = encode_protobuf(&proto_connection_end);
 
     let path = format!("{commitment_prefix}connections/{connection_id}");
 
@@ -39,11 +38,11 @@ pub fn connection_proof_data(
     };
 
     // Sign data using Secret Key
-    let signed_data = sign_with_data(secret_key, &sign_data)?;
+    let signed_data = sign_with_data(secret_key, &sign_data);
 
     // TODO: The signature verification fails on chain, but is successful here
     let proto_sign_bytes = to_proto_sign_bytes(&sign_data);
-    let sign_bytes = encode_protobuf(&proto_sign_bytes)?;
+    let sign_bytes = encode_protobuf(&proto_sign_bytes);
 
     let secp = Secp256k1::verification_only();
     let message = Message::from_hashed_data::<sha256::Hash>(&sign_bytes);
@@ -58,7 +57,7 @@ pub fn connection_proof_data(
         })),
     };
 
-    let bytes_data = encode_protobuf(&data).unwrap();
+    let bytes_data = encode_protobuf(&data);
 
     // Create Timestamped signed data
     let timestamped_signed_data = SolomachineTimestampedSignData {
@@ -66,5 +65,5 @@ pub fn connection_proof_data(
         timestamp: client_state.consensus_state.timestamp,
     };
 
-    Ok(timestamped_signed_data)
+    timestamped_signed_data
 }

--- a/crates/solomachine/solomachine-relayer/src/methods/proofs/consensus_state.rs
+++ b/crates/solomachine/solomachine-relayer/src/methods/proofs/consensus_state.rs
@@ -5,7 +5,6 @@ use ibc_proto::cosmos::tx::signing::v1beta1::signature_descriptor::Data;
 use ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState as ProtoConsensusState;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 use ibc_relayer_types::Height;
-use prost::EncodeError;
 use secp256k1::SecretKey;
 
 use crate::methods::encode::sign_data::sign_with_data;
@@ -21,10 +20,10 @@ pub fn consensus_state_proof_data(
     client_id: &ClientId,
     height: Height,
     cosmos_client_state: &TendermintConsensusState,
-) -> Result<SolomachineTimestampedSignData, EncodeError> {
+) -> SolomachineTimestampedSignData {
     let proto_client_state: ProtoConsensusState = cosmos_client_state.clone().into();
 
-    let client_state_bytes = encode_protobuf(&proto_client_state)?;
+    let client_state_bytes = encode_protobuf(&proto_client_state);
 
     let path = format!("{commitment_prefix}clients/{client_id}/consensusStates/{height}");
 
@@ -38,7 +37,7 @@ pub fn consensus_state_proof_data(
     };
 
     // Sign data using Secret Key
-    let signed_data = sign_with_data(secret_key, &sign_data)?;
+    let signed_data = sign_with_data(secret_key, &sign_data);
 
     let data = Data {
         sum: Some(Sum::Single(Single {
@@ -47,7 +46,7 @@ pub fn consensus_state_proof_data(
         })),
     };
 
-    let bytes_data = encode_protobuf(&data).unwrap();
+    let bytes_data = encode_protobuf(&data);
 
     // Create Timestamped signed data
     let timestamped_signed_data = SolomachineTimestampedSignData {
@@ -55,5 +54,5 @@ pub fn consensus_state_proof_data(
         timestamp: solo_client_state.consensus_state.timestamp,
     };
 
-    Ok(timestamped_signed_data)
+    timestamped_signed_data
 }

--- a/crates/sovereign/sovereign-chain-components/src/cosmos/impls/sovereign_to_cosmos/client/create_client_message.rs
+++ b/crates/sovereign/sovereign-chain-components/src/cosmos/impls/sovereign_to_cosmos/client/create_client_message.rs
@@ -11,7 +11,6 @@ use hermes_relayer_components::chain::traits::types::create_client::HasCreateCli
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 use hermes_wasm_client_components::types::client_state::WasmClientState;
 use hermes_wasm_client_components::types::consensus_state::WasmConsensusState;
-use ibc_proto::google::protobuf::Any as ProtoAny;
 use prost::EncodeError;
 
 use crate::sovereign::types::client_state::SovereignClientState;
@@ -70,14 +69,8 @@ where
             .map_err(Chain::raise_error)?;
 
         let message = CosmosCreateClientMessage {
-            client_state: ProtoAny {
-                type_url: wasm_client_state_any.type_url,
-                value: wasm_client_state_any.value,
-            },
-            consensus_state: ProtoAny {
-                type_url: wasm_consensus_state_any.type_url,
-                value: wasm_consensus_state_any.value,
-            },
+            client_state: wasm_client_state_any,
+            consensus_state: wasm_consensus_state_any,
         };
 
         Ok(message.to_cosmos_message())

--- a/crates/sovereign/sovereign-chain-components/src/encoding/impls/convert.rs
+++ b/crates/sovereign/sovereign-chain-components/src/encoding/impls/convert.rs
@@ -1,4 +1,9 @@
 use cgp_core::prelude::*;
+use hermes_cosmos_chain_components::encoding::components::CosmosEncodingComponents;
+use hermes_cosmos_chain_components::types::tendermint::{
+    ProtoTendermintClientState, ProtoTendermintConsensusState, TendermintClientState,
+    TendermintConsensusState,
+};
 use hermes_encoding_components::impls::convert::{ConvertFrom, TryConvertFrom};
 use hermes_protobuf_encoding_components::types::Any;
 use hermes_wasm_client_components::impls::encoding::components::WasmEncodingComponents;
@@ -16,6 +21,18 @@ pub struct SovereignConverterComponents;
 
 delegate_components! {
     SovereignConverterComponents {
+        [
+            (TendermintClientState, ProtoTendermintClientState),
+            (ProtoTendermintClientState, TendermintClientState),
+            (TendermintConsensusState, ProtoTendermintConsensusState),
+            (ProtoTendermintConsensusState, TendermintConsensusState),
+            (TendermintClientState, Any),
+            (Any, TendermintClientState),
+            (TendermintConsensusState, Any),
+            (Any, TendermintConsensusState),
+        ]:
+            CosmosEncodingComponents,
+
         [
             (WasmClientState, ProtoWasmClientState),
             (ProtoWasmClientState, WasmClientState),

--- a/crates/sovereign/sovereign-chain-components/src/encoding/impls/encoder.rs
+++ b/crates/sovereign/sovereign-chain-components/src/encoding/impls/encoder.rs
@@ -1,4 +1,9 @@
 use cgp_core::prelude::*;
+use hermes_cosmos_chain_components::encoding::components::CosmosEncodingComponents;
+use hermes_cosmos_chain_components::types::tendermint::{
+    ProtoTendermintClientState, ProtoTendermintConsensusState, TendermintClientState,
+    TendermintConsensusState,
+};
 use hermes_encoding_components::impls::convert_and_encode::ConvertAndEncode;
 use hermes_protobuf_encoding_components::impls::protobuf::EncodeAsProtobuf;
 use hermes_protobuf_encoding_components::impls::via_any::EncodeViaAny;
@@ -20,6 +25,17 @@ pub struct SovereignEncoderComponents;
 
 delegate_components! {
     SovereignEncoderComponents {
+        [
+            (Any, TendermintClientState),
+            (Protobuf, TendermintClientState),
+            (Protobuf, ProtoTendermintClientState),
+            (Any, TendermintConsensusState),
+            (Protobuf, TendermintConsensusState),
+            (Protobuf, ProtoTendermintConsensusState),
+            (Protobuf, Any),
+        ]:
+            CosmosEncodingComponents,
+
         [
             (Any, WasmClientState),
             (Protobuf, WasmClientState),
@@ -48,5 +64,6 @@ delegate_components! {
             DecodeViaWasmClientState,
         (WasmConsensusState, SovereignConsensusState):
             EncodeViaWasmConsensusState,
+
     }
 }

--- a/crates/sovereign/sovereign-chain-components/src/encoding/impls/type_url.rs
+++ b/crates/sovereign/sovereign-chain-components/src/encoding/impls/type_url.rs
@@ -1,4 +1,8 @@
 use cgp_core::prelude::*;
+use hermes_cosmos_chain_components::encoding::components::CosmosEncodingComponents;
+use hermes_cosmos_chain_components::types::tendermint::{
+    TendermintClientState, TendermintConsensusState,
+};
 use hermes_protobuf_encoding_components::impl_type_url;
 use hermes_wasm_client_components::impls::encoding::components::WasmEncodingComponents;
 use hermes_wasm_client_components::types::client_state::WasmClientState;
@@ -12,10 +16,17 @@ pub struct SovereignTypeUrlSchemas;
 delegate_components! {
     SovereignTypeUrlSchemas {
         [
+            TendermintClientState,
+            TendermintConsensusState,
+        ]:
+            CosmosEncodingComponents,
+
+        [
             WasmClientState,
             WasmConsensusState,
         ]:
             WasmEncodingComponents,
+
         SovereignClientState:
             SovereignClientStateUrl,
         SovereignConsensusState:

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -110,7 +110,7 @@ fn test_cosmos_to_sovereign() -> Result<(), Error> {
 
         let any_message = create_client_message.message.encode_protobuf(
             &Signer::dummy(),
-        )?;
+        );
 
         let message = SovereignMessage::Ibc(IbcMessage::Core(Any {
             type_url: any_message.type_url,

--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -1,8 +1,13 @@
 use cgp_core::prelude::*;
-use cgp_core::{ErrorRaiserComponent, ErrorTypeComponent};
+use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
-use hermes_relayer_components::relay::traits::chains::ProvideRelayChains;
+use hermes_relayer_components::components::default::relay::{
+    DefaultRelayComponents, IsDefaultRelayComponent,
+};
+use hermes_relayer_components::relay::traits::chains::{
+    CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
+};
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
@@ -20,11 +25,24 @@ pub struct CosmosToSovereignRelay {
     // TODO: Relay fields
 }
 
+pub trait CanUseCosmosToSovereignRelay:
+    HasRelayChains<SrcChain = CosmosChain, DstChain = SovereignChain> + CanRaiseRelayChainErrors
+{
+}
+
+impl CanUseCosmosToSovereignRelay for CosmosToSovereignRelay {}
+
 pub struct CosmosToSovereignRelayComponents;
 
 impl HasComponents for CosmosToSovereignRelay {
     type Components = CosmosToSovereignRelayComponents;
 }
+
+delegate_all!(
+    IsDefaultRelayComponent,
+    DefaultRelayComponents,
+    CosmosToSovereignRelayComponents,
+);
 
 delegate_components! {
     CosmosToSovereignRelayComponents {

--- a/crates/sovereign/sovereign-relayer/src/contexts/encoding.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/encoding.rs
@@ -1,6 +1,9 @@
 use cgp_core::prelude::*;
 use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
+use hermes_cosmos_chain_components::types::tendermint::{
+    TendermintClientState, TendermintConsensusState,
+};
 use hermes_encoding_components::traits::convert::CanConvertBothWays;
 use hermes_encoding_components::traits::decoder::CanDecode;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
@@ -68,6 +71,12 @@ pub trait CanUseSovereignEncoding:
     + CanEncodeAndDecode<WasmConsensusState, SovereignConsensusState>
     + CanConvertBothWays<WasmClientState, Any>
     + CanConvertBothWays<WasmConsensusState, Any>
+    + CanEncodeAndDecode<Protobuf, TendermintClientState>
+    + CanEncodeAndDecode<Any, TendermintClientState>
+    + CanEncodeAndDecode<Protobuf, TendermintConsensusState>
+    + CanEncodeAndDecode<Any, TendermintConsensusState>
+    + CanConvertBothWays<Any, TendermintClientState>
+    + CanConvertBothWays<Any, TendermintConsensusState>
 {
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/encoding.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/encoding.rs
@@ -4,11 +4,12 @@ use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_chain_components::types::tendermint::{
     TendermintClientState, TendermintConsensusState,
 };
+use hermes_encoding_components::impls::default_encoding::GetDefaultEncoding;
 use hermes_encoding_components::traits::convert::CanConvertBothWays;
 use hermes_encoding_components::traits::decoder::CanDecode;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
 use hermes_encoding_components::traits::has_encoding::{
-    DefaultEncodingGetter, HasEncodingType, ProvideEncodingType,
+    DefaultEncodingGetter, EncodingGetterComponent, HasEncodingType, ProvideEncodingType,
 };
 use hermes_protobuf_encoding_components::types::{Any, Protobuf};
 use hermes_sovereign_chain_components::encoding::components::{
@@ -55,6 +56,12 @@ where
 {
     fn default_encoding() -> &'static SovereignEncoding {
         &SovereignEncoding
+    }
+}
+
+delegate_components! {
+    ProvideSovereignEncoding {
+        EncodingGetterComponent: GetDefaultEncoding,
     }
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -2,10 +2,10 @@ use cgp_core::prelude::*;
 use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
-use hermes_encoding_components::impls::default_encoding::GetDefaultEncoding;
 use hermes_encoding_components::traits::has_encoding::{
     DefaultEncodingGetterComponent, EncodingGetterComponent, EncodingTypeComponent, HasEncoding,
 };
+use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
@@ -70,10 +70,10 @@ delegate_components! {
         ]: SovereignDataChainType,
         [
             EncodingTypeComponent,
+            EncodingGetterComponent,
             DefaultEncodingGetterComponent,
         ]:
             ProvideSovereignEncoding,
-        EncodingGetterComponent: GetDefaultEncoding,
     }
 }
 
@@ -91,6 +91,7 @@ pub trait CheckSovereignChainImpls:
     + CanBuildUpdateClientPayload<CosmosChain>
     + HasEncoding<Encoding = SovereignEncoding>
     + CanBuildConnectionHandshakePayloads<CosmosChain>
+    + CanBuildCreateClientMessage<CosmosChain>
 {
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -8,7 +8,9 @@ use hermes_encoding_components::traits::has_encoding::{
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
+use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
+use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientOptionsType;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
@@ -83,7 +85,7 @@ impl RuntimeGetter<SovereignChain> for SovereignChainComponents {
     }
 }
 
-pub trait CheckSovereignChainImpls:
+pub trait CanUseSovereignChain:
     HasDataChain
     + HasUpdateClientPayloadType<CosmosChain>
     + HasHeightType<Height = RollupHeight>
@@ -92,7 +94,9 @@ pub trait CheckSovereignChainImpls:
     + HasEncoding<Encoding = SovereignEncoding>
     + CanBuildConnectionHandshakePayloads<CosmosChain>
     + CanBuildCreateClientMessage<CosmosChain>
+    + HasCreateClientOptionsType<CosmosChain>
+    + HasChainIdType
 {
 }
 
-impl CheckSovereignChainImpls for SovereignChain {}
+impl CanUseSovereignChain for SovereignChain {}

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -10,8 +10,9 @@ use hermes_encoding_components::traits::has_encoding::{
 use hermes_logging_components::traits::has_logger::{
     GlobalLoggerGetterComponent, HasLogger, LoggerGetterComponent, LoggerTypeComponent,
 };
-use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
-use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::create_client::{
+    CanBuildCreateClientMessage, CreateClientMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::{

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -3,12 +3,15 @@ use cgp_core::{ErrorRaiserComponent, ErrorTypeComponent, HasComponents};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use ed25519_dalek::SigningKey;
 use futures::lock::Mutex;
+use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_encoding_components::traits::has_encoding::{
     DefaultEncodingGetterComponent, EncodingGetterComponent, EncodingTypeComponent,
 };
 use hermes_logging_components::traits::has_logger::{
     GlobalLoggerGetterComponent, HasLogger, LoggerGetterComponent, LoggerTypeComponent,
 };
+use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
+use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::{
     ChainIdGetter, ChainIdTypeComponent, HasChainId,
@@ -165,6 +168,8 @@ delegate_components! {
             TxResponseQuerierComponent,
             PollTimeoutGetterComponent,
             TxResponseAsEventsParserComponent,
+
+            CreateClientMessageBuilderComponent,
         ]:
             SovereignRollupClientComponents,
         [
@@ -233,6 +238,7 @@ pub trait CanUseSovereignRollup:
     + CanPollTxResponse
     + CanAssertEventualAmount
     + HasLogger
+    + CanBuildCreateClientMessage<CosmosChain>
 where
     Self::Runtime: HasMutex,
 {

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -12,6 +12,7 @@ use hermes_logging_components::traits::has_logger::{
 };
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::{
     ChainIdGetter, ChainIdTypeComponent, HasChainId,
@@ -170,6 +171,7 @@ delegate_components! {
             TxResponseAsEventsParserComponent,
 
             CreateClientMessageBuilderComponent,
+            UpdateClientMessageBuilderComponent,
         ]:
             SovereignRollupClientComponents,
         [

--- a/crates/sovereign/sovereign-relayer/src/exts/cosmos/chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/exts/cosmos/chain.rs
@@ -2,6 +2,8 @@ use cgp_core::prelude::*;
 use hermes_cosmos_chain_components::components::delegate::DelegateCosmosChainComponents;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_components::chain::impls::queries::query_and_decode_client_state::QueryAndDecodeClientState;
+use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
+use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientOptionsType;
 use hermes_sovereign_chain_components::cosmos::impls::sovereign_to_cosmos::client::create_client_message::BuildCreateSovereignClientMessageOnCosmos;
 use hermes_sovereign_chain_components::cosmos::impls::sovereign_to_cosmos::client::update_client_message::BuildUpdateSovereignClientMessageOnCosmos;
 use hermes_sovereign_chain_components::cosmos::impls::sovereign_to_cosmos::connection_handshake_message::BuildSovereignConnectionHandshakeMessageOnCosmos;
@@ -37,12 +39,14 @@ delegate_components! {
     }
 }
 
-pub trait CanUseSovereignMethodsOnCosmosChain:
+pub trait CanUseCosmosChainWithSovereign:
     CanQueryClientState<SovereignChain>
     + CanBuildCreateClientMessage<SovereignChain>
     + CanBuildUpdateClientMessage<SovereignChain>
     + CanBuildConnectionHandshakeMessages<SovereignChain>
+    + HasCreateClientOptionsType<SovereignChain>
+    + CanBuildCreateClientPayload<SovereignChain>
 {
 }
 
-impl CanUseSovereignMethodsOnCosmosChain for CosmosChain {}
+impl CanUseCosmosChainWithSovereign for CosmosChain {}

--- a/crates/sovereign/sovereign-rollup-components/src/components.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/components.rs
@@ -1,5 +1,6 @@
 use cgp_core::prelude::*;
 use hermes_cosmos_chain_components::impls::transaction::poll_timeout::DefaultPollTimeout;
+use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
 use hermes_relayer_components::chain::traits::types::channel::{
@@ -39,6 +40,7 @@ use hermes_relayer_components::transaction::traits::types::transaction::Transact
 use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionHashTypeComponent;
 use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
 
+use crate::impls::cosmos_to_sovereign::client::create_client_message::BuildCreateCosmosClientMessageOnSovereign;
 use crate::impls::json_rpc_client::ProvideJsonRpseeClient;
 use crate::impls::transaction::encode_tx::EncodeSovereignTx;
 use crate::impls::transaction::estimate_fee::ReturnSovereignTxFee;
@@ -113,5 +115,7 @@ delegate_components! {
             SubmitSovereignTransaction,
         NonceQuerierComponent:
             QuerySovereignNonce,
+        CreateClientMessageBuilderComponent:
+            BuildCreateCosmosClientMessageOnSovereign,
     }
 }

--- a/crates/sovereign/sovereign-rollup-components/src/components.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/components.rs
@@ -1,6 +1,7 @@
 use cgp_core::prelude::*;
 use hermes_cosmos_chain_components::impls::transaction::poll_timeout::DefaultPollTimeout;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
 use hermes_relayer_components::chain::traits::types::channel::{
@@ -41,6 +42,7 @@ use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionH
 use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
 
 use crate::impls::cosmos_to_sovereign::client::create_client_message::BuildCreateCosmosClientMessageOnSovereign;
+use crate::impls::cosmos_to_sovereign::client::update_client_message::BuildUpdateCosmosClientMessageOnSovereign;
 use crate::impls::json_rpc_client::ProvideJsonRpseeClient;
 use crate::impls::transaction::encode_tx::EncodeSovereignTx;
 use crate::impls::transaction::estimate_fee::ReturnSovereignTxFee;
@@ -117,5 +119,7 @@ delegate_components! {
             QuerySovereignNonce,
         CreateClientMessageBuilderComponent:
             BuildCreateCosmosClientMessageOnSovereign,
+        UpdateClientMessageBuilderComponent:
+            BuildUpdateCosmosClientMessageOnSovereign,
     }
 }

--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
@@ -1,5 +1,6 @@
 use cgp_core::HasErrorType;
 use hermes_cosmos_chain_components::types::payloads::client::CosmosCreateClientPayload;
+use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayloadType;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
@@ -11,10 +12,12 @@ use crate::types::message::SovereignMessage;
 */
 pub struct BuildCreateCosmosClientMessageOnSovereign;
 
-impl<Chain, Counterparty> CreateClientMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty, Encoding> CreateClientMessageBuilder<Chain, Counterparty>
     for BuildCreateCosmosClientMessageOnSovereign
 where
-    Chain: HasMessageType<Message = SovereignMessage> + HasErrorType,
+    Chain: HasMessageType<Message = SovereignMessage>
+        + HasEncoding<Encoding = Encoding>
+        + HasErrorType,
     Counterparty:
         HasCreateClientPayloadType<Chain, CreateClientPayload = CosmosCreateClientPayload>,
 {

--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
@@ -1,9 +1,19 @@
-use cgp_core::HasErrorType;
+use cgp_core::CanRaiseError;
+use hermes_cosmos_chain_components::methods::encode::encode_to_any;
+use hermes_cosmos_chain_components::types::messages::client::create::{
+    ProtoMsgCreateClient, TYPE_URL,
+};
 use hermes_cosmos_chain_components::types::payloads::client::CosmosCreateClientPayload;
+use hermes_cosmos_chain_components::types::tendermint::{
+    TendermintClientState, TendermintConsensusState,
+};
+use hermes_encoding_components::traits::convert::CanConvert;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
+use hermes_protobuf_encoding_components::types::Any;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayloadType;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
+use ibc_relayer_types::signer::Signer;
 
 use crate::types::message::SovereignMessage;
 
@@ -17,14 +27,33 @@ impl<Chain, Counterparty, Encoding> CreateClientMessageBuilder<Chain, Counterpar
 where
     Chain: HasMessageType<Message = SovereignMessage>
         + HasEncoding<Encoding = Encoding>
-        + HasErrorType,
+        + CanRaiseError<Encoding::Error>,
     Counterparty:
         HasCreateClientPayloadType<Chain, CreateClientPayload = CosmosCreateClientPayload>,
+    Encoding: CanConvert<TendermintClientState, Any> + CanConvert<TendermintConsensusState, Any>,
 {
     async fn build_create_client_message(
-        _chain: &Chain,
-        _payload: CosmosCreateClientPayload,
+        chain: &Chain,
+        payload: CosmosCreateClientPayload,
     ) -> Result<SovereignMessage, Chain::Error> {
+        let encoding = chain.encoding();
+
+        let client_state = encoding
+            .convert(&payload.client_state)
+            .map_err(Chain::raise_error)?;
+
+        let consensus_state = encoding
+            .convert(&payload.consensus_state)
+            .map_err(Chain::raise_error)?;
+
+        let proto_message = ProtoMsgCreateClient {
+            client_state: Some(client_state),
+            consensus_state: Some(consensus_state),
+            signer: Signer::dummy().to_string(),
+        };
+
+        let any_message = encode_to_any(TYPE_URL, &proto_message);
+
         todo!()
     }
 }

--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
@@ -16,6 +16,7 @@ use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 use ibc_relayer_types::signer::Signer;
 
 use crate::types::message::SovereignMessage;
+use crate::types::messages::ibc::IbcMessage;
 
 /**
    Build a message to create a Cosmos client on a Sovereign rollup
@@ -54,6 +55,8 @@ where
 
         let any_message = encode_to_any(TYPE_URL, &proto_message);
 
-        todo!()
+        let message = SovereignMessage::Ibc(IbcMessage::Core(any_message));
+
+        Ok(message)
     }
 }

--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/update_client_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/update_client_message.rs
@@ -1,11 +1,18 @@
 use cgp_core::prelude::HasErrorType;
+use hermes_cosmos_chain_components::methods::encode::encode_to_any;
+use hermes_cosmos_chain_components::types::messages::client::update::{
+    ProtoMsgUpdateClient, TYPE_URL,
+};
 use hermes_cosmos_chain_components::types::payloads::client::CosmosUpdateClientPayload;
+use hermes_cosmos_chain_components::types::tendermint::TendermintHeader;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
+use ibc_relayer_types::signer::Signer;
 
 use crate::types::message::SovereignMessage;
+use crate::types::messages::ibc::IbcMessage;
 
 pub struct BuildUpdateCosmosClientMessageOnSovereign;
 
@@ -19,9 +26,30 @@ where
 {
     async fn build_update_client_message(
         _chain: &Chain,
-        _client_id: &ClientId,
-        _payload: CosmosUpdateClientPayload,
+        client_id: &ClientId,
+        payload: CosmosUpdateClientPayload,
     ) -> Result<Vec<SovereignMessage>, Chain::Error> {
-        todo!()
+        let messages = payload
+            .headers
+            .into_iter()
+            .map(|header| encode_tendermint_header(client_id, header))
+            .collect();
+
+        Ok(messages)
     }
+}
+
+pub fn encode_tendermint_header(
+    client_id: &ClientId,
+    header: TendermintHeader,
+) -> SovereignMessage {
+    let proto_message = ProtoMsgUpdateClient {
+        client_id: client_id.to_string(),
+        client_message: Some(header.into()),
+        signer: Signer::dummy().to_string(),
+    };
+
+    let any_message = encode_to_any(TYPE_URL, &proto_message);
+
+    SovereignMessage::Ibc(IbcMessage::Core(any_message))
 }


### PR DESCRIPTION
- Implement methods such as `BuildCreateCosmosClientMessageOnSovereign`.
- Various refactoring and in-progress implementation of `ClientCreator` for `CosmosToSovereignRelay`