### PR TITLE
Implement `CanBuildTargetUpdateClientMessage` for Sovereign relay contexts

### DIFF
--- a/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/cosmos_to_sovereign_relay.rs
@@ -8,14 +8,12 @@ use hermes_logging_components::traits::has_logger::{
 use hermes_relayer_components::components::default::relay::{
     DefaultRelayComponents, IsDefaultRelayComponent,
 };
-use hermes_relayer_components::relay::impls::update_client::build::BuildUpdateClientMessages;
-use hermes_relayer_components::relay::impls::update_client::wait::WaitUpdateClient;
 use hermes_relayer_components::relay::traits::chains::{
     CanRaiseRelayChainErrors, HasRelayChains, ProvideRelayChains,
 };
 use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
-use hermes_relayer_components::relay::traits::update_client_message_builder::TargetUpdateClientMessageBuilder;
+use hermes_relayer_components::relay::traits::update_client_message_builder::CanBuildTargetUpdateClientMessage;
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
@@ -39,17 +37,18 @@ pub trait CanUseCosmosToSovereignRelay:
     + CanRaiseRelayChainErrors
     + CanCreateClient<SourceTarget>
     + CanCreateClient<DestinationTarget>
+    + CanBuildTargetUpdateClientMessage<DestinationTarget>
 {
 }
 
 impl CanUseCosmosToSovereignRelay for CosmosToSovereignRelay {}
 
-pub trait CanUseClientUpdateMessageBuilder:
-    TargetUpdateClientMessageBuilder<CosmosToSovereignRelay, DestinationTarget>
-{
-}
+// pub trait CanUseClientUpdateMessageBuilder:
+//     TargetUpdateClientMessageBuilder<CosmosToSovereignRelay, SourceTarget>
+// {
+// }
 
-impl CanUseClientUpdateMessageBuilder for WaitUpdateClient<BuildUpdateClientMessages> {}
+// impl CanUseClientUpdateMessageBuilder for SkipUpdateClient<WaitUpdateClient<BuildUpdateClientMessages>> {}
 
 pub struct CosmosToSovereignRelayComponents;
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -49,6 +49,7 @@ use crate::contexts::encoding::{ProvideSovereignEncoding, SovereignEncoding};
 use crate::contexts::logger::ProvideSovereignLogger;
 use crate::contexts::sovereign_rollup::SovereignRollup;
 
+#[derive(Clone)]
 pub struct SovereignChain {
     pub runtime: HermesRuntime,
     pub data_chain: CosmosChain,

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_to_cosmos_relay.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_to_cosmos_relay.rs
@@ -13,6 +13,7 @@ use hermes_relayer_components::relay::traits::chains::{
 };
 use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
+use hermes_relayer_components::relay::traits::update_client_message_builder::CanBuildTargetUpdateClientMessage;
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
@@ -36,6 +37,7 @@ pub trait CanUseSovereignToCosmosRelay:
     + CanRaiseRelayChainErrors
     + CanCreateClient<SourceTarget>
     + CanCreateClient<DestinationTarget>
+    + CanBuildTargetUpdateClientMessage<SourceTarget>
 {
 }
 


### PR DESCRIPTION
The trait `CanBuildTargetUpdateClientMessage` is now implemented for the Sovereign relay contexts