### PR TITLE
Implement `CanCreateClient` for Sovereign relay contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,6 +2122,7 @@ dependencies = [
  "cgp-core",
  "cgp-error-eyre",
  "ed25519-dalek",
+ "eyre",
  "futures",
  "hermes-celestia-chain",
  "hermes-cosmos-chain-components",

--- a/crates/cosmos/cosmos-chain-components/src/components/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/client.rs
@@ -61,6 +61,7 @@ use hermes_relayer_components::chain::traits::types::connection::{
     InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::ConsensusStateTypeComponent;
+use hermes_relayer_components::chain::traits::types::create_client::CreateClientEventComponent;
 use hermes_relayer_components::chain::traits::types::create_client::{
     CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
 };
@@ -88,6 +89,7 @@ use crate::impls::client::create_client_payload::BuildCreateClientPayloadWithCha
 use crate::impls::client::update_client_payload::BuildUpdateClientPayloadWithChainHandle;
 use crate::impls::connection::connection_handshake_payload::BuildCosmosConnectionHandshakePayload;
 use crate::impls::connection::init_connection_options::ProvideCosmosInitConnectionOptionsType;
+use crate::impls::events::ProvideCosmosEvents;
 use crate::impls::packet::ack_packet_message::BuildCosmosAckPacketMessage;
 use crate::impls::packet::ack_packet_payload::BuildCosmosAckPacketPayload;
 use crate::impls::packet::packet_fields::CosmosPacketFieldReader;
@@ -145,6 +147,10 @@ delegate_components! {
             BlockHashComponent,
         ]:
             ProvideCosmosChainTypes,
+        [
+            CreateClientEventComponent,
+        ]:
+            ProvideCosmosEvents,
         [
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,

--- a/crates/cosmos/cosmos-chain-components/src/impls/events.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/events.rs
@@ -1,0 +1,42 @@
+use alloc::sync::Arc;
+use hermes_relayer_components::chain::traits::types::create_client::ProvideCreateClientEvent;
+use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use ibc_relayer_types::core::ics02_client::events::CLIENT_ID_ATTRIBUTE_KEY;
+use ibc_relayer_types::core::ics24_host::identifier::ClientId;
+use ibc_relayer_types::events::IbcEventType;
+use tendermint::abci::Event as AbciEvent;
+
+use crate::types::events::client::CosmosCreateClientEvent;
+
+pub struct ProvideCosmosEvents;
+
+impl<Chain, Counterparty> ProvideCreateClientEvent<Chain, Counterparty> for ProvideCosmosEvents
+where
+    Chain: HasIbcChainTypes<Counterparty, Event = Arc<AbciEvent>, ClientId = ClientId>,
+{
+    type CreateClientEvent = CosmosCreateClientEvent;
+
+    fn try_extract_create_client_event(event: Arc<AbciEvent>) -> Option<CosmosCreateClientEvent> {
+        let event_type = event.kind.parse().ok()?;
+
+        if let IbcEventType::CreateClient = event_type {
+            for tag in &event.attributes {
+                let key = tag.key.as_str();
+                let value = tag.value.as_str();
+                if key == CLIENT_ID_ATTRIBUTE_KEY {
+                    let client_id = value.parse().ok()?;
+
+                    return Some(CosmosCreateClientEvent { client_id });
+                }
+            }
+
+            None
+        } else {
+            None
+        }
+    }
+
+    fn create_client_event_client_id(event: &CosmosCreateClientEvent) -> &ClientId {
+        &event.client_id
+    }
+}

--- a/crates/cosmos/cosmos-chain-components/src/impls/mod.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/mod.rs
@@ -1,6 +1,7 @@
 pub mod channel;
 pub mod client;
 pub mod connection;
+pub mod events;
 pub mod packet;
 pub mod queries;
 pub mod transaction;

--- a/crates/cosmos/cosmos-chain-components/src/methods/event.rs
+++ b/crates/cosmos/cosmos-chain-components/src/methods/event.rs
@@ -5,13 +5,11 @@ use ibc_relayer::event::{
     connection_open_ack_try_from_abci_event, connection_open_try_try_from_abci_event,
     extract_packet_and_write_ack_from_tx,
 };
-use ibc_relayer_types::core::ics02_client::events::CLIENT_ID_ATTRIBUTE_KEY;
 use ibc_relayer_types::core::ics04_channel::events::{SendPacket, WriteAcknowledgement};
 use ibc_relayer_types::events::IbcEventType;
 use tendermint::abci::Event as AbciEvent;
 
 use crate::types::events::channel::{CosmosChannelOpenInitEvent, CosmosChannelOpenTryEvent};
-use crate::types::events::client::CosmosCreateClientEvent;
 use crate::types::events::connection::{
     CosmosConnectionOpenInitEvent, CosmosConnectionOpenTryEvent,
 };
@@ -40,26 +38,6 @@ pub fn try_extract_write_ack_event(event: &Arc<AbciEvent>) -> Option<WriteAcknow
         };
 
         Some(ack)
-    } else {
-        None
-    }
-}
-
-pub fn try_extract_create_client_event(event: Arc<AbciEvent>) -> Option<CosmosCreateClientEvent> {
-    let event_type = event.kind.parse().ok()?;
-
-    if let IbcEventType::CreateClient = event_type {
-        for tag in &event.attributes {
-            let key = tag.key.as_str();
-            let value = tag.value.as_str();
-            if key == CLIENT_ID_ATTRIBUTE_KEY {
-                let client_id = value.parse().ok()?;
-
-                return Some(CosmosCreateClientEvent { client_id });
-            }
-        }
-
-        None
     } else {
         None
     }

--- a/crates/cosmos/cosmos-relayer/src/chain/components.rs
+++ b/crates/cosmos/cosmos-relayer/src/chain/components.rs
@@ -75,7 +75,7 @@ use hermes_relayer_components::chain::traits::types::connection::{
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::ConsensusStateTypeComponent;
 use hermes_relayer_components::chain::traits::types::create_client::{
-    CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    CreateClientEventComponent, CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
 use hermes_relayer_components::chain::traits::types::height::{
@@ -199,6 +199,8 @@ delegate_components! {
             ChainStatusTypeComponent,
             BlockTypeComponent,
             BlockHashComponent,
+
+            CreateClientEventComponent,
 
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,

--- a/crates/cosmos/cosmos-relayer/src/chain/impls/events.rs
+++ b/crates/cosmos/cosmos-relayer/src/chain/impls/events.rs
@@ -3,16 +3,14 @@ use alloc::sync::Arc;
 use hermes_cosmos_chain_components::methods::event::{
     try_extract_channel_open_init_event, try_extract_channel_open_try_event,
     try_extract_connection_open_init_event, try_extract_connection_open_try_event,
-    try_extract_create_client_event, try_extract_send_packet_event, try_extract_write_ack_event,
+    try_extract_send_packet_event, try_extract_write_ack_event,
 };
 use hermes_cosmos_chain_components::types::events::channel::{
     CosmosChannelOpenInitEvent, CosmosChannelOpenTryEvent,
 };
-use hermes_cosmos_chain_components::types::events::client::CosmosCreateClientEvent;
 use hermes_cosmos_chain_components::types::events::connection::{
     CosmosConnectionOpenInitEvent, CosmosConnectionOpenTryEvent,
 };
-use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientEvent;
 use hermes_relayer_components::chain::traits::types::ibc_events::channel::{
     HasChannelOpenInitEvent, HasChannelOpenTryEvent,
 };
@@ -23,22 +21,10 @@ use hermes_relayer_components::chain::traits::types::ibc_events::send_packet::Ha
 use hermes_relayer_components::chain::traits::types::ibc_events::write_ack::HasWriteAckEvent;
 use ibc_relayer_types::core::ics04_channel::events::{SendPacket, WriteAcknowledgement};
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
-use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId};
+use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ConnectionId};
 use tendermint::abci::Event as AbciEvent;
 
 use crate::contexts::chain::CosmosChain;
-
-impl<Counterparty> HasCreateClientEvent<Counterparty> for CosmosChain {
-    type CreateClientEvent = CosmosCreateClientEvent;
-
-    fn try_extract_create_client_event(event: Arc<AbciEvent>) -> Option<CosmosCreateClientEvent> {
-        try_extract_create_client_event(event)
-    }
-
-    fn create_client_event_client_id(event: &CosmosCreateClientEvent) -> &ClientId {
-        &event.client_id
-    }
-}
 
 impl<Counterparty> HasSendPacketEvent<Counterparty> for CosmosChain {
     type SendPacketEvent = SendPacket;

--- a/crates/mock/mock-cosmos-relayer/src/impls/chain.rs
+++ b/crates/mock/mock-cosmos-relayer/src/impls/chain.rs
@@ -30,7 +30,7 @@ use hermes_relayer_components::chain::traits::types::client_state::{
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::ProvideConsensusStateType;
 use hermes_relayer_components::chain::traits::types::create_client::{
-    HasCreateClientEvent, ProvideCreateClientOptionsType, ProvideCreateClientPayloadType,
+    ProvideCreateClientEvent, ProvideCreateClientOptionsType, ProvideCreateClientPayloadType,
 };
 use hermes_relayer_components::chain::traits::types::event::ProvideEventType;
 use hermes_relayer_components::chain::traits::types::height::{
@@ -396,22 +396,23 @@ where
     type CreateClientPayload = Any;
 }
 
-impl<Chain, Counterparty> HasCreateClientEvent<MockCosmosContext<Counterparty>>
-    for MockCosmosContext<Chain>
+impl<Chain, Counterparty>
+    ProvideCreateClientEvent<MockCosmosContext<Chain>, MockCosmosContext<Counterparty>>
+    for MockCosmosChainComponents
 where
     Chain: BasecoinEndpoint,
     Counterparty: BasecoinEndpoint,
 {
     type CreateClientEvent = CreateClient;
 
-    fn try_extract_create_client_event(event: Self::Event) -> Option<Self::CreateClientEvent> {
+    fn try_extract_create_client_event(event: IbcEvent) -> Option<CreateClient> {
         match event {
             IbcEvent::CreateClient(e) => Some(e.clone()),
             _ => None,
         }
     }
 
-    fn create_client_event_client_id(event: &Self::CreateClientEvent) -> &Self::ClientId {
+    fn create_client_event_client_id(event: &CreateClient) -> &ClientId {
         event.client_id()
     }
 }

--- a/crates/relayer/relayer-components/src/chain/traits/types/create_client.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/create_client.rs
@@ -15,6 +15,7 @@ pub trait HasCreateClientPayloadType<Counterparty>: Async {
     type CreateClientPayload: Async;
 }
 
+#[derive_component(CreateClientEventComponent, ProvideCreateClientEvent<Chain>)]
 pub trait HasCreateClientEvent<Counterparty>: HasIbcChainTypes<Counterparty> {
     type CreateClientEvent: Async;
 

--- a/crates/relayer/relayer-components/src/relay/impls/create_client.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/create_client.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_core::{async_trait, CanRaiseError};
+use cgp_core::CanRaiseError;
 
 use crate::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use crate::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
@@ -44,7 +44,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Relay, Target, TargetChain, CounterpartyChain> ClientCreator<Relay, Target>
     for CreateClientWithChains
 where

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/types.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/types.rs
@@ -11,7 +11,7 @@ use hermes_relayer_components::chain::traits::types::connection::{
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::ProvideConsensusStateType;
 use hermes_relayer_components::chain::traits::types::create_client::{
-    HasCreateClientEvent, ProvideCreateClientOptionsType, ProvideCreateClientPayloadType,
+    ProvideCreateClientEvent, ProvideCreateClientOptionsType, ProvideCreateClientPayloadType,
 };
 use hermes_relayer_components::chain::traits::types::ibc_events::connection::HasConnectionOpenInitEvent;
 use hermes_relayer_components::chain::traits::types::packets::ack::ProvideAckPacketPayloadType;
@@ -195,20 +195,23 @@ where
     type TimeoutUnorderedPacketPayload = SolomachineTimeoutUnorderedPacketPayload;
 }
 
-impl<Chain, Counterparty> HasCreateClientEvent<Counterparty> for SolomachineChain<Chain>
+impl<Chain, Counterparty> ProvideCreateClientEvent<SolomachineChain<Chain>, Counterparty>
+    for SolomachineChainComponents
 where
     Chain: Async,
 {
     type CreateClientEvent = SolomachineCreateClientEvent;
 
-    fn try_extract_create_client_event(event: Self::Event) -> Option<Self::CreateClientEvent> {
+    fn try_extract_create_client_event(
+        event: SolomachineEvent,
+    ) -> Option<SolomachineCreateClientEvent> {
         match event {
             SolomachineEvent::CreateClient(e) => Some(e),
             _ => None,
         }
     }
 
-    fn create_client_event_client_id(event: &Self::CreateClientEvent) -> &ClientId {
+    fn create_client_event_client_id(event: &SolomachineCreateClientEvent) -> &ClientId {
         &event.client_id
     }
 }

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/components.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/components.rs
@@ -31,12 +31,12 @@ use hermes_relayer_components::transaction::traits::types::tx_response::TxRespon
 use hermes_sovereign_rollup_components::impls::cosmos_to_sovereign::client::create_client_message::BuildCreateCosmosClientMessageOnSovereign;
 use hermes_sovereign_rollup_components::impls::cosmos_to_sovereign::client::update_client_message::BuildUpdateCosmosClientMessageOnSovereign;
 use hermes_sovereign_rollup_components::impls::events::ProvideSovereignEvents;
-use hermes_sovereign_rollup_components::impls::types::chain::ProvideSovereignChainTypes;
 use hermes_sovereign_rollup_components::impls::types::transaction::ProvideSovereignTransactionTypes;
 
 use crate::sovereign::impls::sovereign_to_cosmos::client::create_client_payload::BuildSovereignCreateClientPayload;
 use crate::sovereign::impls::sovereign_to_cosmos::client::update_client_payload::BuildSovereignUpdateClientPayload;
 use crate::sovereign::impls::sovereign_to_cosmos::connection::connection_handshake_payload::BuildSovereignConnectionHandshakePayload;
+use crate::sovereign::impls::types::chain::ProvideSovereignChainTypes;
 use crate::sovereign::impls::types::client_state::ProvideSovereignClientState;
 use crate::sovereign::impls::types::payload::ProvideSovereignPayloadTypes;
 

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/components/chain.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/components/chain.rs
@@ -13,7 +13,7 @@ use hermes_relayer_components::chain::traits::types::connection::{
     ConnectionHandshakePayloadTypeComponent, InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::create_client::{
-    CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    CreateClientEventComponent, CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
 use hermes_relayer_components::chain::traits::types::height::HeightTypeComponent;
@@ -30,6 +30,7 @@ use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionH
 use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
 use hermes_sovereign_rollup_components::impls::cosmos_to_sovereign::client::create_client_message::BuildCreateCosmosClientMessageOnSovereign;
 use hermes_sovereign_rollup_components::impls::cosmos_to_sovereign::client::update_client_message::BuildUpdateCosmosClientMessageOnSovereign;
+use hermes_sovereign_rollup_components::impls::events::ProvideSovereignEvents;
 use hermes_sovereign_rollup_components::impls::types::chain::ProvideSovereignChainTypes;
 use hermes_sovereign_rollup_components::impls::types::transaction::ProvideSovereignTransactionTypes;
 
@@ -54,6 +55,10 @@ delegate_components! {
             IbcPacketTypesProviderComponent,
         ]:
             ProvideSovereignChainTypes,
+        [
+            CreateClientEventComponent,
+        ]:
+            ProvideSovereignEvents,
         [
             CreateClientOptionsTypeComponent,
             CreateClientPayloadTypeComponent,

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/components/mod.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/components/mod.rs
@@ -1,1 +1,0 @@
-pub mod chain;

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/impls/types/chain.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/impls/types/chain.rs
@@ -1,0 +1,37 @@
+use cgp_core::prelude::*;
+use hermes_relayer_components::chain::traits::types::chain_id::ProvideChainIdType;
+use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
+use hermes_relayer_components::chain::traits::types::height::HeightTypeComponent;
+use hermes_relayer_components::chain::traits::types::ibc::IbcChainTypesComponent;
+use hermes_relayer_components::chain::traits::types::message::MessageTypeComponent;
+use hermes_relayer_components::chain::traits::types::packet::IbcPacketTypesProviderComponent;
+use hermes_relayer_components::chain::traits::types::timestamp::TimestampTypeComponent;
+use hermes_sovereign_rollup_components::impls::types::rollup::ProvideSovereignRollupTypes;
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
+
+pub struct ProvideSovereignChainTypes;
+
+delegate_components! {
+    ProvideSovereignChainTypes {
+        [
+            HeightTypeComponent,
+            TimestampTypeComponent,
+            MessageTypeComponent,
+            EventTypeComponent,
+            IbcChainTypesComponent,
+            IbcPacketTypesProviderComponent,
+        ]:
+            ProvideSovereignRollupTypes,
+
+    }
+}
+
+impl<Chain> ProvideChainIdType<Chain> for ProvideSovereignChainTypes
+where
+    Chain: Async,
+{
+    // TODO: A rollup chain ID should be a composite of the rollup ID
+    // and the DA chain ID. But for now we will handle only the DA chain ID
+    // for simplicity.
+    type ChainId = ChainId;
+}

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/impls/types/mod.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/impls/types/mod.rs
@@ -1,2 +1,3 @@
+pub mod chain;
 pub mod client_state;
 pub mod payload;

--- a/crates/sovereign/sovereign-integration-tests/src/impls/build_rollup_driver.rs
+++ b/crates/sovereign/sovereign-integration-tests/src/impls/build_rollup_driver.rs
@@ -27,7 +27,8 @@ where
         + HasRollupDriverType<RollupDriver = SovereignRollupDriver>
         + HasRollupNodeConfigType<RollupNodeConfig = SovereignRollupNodeConfig>
         + HasRollupGenesisConfigType<RollupGenesisConfig = SovereignGenesisConfig>
-        + CanRaiseError<ClientError>,
+        + CanRaiseError<ClientError>
+        + CanRaiseError<&'static str>,
 {
     async fn build_rollup_driver(
         bootstrap: &Bootstrap,
@@ -43,7 +44,15 @@ where
             .build(rpc_url)
             .map_err(Bootstrap::raise_error)?;
 
-        let rollup = SovereignRollup::new(bootstrap.runtime().clone(), rpc_client);
+        let relayer_wallet = wallets
+            .get("relayer")
+            .ok_or_else(|| Bootstrap::raise_error("expect relayer wallet"))?;
+
+        let rollup = SovereignRollup::new(
+            bootstrap.runtime().clone(),
+            rpc_client,
+            relayer_wallet.signing_key.clone(),
+        );
 
         Ok(SovereignRollupDriver {
             rollup,

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -10,12 +10,13 @@ use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
 use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
 use hermes_cosmos_relayer::types::error::Error;
 use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
-use hermes_relayer_components::relay::traits::target::DestinationTarget;
+use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_sovereign_chain_components::sovereign::traits::chain::rollup::HasRollup;
 use hermes_sovereign_integration_tests::contexts::bootstrap::SovereignBootstrap;
 use hermes_sovereign_relayer::contexts::cosmos_to_sovereign_relay::CosmosToSovereignRelay;
 use hermes_sovereign_relayer::contexts::sovereign_chain::SovereignChain;
+use hermes_sovereign_relayer::contexts::sovereign_to_cosmos_relay::SovereignToCosmosRelay;
 use hermes_sovereign_test_components::bootstrap::traits::bootstrap_rollup::CanBootstrapRollup;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
 use hermes_test_components::chain_driver::traits::types::chain::HasChain;
@@ -107,9 +108,19 @@ fn test_cosmos_to_sovereign() -> Result<(), Error> {
                 cosmos_chain,
                 &create_client_settings,
             )
-            .await;
+            .await?;
 
             println!("client ID of Cosmos on Sovereign: {:?}", client_id);
+
+            let client_id = SovereignToCosmosRelay::create_client(
+                SourceTarget,
+                &sovereign_chain,
+                cosmos_chain,
+                &create_client_settings,
+            )
+            .await?;
+
+            println!("client ID 2 of Cosmos on Sovereign: {:?}", client_id);
         }
 
         <Result<(), Error>>::Ok(())

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -17,6 +17,7 @@ use hermes_relayer_components::transaction::traits::send_messages_with_signer::C
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_sovereign_chain_components::sovereign::traits::chain::rollup::HasRollup;
 use hermes_sovereign_integration_tests::contexts::bootstrap::SovereignBootstrap;
+use hermes_sovereign_relayer::contexts::cosmos_to_sovereign_relay::CosmosToSovereignRelay;
 use hermes_sovereign_relayer::contexts::sovereign_chain::SovereignChain;
 use hermes_sovereign_relayer::contexts::sovereign_rollup::SovereignRollup;
 use hermes_sovereign_test_components::bootstrap::traits::bootstrap_rollup::CanBootstrapRollup;
@@ -88,6 +89,12 @@ fn test_cosmos_to_sovereign() -> Result<(), Error> {
 
         let cosmos_chain = cosmos_chain_driver.chain();
         let rollup = rollup_driver.rollup();
+
+        let sovereign_chain = SovereignChain {
+            runtime: runtime.clone(),
+            data_chain: celestia_chain_driver.chain().clone(),
+            rollup: rollup.clone(),
+        };
 
         {
             let create_client_settings = ClientSettings::Tendermint(Settings {

--- a/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/cosmos_to_sovereign.rs
@@ -4,22 +4,18 @@ use core::time::Duration;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use eyre::eyre;
 use hermes_celestia_integration_tests::contexts::bootstrap::CelestiaBootstrap;
 use hermes_celestia_test_components::bootstrap::traits::bootstrap_bridge::CanBootstrapBridge;
 use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
 use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
-use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_relayer::types::error::Error;
-use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
-use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
-use hermes_relayer_components::transaction::traits::send_messages_with_signer::CanSendMessagesWithSigner;
+use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
+use hermes_relayer_components::relay::traits::target::DestinationTarget;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_sovereign_chain_components::sovereign::traits::chain::rollup::HasRollup;
 use hermes_sovereign_integration_tests::contexts::bootstrap::SovereignBootstrap;
 use hermes_sovereign_relayer::contexts::cosmos_to_sovereign_relay::CosmosToSovereignRelay;
 use hermes_sovereign_relayer::contexts::sovereign_chain::SovereignChain;
-use hermes_sovereign_relayer::contexts::sovereign_rollup::SovereignRollup;
 use hermes_sovereign_test_components::bootstrap::traits::bootstrap_rollup::CanBootstrapRollup;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
 use hermes_test_components::chain_driver::traits::types::chain::HasChain;
@@ -105,30 +101,15 @@ fn test_cosmos_to_sovereign() -> Result<(), Error> {
 
             sleep(Duration::from_secs(2)).await;
 
-            let create_client_payload = <CosmosChain as CanBuildCreateClientPayload<
-                SovereignChain,
-            >>::build_create_client_payload(
-                cosmos_chain, &create_client_settings
+            let client_id = CosmosToSovereignRelay::create_client(
+                DestinationTarget,
+                &sovereign_chain,
+                cosmos_chain,
+                &create_client_settings,
             )
-            .await?;
+            .await;
 
-            let create_client_message = <SovereignRollup as CanBuildCreateClientMessage<
-                CosmosChain,
-            >>::build_create_client_message(
-                rollup, create_client_payload
-            )
-            .await?;
-
-            let wallet_a = rollup_driver
-                .wallets
-                .get("user-a")
-                .ok_or_else(|| eyre!("expect user-a wallet"))?;
-
-            let events = rollup
-                .send_messages_with_signer(&wallet_a.signing_key, &[create_client_message])
-                .await?;
-
-            println!("CreateClient events: {:?}", events);
+            println!("client ID of Cosmos on Sovereign: {:?}", client_id);
         }
 
         <Result<(), Error>>::Ok(())

--- a/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use eyre::eyre;
 use hermes_celestia_integration_tests::contexts::bootstrap::CelestiaBootstrap;
+use hermes_celestia_test_components::bootstrap::traits::bootstrap_bridge::CanBootstrapBridge;
 use hermes_cosmos_chain_components::types::connection::CosmosInitConnectionOptions;
 use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
 use hermes_cosmos_integration_tests::contexts::chain_driver::CosmosChainDriver;
@@ -28,8 +29,10 @@ use hermes_relayer_components::chain::traits::send_message::CanSendSingleMessage
 use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientEvent;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_sovereign_chain_components::sovereign::types::payloads::client::SovereignCreateClientOptions;
+use hermes_sovereign_integration_tests::contexts::bootstrap::SovereignBootstrap;
 use hermes_sovereign_relayer::contexts::sovereign_chain::SovereignChain;
 use hermes_sovereign_rollup_components::types::height::RollupHeight;
+use hermes_sovereign_test_components::bootstrap::traits::bootstrap_rollup::CanBootstrapRollup;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
 use hermes_test_components::chain_driver::traits::types::chain::HasChain;
 use hermes_wasm_client_components::contexts::wasm_counterparty::WasmCounterparty;
@@ -65,6 +68,8 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
         rand::random::<u64>()
     );
 
+    let store_dir = std::env::current_dir()?.join(format!("test-data/{store_postfix}"));
+
     // TODO: load parameters from environment variables
     let bootstrap = Arc::new(CosmosBootstrap {
         runtime: runtime.clone(),
@@ -75,58 +80,7 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
         account_prefix: "sov".into(),
         staking_denom: "stake".into(),
         transfer_denom: "coin".into(),
-        genesis_config_modifier: Box::new(|genesis| {
-            let max_deposit_period = genesis
-                .get_mut("app_state")
-                .and_then(|app_state| app_state.get_mut("gov"))
-                .and_then(|gov| gov.get_mut("params"))
-                .and_then(|deposit_params| deposit_params.as_object_mut())
-                .ok_or_else(|| {
-                    eyre!("Failed to retrieve `deposit_params` in genesis configuration")
-                })?;
-
-            max_deposit_period
-                .insert(
-                    "max_deposit_period".to_owned(),
-                    JsonValue::String("10s".to_owned()),
-                )
-                .ok_or_else(|| {
-                    eyre!("Failed to update `max_deposit_period` in genesis configuration")
-                })?;
-
-            let voting_period = genesis
-                .get_mut("app_state")
-                .and_then(|app_state| app_state.get_mut("gov"))
-                .and_then(|gov| gov.get_mut("params"))
-                .and_then(|voting_params| voting_params.as_object_mut())
-                .ok_or_else(|| {
-                    eyre!("Failed to retrieve `voting_params` in genesis configuration")
-                })?;
-
-            voting_period
-                .insert(
-                    "voting_period".to_owned(),
-                    serde_json::Value::String("10s".to_owned()),
-                )
-                .ok_or_else(|| {
-                    eyre!("Failed to update `voting_period` in genesis configuration")
-                })?;
-
-            let allowed_clients = genesis
-                .get_mut("app_state")
-                .and_then(|app_state| app_state.get_mut("ibc"))
-                .and_then(|ibc| ibc.get_mut("client_genesis"))
-                .and_then(|client_genesis| client_genesis.get_mut("params"))
-                .and_then(|params| params.get_mut("allowed_clients"))
-                .and_then(|allowed_clients| allowed_clients.as_array_mut())
-                .ok_or_else(|| {
-                    eyre!("Failed to retrieve `allowed_clients` in genesis configuration")
-                })?;
-
-            allowed_clients.push(JsonValue::String("08-wasm".to_string()));
-
-            Ok(())
-        }),
+        genesis_config_modifier: Box::new(modify_wasm_client_genesis),
         comet_config_modifier: Box::new(|config| {
             config
                 .get_mut("rpc")
@@ -145,6 +99,13 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
         builder,
         chain_store_dir: format!("./test-data/{store_postfix}/chains").into(),
         bridge_store_dir: format!("./test-data/{store_postfix}/bridges").into(),
+    };
+
+    let sovereign_bootstrap = SovereignBootstrap {
+        runtime: runtime.clone(),
+        rollup_store_dir: store_dir.join("rollups"),
+        rollup_command_path: "node".into(),
+        account_prefix: "sov".into(),
     };
 
     let create_client_settings = ClientSettings::Tendermint(Settings {
@@ -184,6 +145,14 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
 
         let celestia_chain = celestia_chain_driver.chain();
 
+        let bridge_driver = celestia_bootstrap
+            .bootstrap_bridge(&celestia_chain_driver)
+            .await?;
+
+        let rollup_driver = sovereign_bootstrap
+            .bootstrap_rollup(&celestia_chain_driver, &bridge_driver, "test-rollup")
+            .await?;
+
         // Upload Wasm contract on Cosmos chain
         cosmos_chain_driver.store_wasm_client_code(
             &wasm_client_code_path,
@@ -205,6 +174,7 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
         let sovereign_chain = SovereignChain {
             runtime: runtime.clone(),
             data_chain: celestia_chain.clone(),
+            rollup: rollup_driver.rollup,
         };
 
         // Create Sovereign client on Cosmos chain
@@ -323,4 +293,47 @@ async fn assert_eventual_governance_status(
         }
     }
     Err(eyre!("Governance proposal `{governance_id}` was not in status `{expected_status}`").into())
+}
+
+fn modify_wasm_client_genesis(genesis: &mut serde_json::Value) -> Result<(), Error> {
+    let max_deposit_period = genesis
+        .get_mut("app_state")
+        .and_then(|app_state| app_state.get_mut("gov"))
+        .and_then(|gov| gov.get_mut("params"))
+        .and_then(|deposit_params| deposit_params.as_object_mut())
+        .ok_or_else(|| eyre!("Failed to retrieve `deposit_params` in genesis configuration"))?;
+
+    max_deposit_period
+        .insert(
+            "max_deposit_period".to_owned(),
+            JsonValue::String("10s".to_owned()),
+        )
+        .ok_or_else(|| eyre!("Failed to update `max_deposit_period` in genesis configuration"))?;
+
+    let voting_period = genesis
+        .get_mut("app_state")
+        .and_then(|app_state| app_state.get_mut("gov"))
+        .and_then(|gov| gov.get_mut("params"))
+        .and_then(|voting_params| voting_params.as_object_mut())
+        .ok_or_else(|| eyre!("Failed to retrieve `voting_params` in genesis configuration"))?;
+
+    voting_period
+        .insert(
+            "voting_period".to_owned(),
+            serde_json::Value::String("10s".to_owned()),
+        )
+        .ok_or_else(|| eyre!("Failed to update `voting_period` in genesis configuration"))?;
+
+    let allowed_clients = genesis
+        .get_mut("app_state")
+        .and_then(|app_state| app_state.get_mut("ibc"))
+        .and_then(|ibc| ibc.get_mut("client_genesis"))
+        .and_then(|client_genesis| client_genesis.get_mut("params"))
+        .and_then(|params| params.get_mut("allowed_clients"))
+        .and_then(|allowed_clients| allowed_clients.as_array_mut())
+        .ok_or_else(|| eyre!("Failed to retrieve `allowed_clients` in genesis configuration"))?;
+
+    allowed_clients.push(JsonValue::String("08-wasm".to_string()));
+
+    Ok(())
 }

--- a/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/create_client.rs
@@ -7,7 +7,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use eyre::eyre;
 use hermes_celestia_integration_tests::contexts::bootstrap::CelestiaBootstrap;
-use hermes_cosmos_chain_components::methods::event::try_extract_create_client_event;
 use hermes_cosmos_chain_components::types::connection::CosmosInitConnectionOptions;
 use hermes_cosmos_integration_tests::contexts::bootstrap::CosmosBootstrap;
 use hermes_cosmos_integration_tests::contexts::chain_driver::CosmosChainDriver;
@@ -26,6 +25,7 @@ use hermes_relayer_components::chain::traits::payload_builders::create_client::C
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
 use hermes_relayer_components::chain::traits::send_message::CanSendSingleMessage;
+use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientEvent;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_sovereign_chain_components::sovereign::types::payloads::client::SovereignCreateClientOptions;
 use hermes_sovereign_relayer::contexts::sovereign_chain::SovereignChain;
@@ -237,7 +237,9 @@ pub fn test_create_sovereign_client_on_cosmos() -> Result<(), Error> {
 
         let events = cosmos_chain.send_message(create_celestia_client_message).await?;
 
-        let create_client_event = events.into_iter().find_map(try_extract_create_client_event).ok_or_else(|| eyre!("Could not extract Celestia create client event"))?;
+        let create_client_event = events.into_iter()
+            .find_map(<CosmosChain as HasCreateClientEvent<CosmosChain>>::try_extract_create_client_event)
+            .ok_or_else(|| eyre!("Could not extract Celestia create client event"))?;
 
         let celestia_client_id = create_client_event.client_id;
 

--- a/crates/sovereign/sovereign-relayer/Cargo.toml
+++ b/crates/sovereign/sovereign-relayer/Cargo.toml
@@ -36,6 +36,7 @@ ibc-relayer-types                       = { workspace = true }
 ibc-proto                               = { workspace = true }
 sov-celestia-client                     = { workspace = true }
 
+eyre            = { workspace = true }
 futures         = { workspace = true }
 ed25519-dalek   = { workspace = true }
 jsonrpsee       = { workspace = true, features = ["http-client"] }

--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -10,7 +10,7 @@ use hermes_relayer_components::relay::traits::chains::{
     CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
 };
 use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
-use hermes_relayer_components::relay::traits::target::SourceTarget;
+use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
@@ -31,7 +31,8 @@ pub struct CosmosToSovereignRelay {
 pub trait CanUseCosmosToSovereignRelay:
     HasRelayChains<SrcChain = CosmosChain, DstChain = SovereignChain>
     + CanRaiseRelayChainErrors
-    // + CanCreateClient<SourceTarget>
+    + CanCreateClient<SourceTarget>
+    // + CanCreateClient<DestinationTarget>
     + for<'a> CanRaiseError<MissingCreateClientEventError<'a, CosmosChain, SovereignChain>>
     + for<'a> CanRaiseError<MissingCreateClientEventError<'a, SovereignChain, CosmosChain>>
 {

--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -1,10 +1,11 @@
 use cgp_core::prelude::*;
-use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp_core::{delegate_all, CanRaiseError, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_components::components::default::relay::{
     DefaultRelayComponents, IsDefaultRelayComponent,
 };
+use hermes_relayer_components::relay::impls::create_client::MissingCreateClientEventError;
 use hermes_relayer_components::relay::traits::chains::{
     CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
 };
@@ -26,7 +27,10 @@ pub struct CosmosToSovereignRelay {
 }
 
 pub trait CanUseCosmosToSovereignRelay:
-    HasRelayChains<SrcChain = CosmosChain, DstChain = SovereignChain> + CanRaiseRelayChainErrors
+    HasRelayChains<SrcChain = CosmosChain, DstChain = SovereignChain>
+    + CanRaiseRelayChainErrors
+    + for<'a> CanRaiseError<MissingCreateClientEventError<'a, CosmosChain, SovereignChain>>
+    + for<'a> CanRaiseError<MissingCreateClientEventError<'a, SovereignChain, CosmosChain>>
 {
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -1,11 +1,10 @@
 use cgp_core::prelude::*;
-use cgp_core::{delegate_all, CanRaiseError, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_components::components::default::relay::{
     DefaultRelayComponents, IsDefaultRelayComponent,
 };
-use hermes_relayer_components::relay::impls::create_client::MissingCreateClientEventError;
 use hermes_relayer_components::relay::traits::chains::{
     CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
 };
@@ -33,8 +32,6 @@ pub trait CanUseCosmosToSovereignRelay:
     + CanRaiseRelayChainErrors
     + CanCreateClient<SourceTarget>
     + CanCreateClient<DestinationTarget>
-    + for<'a> CanRaiseError<MissingCreateClientEventError<'a, CosmosChain, SovereignChain>>
-    + for<'a> CanRaiseError<MissingCreateClientEventError<'a, SovereignChain, CosmosChain>>
 {
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -9,6 +9,8 @@ use hermes_relayer_components::relay::impls::create_client::MissingCreateClientE
 use hermes_relayer_components::relay::traits::chains::{
     CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
 };
+use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
+use hermes_relayer_components::relay::traits::target::SourceTarget;
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
@@ -29,6 +31,7 @@ pub struct CosmosToSovereignRelay {
 pub trait CanUseCosmosToSovereignRelay:
     HasRelayChains<SrcChain = CosmosChain, DstChain = SovereignChain>
     + CanRaiseRelayChainErrors
+    // + CanCreateClient<SourceTarget>
     + for<'a> CanRaiseError<MissingCreateClientEventError<'a, CosmosChain, SovereignChain>>
     + for<'a> CanRaiseError<MissingCreateClientEventError<'a, SovereignChain, CosmosChain>>
 {

--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -32,7 +32,7 @@ pub trait CanUseCosmosToSovereignRelay:
     HasRelayChains<SrcChain = CosmosChain, DstChain = SovereignChain>
     + CanRaiseRelayChainErrors
     + CanCreateClient<SourceTarget>
-    // + CanCreateClient<DestinationTarget>
+    + CanCreateClient<DestinationTarget>
     + for<'a> CanRaiseError<MissingCreateClientEventError<'a, CosmosChain, SovereignChain>>
     + for<'a> CanRaiseError<MissingCreateClientEventError<'a, SovereignChain, CosmosChain>>
 {

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -8,6 +8,7 @@ use hermes_encoding_components::traits::has_encoding::{
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
+use hermes_relayer_components::chain::traits::send_message::CanSendMessages;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
 use hermes_relayer_components::chain::traits::types::chain_id::{ChainIdGetter, HasChainIdType};
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -10,7 +10,9 @@ use hermes_relayer_components::chain::traits::payload_builders::connection_hands
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
-use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientOptionsType;
+use hermes_relayer_components::chain::traits::types::create_client::{
+    HasCreateClientEvent, HasCreateClientOptionsType,
+};
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
@@ -87,6 +89,7 @@ impl RuntimeGetter<SovereignChain> for SovereignChainComponents {
 
 pub trait CanUseSovereignChain:
     HasDataChain
+    + HasChainIdType
     + HasUpdateClientPayloadType<CosmosChain>
     + HasHeightType<Height = RollupHeight>
     + HasClientStateType<CosmosChain, ClientState = SovereignClientState>
@@ -95,7 +98,7 @@ pub trait CanUseSovereignChain:
     + CanBuildConnectionHandshakePayloads<CosmosChain>
     + CanBuildCreateClientMessage<CosmosChain>
     + HasCreateClientOptionsType<CosmosChain>
-    + HasChainIdType
+    + HasCreateClientEvent<CosmosChain>
 {
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -8,7 +8,8 @@ use hermes_encoding_components::traits::has_encoding::{
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
-use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
+use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
+use hermes_relayer_components::chain::traits::types::chain_id::{ChainIdGetter, HasChainIdType};
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
 use hermes_relayer_components::chain::traits::types::create_client::{
     HasCreateClientEvent, HasCreateClientOptionsType,
@@ -18,7 +19,7 @@ use hermes_relayer_components::chain::traits::types::update_client::HasUpdateCli
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
-use hermes_sovereign_chain_components::sovereign::components::chain::{
+use hermes_sovereign_chain_components::sovereign::components::{
     IsSovereignChainClientComponent, SovereignChainClientComponents,
 };
 use hermes_sovereign_chain_components::sovereign::traits::chain::data_chain::{
@@ -27,6 +28,7 @@ use hermes_sovereign_chain_components::sovereign::traits::chain::data_chain::{
 };
 use hermes_sovereign_chain_components::sovereign::types::client_state::SovereignClientState;
 use hermes_sovereign_rollup_components::types::height::RollupHeight;
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 
 use crate::contexts::encoding::{ProvideSovereignEncoding, SovereignEncoding};
 use crate::contexts::sovereign_rollup::SovereignRollup;
@@ -85,6 +87,12 @@ delegate_components! {
 impl RuntimeGetter<SovereignChain> for SovereignChainComponents {
     fn runtime(chain: &SovereignChain) -> &HermesRuntime {
         &chain.runtime
+    }
+}
+
+impl ChainIdGetter<SovereignChain> for SovereignChainComponents {
+    fn chain_id(chain: &SovereignChain) -> &ChainId {
+        chain.data_chain.chain_id()
     }
 }
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -29,11 +29,12 @@ use hermes_sovereign_chain_components::sovereign::types::client_state::Sovereign
 use hermes_sovereign_rollup_components::types::height::RollupHeight;
 
 use crate::contexts::encoding::{ProvideSovereignEncoding, SovereignEncoding};
+use crate::contexts::sovereign_rollup::SovereignRollup;
 
 pub struct SovereignChain {
     pub runtime: HermesRuntime,
     pub data_chain: CosmosChain,
-    // TODO: fields such as rollup JSON RPC address
+    pub rollup: SovereignRollup,
 }
 
 pub struct SovereignChainComponents;

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -14,7 +14,9 @@ use hermes_relayer_components::chain::traits::message_builders::create_client::{
     CanBuildCreateClientMessage, CreateClientMessageBuilderComponent,
 };
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
+use hermes_relayer_components::chain::traits::send_message::{
+    CanSendMessages, MessageSenderComponent,
+};
 use hermes_relayer_components::chain::traits::types::chain_id::{
     ChainIdGetter, ChainIdTypeComponent, HasChainId,
 };
@@ -30,6 +32,7 @@ use hermes_relayer_components::chain::traits::types::timestamp::TimestampTypeCom
 use hermes_relayer_components::error::impls::retry::ReturnRetryable;
 use hermes_relayer_components::error::traits::retry::RetryableErrorComponent;
 use hermes_relayer_components::transaction::impls::poll_tx_response::PollTimeoutGetterComponent;
+use hermes_relayer_components::transaction::traits::default_signer::DefaultSignerGetter;
 use hermes_relayer_components::transaction::traits::encode_tx::{CanEncodeTx, TxEncoderComponent};
 use hermes_relayer_components::transaction::traits::estimate_tx_fee::{
     CanEstimateTxFee, TxFeeEstimatorComponent,
@@ -94,22 +97,26 @@ use hermes_test_components::chain::traits::types::amount::AmountTypeComponent;
 use hermes_test_components::chain::traits::types::denom::DenomTypeComponent;
 use hermes_test_components::chain::traits::types::wallet::WalletTypeComponent;
 use jsonrpsee::http_client::HttpClient;
+use std::sync::Arc;
 
 use crate::contexts::encoding::ProvideSovereignEncoding;
 use crate::contexts::logger::ProvideSovereignLogger;
 
+#[derive(Clone)]
 pub struct SovereignRollup {
     pub runtime: HermesRuntime,
     pub rpc_client: HttpClient,
-    pub nonce_mutex: Mutex<()>,
+    pub signing_key: SigningKey,
+    pub nonce_mutex: Arc<Mutex<()>>,
 }
 
 impl SovereignRollup {
-    pub fn new(runtime: HermesRuntime, rpc_client: HttpClient) -> Self {
+    pub fn new(runtime: HermesRuntime, rpc_client: HttpClient, signing_key: SigningKey) -> Self {
         Self {
             runtime,
             rpc_client,
-            nonce_mutex: Mutex::new(()),
+            signing_key,
+            nonce_mutex: Arc::new(Mutex::new(())),
         }
     }
 }
@@ -213,6 +220,12 @@ impl ChainIdGetter<SovereignRollup> for SovereignRollupComponents {
     }
 }
 
+impl DefaultSignerGetter<SovereignRollup> for SovereignRollupComponents {
+    fn get_default_signer(rollup: &SovereignRollup) -> &SigningKey {
+        &rollup.signing_key
+    }
+}
+
 impl ProvideMutexForNonceAllocation<SovereignRollup> for SovereignRollupComponents {
     fn mutex_for_nonce_allocation<'a>(
         rollup: &'a SovereignRollup,
@@ -240,6 +253,7 @@ pub trait CanUseSovereignRollup:
     + HasMutexForNonceAllocation
     + CanQueryNonce
     + CanAllocateNonce
+    + CanSendMessages
     + CanSendMessagesWithSigner
     + CanSendMessagesWithSignerAndNonce
     + CanQueryTxResponse

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -18,6 +18,9 @@ use hermes_relayer_components::chain::traits::send_message::MessageSenderCompone
 use hermes_relayer_components::chain::traits::types::chain_id::{
     ChainIdGetter, ChainIdTypeComponent, HasChainId,
 };
+use hermes_relayer_components::chain::traits::types::create_client::{
+    CreateClientEventComponent, HasCreateClientEvent,
+};
 use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
 use hermes_relayer_components::chain::traits::types::height::HeightTypeComponent;
 use hermes_relayer_components::chain::traits::types::ibc::IbcChainTypesComponent;
@@ -155,6 +158,8 @@ delegate_components! {
             TransactionHashTypeComponent,
             TxResponseTypeComponent,
 
+            CreateClientEventComponent,
+
             NonceAllocatorComponent,
             MessageSenderComponent,
             MessagesWithSignerSenderComponent,
@@ -242,6 +247,7 @@ pub trait CanUseSovereignRollup:
     + CanAssertEventualAmount
     + HasLogger
     + CanBuildCreateClientMessage<CosmosChain>
+    + HasCreateClientEvent<CosmosChain>
 where
     Self::Runtime: HasMutex,
 {

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_to_cosmos_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_to_cosmos_relay.rs
@@ -1,8 +1,15 @@
 use cgp_core::prelude::*;
-use cgp_core::{ErrorRaiserComponent, ErrorTypeComponent};
+use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
-use hermes_relayer_components::relay::traits::chains::ProvideRelayChains;
+use hermes_relayer_components::components::default::relay::{
+    DefaultRelayComponents, IsDefaultRelayComponent,
+};
+use hermes_relayer_components::relay::traits::chains::{
+    CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
+};
+use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
+use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
@@ -20,11 +27,27 @@ pub struct SovereignToCosmosRelay {
     // TODO: Relay fields
 }
 
+pub trait CanUseSovereignToCosmosRelay:
+    HasRelayChains<SrcChain = SovereignChain, DstChain = CosmosChain>
+    + CanRaiseRelayChainErrors
+    + CanCreateClient<SourceTarget>
+    + CanCreateClient<DestinationTarget>
+{
+}
+
+impl CanUseSovereignToCosmosRelay for SovereignToCosmosRelay {}
+
 pub struct SovereignToCosmosRelayComponents;
 
 impl HasComponents for SovereignToCosmosRelay {
     type Components = SovereignToCosmosRelayComponents;
 }
+
+delegate_all!(
+    IsDefaultRelayComponent,
+    DefaultRelayComponents,
+    SovereignToCosmosRelayComponents,
+);
 
 delegate_components! {
     SovereignToCosmosRelayComponents {

--- a/crates/sovereign/sovereign-rollup-components/src/components.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/components.rs
@@ -11,7 +11,7 @@ use hermes_relayer_components::chain::traits::types::connection::{
     ConnectionHandshakePayloadTypeComponent, InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::create_client::{
-    CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    CreateClientEventComponent, CreateClientOptionsTypeComponent, CreateClientPayloadTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
 use hermes_relayer_components::chain::traits::types::height::HeightTypeComponent;
@@ -43,6 +43,7 @@ use hermes_relayer_components::transaction::traits::types::tx_response::TxRespon
 
 use crate::impls::cosmos_to_sovereign::client::create_client_message::BuildCreateCosmosClientMessageOnSovereign;
 use crate::impls::cosmos_to_sovereign::client::update_client_message::BuildUpdateCosmosClientMessageOnSovereign;
+use crate::impls::events::ProvideSovereignEvents;
 use crate::impls::json_rpc_client::ProvideJsonRpseeClient;
 use crate::impls::transaction::encode_tx::EncodeSovereignTx;
 use crate::impls::transaction::estimate_fee::ReturnSovereignTxFee;
@@ -70,6 +71,10 @@ delegate_components! {
             IbcPacketTypesProviderComponent,
         ]:
             ProvideSovereignChainTypes,
+        [
+            CreateClientEventComponent,
+        ]:
+            ProvideSovereignEvents,
         [
             CreateClientOptionsTypeComponent,
             CreateClientPayloadTypeComponent,

--- a/crates/sovereign/sovereign-rollup-components/src/components.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/components.rs
@@ -51,8 +51,8 @@ use crate::impls::transaction::event::ParseSovTxResponseAsEvents;
 use crate::impls::transaction::query_nonce::QuerySovereignNonce;
 use crate::impls::transaction::query_tx_response::QuerySovereignTxResponse;
 use crate::impls::transaction::submit_tx::SubmitSovereignTransaction;
-use crate::impls::types::chain::ProvideSovereignChainTypes;
 use crate::impls::types::payload::ProvideSovereignRollupPayloadTypes;
+use crate::impls::types::rollup::ProvideSovereignRollupTypes;
 use crate::impls::types::transaction::ProvideSovereignTransactionTypes;
 use crate::traits::json_rpc_client::JsonRpcClientTypeComponent;
 
@@ -70,7 +70,7 @@ delegate_components! {
             IbcChainTypesComponent,
             IbcPacketTypesProviderComponent,
         ]:
-            ProvideSovereignChainTypes,
+            ProvideSovereignRollupTypes,
         [
             CreateClientEventComponent,
         ]:

--- a/crates/sovereign/sovereign-rollup-components/src/impls/events.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/events.rs
@@ -1,0 +1,39 @@
+use hermes_cosmos_chain_components::types::events::client::CosmosCreateClientEvent;
+use hermes_relayer_components::chain::traits::types::create_client::ProvideCreateClientEvent;
+use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use ibc_relayer_types::core::ics24_host::identifier::ClientId;
+use serde_json::Value;
+
+use crate::types::event::SovereignEvent;
+
+pub struct ProvideSovereignEvents;
+
+impl<Chain, Counterparty> ProvideCreateClientEvent<Chain, Counterparty> for ProvideSovereignEvents
+where
+    Chain: HasIbcChainTypes<Counterparty, Event = SovereignEvent, ClientId = ClientId>,
+{
+    type CreateClientEvent = CosmosCreateClientEvent;
+
+    fn try_extract_create_client_event(event: SovereignEvent) -> Option<CosmosCreateClientEvent> {
+        if event.module_name != "ibc" {
+            return None;
+        }
+
+        let create_client_event_json = event.event_value.get("CreateClient")?;
+
+        let client_id_value = create_client_event_json
+            .get("client_id")?
+            .get("client_id")?;
+
+        if let Value::String(client_id_str) = client_id_value {
+            let client_id = client_id_str.parse().ok()?;
+            Some(CosmosCreateClientEvent { client_id })
+        } else {
+            None
+        }
+    }
+
+    fn create_client_event_client_id(event: &CosmosCreateClientEvent) -> &ClientId {
+        &event.client_id
+    }
+}

--- a/crates/sovereign/sovereign-rollup-components/src/impls/mod.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/mod.rs
@@ -1,5 +1,6 @@
 pub mod cosmos_to_sovereign;
 pub mod errors;
+pub mod events;
 pub mod json_rpc_client;
 pub mod sovereign_to_cosmos;
 pub mod transaction;

--- a/crates/sovereign/sovereign-rollup-components/src/impls/types/mod.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/types/mod.rs
@@ -1,4 +1,4 @@
-pub mod chain;
 pub mod client_state;
 pub mod payload;
+pub mod rollup;
 pub mod transaction;

--- a/crates/sovereign/sovereign-rollup-components/src/impls/types/rollup.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/types/rollup.rs
@@ -18,37 +18,37 @@ use crate::types::message::SovereignMessage;
 use crate::types::rollup_id::RollupId;
 use crate::types::status::SovereignRollupStatus;
 
-pub struct ProvideSovereignChainTypes;
+pub struct ProvideSovereignRollupTypes;
 
-impl<Chain> ProvideHeightType<Chain> for ProvideSovereignChainTypes
+impl<Chain> ProvideHeightType<Chain> for ProvideSovereignRollupTypes
 where
     Chain: Async,
 {
     type Height = RollupHeight;
 }
 
-impl<Chain> ProvideChainIdType<Chain> for ProvideSovereignChainTypes
+impl<Chain> ProvideChainIdType<Chain> for ProvideSovereignRollupTypes
 where
     Chain: Async,
 {
     type ChainId = RollupId;
 }
 
-impl<Chain> ProvideMessageType<Chain> for ProvideSovereignChainTypes
+impl<Chain> ProvideMessageType<Chain> for ProvideSovereignRollupTypes
 where
     Chain: Async,
 {
     type Message = SovereignMessage;
 }
 
-impl<Chain> ProvideEventType<Chain> for ProvideSovereignChainTypes
+impl<Chain> ProvideEventType<Chain> for ProvideSovereignRollupTypes
 where
     Chain: Async,
 {
     type Event = SovereignEvent;
 }
 
-impl<Chain> ProvideChainStatusType<Chain> for ProvideSovereignChainTypes
+impl<Chain> ProvideChainStatusType<Chain> for ProvideSovereignRollupTypes
 where
     Chain: HasHeightType<Height = RollupHeight> + HasTimestampType<Timestamp = Timestamp>,
 {
@@ -64,7 +64,7 @@ where
 }
 
 delegate_components! {
-    ProvideSovereignChainTypes {
+    ProvideSovereignRollupTypes {
         [
             TimestampTypeComponent,
             IbcChainTypesComponent,

--- a/crates/sovereign/sovereign-rollup-components/src/lib.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 pub mod components;
 pub mod impls;
 pub mod traits;


### PR DESCRIPTION
- The relay contexts `CosmosToSovereignRelay` and `SovereignToCosmosRelay` now implement `CanCreateClient` for both source and destination targets.
- The `cosmos_to_sovereign` test is updated to use the relay contexts to create a Cosmos client on Sovereign.