### PR TITLE
Split up connection handshake components

### DIFF
--- a/crates/cosmos/cosmos-chain-components/src/components/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/client.rs
@@ -10,7 +10,10 @@ use hermes_relayer_components::chain::impls::queries::consensus_state_height::Qu
 use hermes_relayer_components::chain::traits::commitment_prefix::CommitmentPrefixTypeComponent;
 use hermes_relayer_components::chain::traits::message_builders::ack_packet::AckPacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::receive_packet::ReceivePacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::timeout_unordered_packet::TimeoutUnorderedPacketMessageBuilderComponent;
@@ -19,7 +22,10 @@ use hermes_relayer_components::chain::traits::packet::fields::PacketFieldsReader
 use hermes_relayer_components::chain::traits::packet::from_write_ack::PacketFromWriteAckBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::ack_packet::AckPacketPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::channel_handshake::ChannelHandshakePayloadBuilderComponent;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    ConnectionOpenAckPayloadBuilderComponent, ConnectionOpenConfirmPayloadBuilderComponent,
+    ConnectionOpenInitPayloadBuilderComponent, ConnectionOpenTryPayloadBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::receive_packet::ReceivePacketPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::timeout_unordered_packet::TimeoutUnorderedPacketPayloadBuilderComponent;
@@ -65,8 +71,9 @@ use hermes_relayer_components::chain::traits::types::client_state::{
     ClientStateFieldsGetterComponent, ClientStateTypeComponent, RawClientStateTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::connection::{
-    ConnectionEndTypeComponent, ConnectionHandshakePayloadTypeComponent,
-    InitConnectionOptionsTypeComponent,
+    ConnectionEndTypeComponent, ConnectionOpenAckPayloadTypeComponent,
+    ConnectionOpenConfirmPayloadTypeComponent, ConnectionOpenInitPayloadTypeComponent,
+    ConnectionOpenTryPayloadTypeComponent, InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::{
     ConsensusStateTypeComponent, RawConsensusStateTypeComponent,
@@ -166,7 +173,10 @@ delegate_components! {
         [
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
-            ConnectionHandshakePayloadTypeComponent,
+            ConnectionOpenInitPayloadTypeComponent,
+            ConnectionOpenTryPayloadTypeComponent,
+            ConnectionOpenAckPayloadTypeComponent,
+            ConnectionOpenConfirmPayloadTypeComponent,
             ChannelHandshakePayloadTypeComponent,
             ReceivePacketPayloadTypeComponent,
             AckPacketPayloadTypeComponent,
@@ -209,7 +219,12 @@ delegate_components! {
             BuildUpdateClientPayloadWithChainHandle,
         CounterpartyChainIdQuerierComponent:
             QueryChainIdWithChainHandle,
-        ConnectionHandshakePayloadBuilderComponent:
+        [
+            ConnectionOpenInitPayloadBuilderComponent,
+            ConnectionOpenTryPayloadBuilderComponent,
+            ConnectionOpenAckPayloadBuilderComponent,
+            ConnectionOpenConfirmPayloadBuilderComponent,
+        ]:
             BuildCosmosConnectionHandshakePayload,
         ChannelHandshakePayloadBuilderComponent:
             BuildCosmosChannelHandshakePayload,
@@ -277,7 +292,12 @@ delegate_components! {
             DelegateQueryConsensusStateHeights<DelegateCosmosChainComponents>,
         UpdateClientMessageBuilderComponent:
             DelegateBuildUpdateClientMessage<DelegateCosmosChainComponents>,
-        ConnectionHandshakeMessageBuilderComponent:
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             DelegateBuildConnectionHandshakeMessage<DelegateCosmosChainComponents>,
         ChannelHandshakeMessageBuilderComponent:
             DelegateBuildChannelHandshakeMessage<DelegateCosmosChainComponents>,

--- a/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
@@ -2,7 +2,10 @@ use cgp_core::prelude::*;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_client_state::QueryAndConvertRawClientState;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_consensus_state::QueryAndConvertRawConsensusState;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::queries::client_state::{
@@ -39,7 +42,12 @@ delegate_components! {
             BuildCosmosCreateClientMessage,
         UpdateClientMessageBuilderComponent:
             BuildCosmosUpdateClientMessage,
-        ConnectionHandshakeMessageBuilderComponent:
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             BuildCosmosConnectionHandshakeMessage,
         ChannelHandshakeMessageBuilderComponent:
             BuildCosmosChannelHandshakeMessage,

--- a/crates/cosmos/cosmos-chain-components/src/impls/connection/connection_handshake_message.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/connection/connection_handshake_message.rs
@@ -1,3 +1,4 @@
+use cgp_core::HasErrorType;
 use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
     ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
     ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
@@ -85,7 +86,7 @@ where
             ClientId = ClientId,
             ConnectionId = ConnectionId,
             Message = CosmosMessage,
-        > + HasBlockingChainHandle,
+        > + HasErrorType,
     Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasConnectionOpenTryPayloadType<
             Chain,
@@ -126,7 +127,7 @@ where
             ClientId = ClientId,
             ConnectionId = ConnectionId,
             Message = CosmosMessage,
-        > + HasBlockingChainHandle,
+        > + HasErrorType,
     Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasConnectionOpenAckPayloadType<
             Chain,
@@ -166,7 +167,7 @@ where
             ClientId = ClientId,
             ConnectionId = ConnectionId,
             Message = CosmosMessage,
-        > + HasBlockingChainHandle,
+        > + HasErrorType,
     Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasConnectionOpenConfirmPayloadType<
             Chain,

--- a/crates/cosmos/cosmos-chain-components/src/impls/connection/connection_handshake_message.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/connection/connection_handshake_message.rs
@@ -1,6 +1,11 @@
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
+    ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
+};
 use hermes_relayer_components::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_relayer::chain::handle::ChainHandle;
@@ -20,7 +25,7 @@ use crate::types::payloads::connection::{
 
 pub struct BuildCosmosConnectionHandshakeMessage;
 
-impl<Chain, Counterparty> ConnectionHandshakeMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildCosmosConnectionHandshakeMessage
 where
     Chain: HasInitConnectionOptionsType<
@@ -33,12 +38,9 @@ where
             Message = CosmosMessage,
         > + HasBlockingChainHandle,
     Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
-        + HasConnectionHandshakePayloadTypes<
+        + HasConnectionOpenInitPayloadType<
             Chain,
             ConnectionOpenInitPayload = CosmosConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
         >,
 {
     async fn build_connection_open_init_message(
@@ -73,7 +75,23 @@ where
             })
             .await
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
+    for BuildCosmosConnectionHandshakeMessage
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasBlockingChainHandle,
+    Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasConnectionOpenTryPayloadType<
+            Chain,
+            ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
+        >,
+{
     async fn build_connection_open_try_message(
         _chain: &Chain,
         client_id: &Chain::ClientId,
@@ -98,7 +116,23 @@ where
 
         Ok(message.to_cosmos_message())
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
+    for BuildCosmosConnectionHandshakeMessage
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasBlockingChainHandle,
+    Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasConnectionOpenAckPayloadType<
+            Chain,
+            ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
+        >,
+{
     async fn build_connection_open_ack_message(
         _chain: &Chain,
         connection_id: &Chain::ConnectionId,
@@ -122,7 +156,23 @@ where
 
         Ok(message.to_cosmos_message())
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
+    for BuildCosmosConnectionHandshakeMessage
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasBlockingChainHandle,
+    Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasConnectionOpenConfirmPayloadType<
+            Chain,
+            ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
+        >,
+{
     async fn build_connection_open_confirm_message(
         _chain: &Chain,
         connection_id: &Chain::ConnectionId,

--- a/crates/cosmos/cosmos-chain-components/src/impls/connection/connection_handshake_payload.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/connection/connection_handshake_payload.rs
@@ -7,9 +7,7 @@ use hermes_relayer_components::chain::traits::payload_builders::connection_hands
     ConnectionOpenInitPayloadBuilder, ConnectionOpenTryPayloadBuilder,
 };
 use hermes_relayer_components::chain::traits::queries::client_state::CanQueryClientStateWithProofs;
-use hermes_relayer_components::chain::traits::queries::connection_end::{
-    CanQueryConnectionEnd, CanQueryConnectionEndWithProofs,
-};
+use hermes_relayer_components::chain::traits::queries::connection_end::CanQueryConnectionEndWithProofs;
 use hermes_relayer_components::chain::traits::queries::consensus_state::CanQueryRawConsensusStateWithProofs;
 use hermes_relayer_components::chain::traits::types::client_state::{
     HasClientStateFields, HasClientStateType,
@@ -25,11 +23,9 @@ use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::proof::HasCommitmentProofType;
 use ibc_relayer_types::core::ics02_client::error::Error as Ics02Error;
 use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
-use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 use ibc_relayer_types::Height;
 use prost_types::Any;
 
-use crate::traits::grpc_address::HasGrpcAddress;
 use crate::types::payloads::connection::{
     CosmosConnectionOpenAckPayload, CosmosConnectionOpenConfirmPayload,
     CosmosConnectionOpenInitPayload, CosmosConnectionOpenTryPayload,
@@ -63,20 +59,14 @@ where
     Chain: HasConnectionOpenTryPayloadType<
             Counterparty,
             ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
-        > + HasIbcChainTypes<
-            Counterparty,
-            Height = Height,
-            ClientId = ClientId,
-            ConnectionId = ConnectionId,
-        > + HasClientStateType<Counterparty>
+        > + HasIbcChainTypes<Counterparty, Height = Height>
+        + HasClientStateType<Counterparty>
         + HasIbcCommitmentPrefix<CommitmentPrefix = Vec<u8>>
         + HasCommitmentProofType<CommitmentProof = Vec<u8>>
         + CanIncrementHeight
-        + CanQueryConnectionEnd<Counterparty, ConnectionEnd = ConnectionEnd>
         + CanQueryConnectionEndWithProofs<Counterparty, ConnectionEnd = ConnectionEnd>
         + CanQueryClientStateWithProofs<Counterparty>
         + CanQueryRawConsensusStateWithProofs<Counterparty, RawConsensusState = Any>
-        + HasGrpcAddress
         + CanRaiseError<Encoding::Error>
         + CanRaiseError<Ics02Error>,
     Counterparty:
@@ -87,8 +77,8 @@ where
         chain: &Chain,
         _client_state: &Chain::ClientState,
         height: &Height,
-        client_id: &ClientId,
-        connection_id: &ConnectionId,
+        client_id: &Chain::ClientId,
+        connection_id: &Chain::ConnectionId,
     ) -> Result<CosmosConnectionOpenTryPayload, Chain::Error> {
         let commitment_prefix = chain.ibc_commitment_prefix().clone();
 
@@ -143,23 +133,15 @@ where
     Chain: HasConnectionOpenAckPayloadType<
             Counterparty,
             ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
-        > + HasIbcChainTypes<
-            Counterparty,
-            Height = Height,
-            ClientId = ClientId,
-            ConnectionId = ConnectionId,
-        > + HasClientStateType<Counterparty>
-        + HasIbcCommitmentPrefix<CommitmentPrefix = Vec<u8>>
+        > + HasIbcChainTypes<Counterparty, Height = Height>
+        + HasClientStateType<Counterparty>
         + HasCommitmentProofType<CommitmentProof = Vec<u8>>
         + CanIncrementHeight
-        + CanQueryConnectionEnd<Counterparty, ConnectionEnd = ConnectionEnd>
         + CanQueryConnectionEndWithProofs<Counterparty, ConnectionEnd = ConnectionEnd>
         + CanQueryClientStateWithProofs<Counterparty>
         + CanQueryRawConsensusStateWithProofs<Counterparty, RawConsensusState = Any>
-        + HasGrpcAddress
         + CanRaiseError<Encoding::Error>
-        + CanRaiseError<Ics02Error>
-        + CanRaiseError<&'static str>,
+        + CanRaiseError<Ics02Error>,
     Counterparty:
         HasClientStateFields<Chain> + HasDefaultEncoding<Encoding = Encoding> + HasHeightFields,
     Encoding: CanConvert<Counterparty::ClientState, Any>,
@@ -218,32 +200,17 @@ where
     }
 }
 
-impl<Chain, Counterparty, Encoding> ConnectionOpenConfirmPayloadBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenConfirmPayloadBuilder<Chain, Counterparty>
     for BuildCosmosConnectionHandshakePayload
 where
     Chain: HasConnectionOpenConfirmPayloadType<
             Counterparty,
             ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
-        > + HasIbcChainTypes<
-            Counterparty,
-            Height = Height,
-            ClientId = ClientId,
-            ConnectionId = ConnectionId,
-        > + HasClientStateType<Counterparty>
-        + HasIbcCommitmentPrefix<CommitmentPrefix = Vec<u8>>
+        > + HasIbcChainTypes<Counterparty, Height = Height>
+        + HasClientStateType<Counterparty>
         + HasCommitmentProofType<CommitmentProof = Vec<u8>>
         + CanIncrementHeight
-        + CanQueryConnectionEnd<Counterparty, ConnectionEnd = ConnectionEnd>
-        + CanQueryConnectionEndWithProofs<Counterparty, ConnectionEnd = ConnectionEnd>
-        + CanQueryClientStateWithProofs<Counterparty>
-        + CanQueryRawConsensusStateWithProofs<Counterparty, RawConsensusState = Any>
-        + HasGrpcAddress
-        + CanRaiseError<Encoding::Error>
-        + CanRaiseError<Ics02Error>
-        + CanRaiseError<&'static str>,
-    Counterparty:
-        HasClientStateFields<Chain> + HasDefaultEncoding<Encoding = Encoding> + HasHeightFields,
-    Encoding: CanConvert<Counterparty::ClientState, Any>,
+        + CanQueryConnectionEndWithProofs<Counterparty>,
 {
     async fn build_connection_open_confirm_payload(
         chain: &Chain,

--- a/crates/cosmos/cosmos-chain-components/src/impls/types/payload.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/types/payload.rs
@@ -1,6 +1,9 @@
 use cgp_core::Async;
 use hermes_relayer_components::chain::traits::types::channel::ProvideChannelHandshakePayloadTypes;
-use hermes_relayer_components::chain::traits::types::connection::ProvideConnectionHandshakePayloadTypes;
+use hermes_relayer_components::chain::traits::types::connection::{
+    ProvideConnectionOpenAckPayloadType, ProvideConnectionOpenConfirmPayloadType,
+    ProvideConnectionOpenInitPayloadType, ProvideConnectionOpenTryPayloadType,
+};
 use hermes_relayer_components::chain::traits::types::create_client::ProvideCreateClientPayloadType;
 use hermes_relayer_components::chain::traits::types::packets::ack::ProvideAckPacketPayloadType;
 use hermes_relayer_components::chain::traits::types::packets::receive::ProvideReceivePacketPayloadType;
@@ -49,17 +52,35 @@ where
     type ChannelOpenConfirmPayload = CosmosChannelOpenConfirmPayload;
 }
 
-impl<Chain, Counterparty> ProvideConnectionHandshakePayloadTypes<Chain, Counterparty>
+impl<Chain, Counterparty> ProvideConnectionOpenInitPayloadType<Chain, Counterparty>
     for ProvideCosmosPayloadTypes
 where
     Chain: Async,
 {
     type ConnectionOpenInitPayload = CosmosConnectionOpenInitPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenTryPayloadType<Chain, Counterparty>
+    for ProvideCosmosPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenAckPayloadType<Chain, Counterparty>
+    for ProvideCosmosPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenConfirmPayloadType<Chain, Counterparty>
+    for ProvideCosmosPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload;
 }
 

--- a/crates/cosmos/cosmos-chain-components/src/lib.rs
+++ b/crates/cosmos/cosmos-chain-components/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::infallible_destructuring_match)]
+#![recursion_limit = "256"]
 
 extern crate alloc;
 

--- a/crates/cosmos/cosmos-relayer/src/chain/components.rs
+++ b/crates/cosmos/cosmos-relayer/src/chain/components.rs
@@ -21,7 +21,10 @@ use hermes_relayer_components::chain::traits::commitment_prefix::{
 };
 use hermes_relayer_components::chain::traits::message_builders::ack_packet::AckPacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::receive_packet::ReceivePacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::timeout_unordered_packet::TimeoutUnorderedPacketMessageBuilderComponent;
@@ -30,7 +33,10 @@ use hermes_relayer_components::chain::traits::packet::fields::PacketFieldsReader
 use hermes_relayer_components::chain::traits::packet::from_write_ack::PacketFromWriteAckBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::ack_packet::AckPacketPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::channel_handshake::ChannelHandshakePayloadBuilderComponent;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    ConnectionOpenAckPayloadBuilderComponent, ConnectionOpenConfirmPayloadBuilderComponent,
+    ConnectionOpenInitPayloadBuilderComponent, ConnectionOpenTryPayloadBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::receive_packet::ReceivePacketPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::timeout_unordered_packet::TimeoutUnorderedPacketPayloadBuilderComponent;
@@ -77,8 +83,9 @@ use hermes_relayer_components::chain::traits::types::client_state::{
     ClientStateFieldsGetterComponent, ClientStateTypeComponent, RawClientStateTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::connection::{
-    ConnectionEndTypeComponent, ConnectionHandshakePayloadTypeComponent,
-    InitConnectionOptionsTypeComponent,
+    ConnectionEndTypeComponent, ConnectionOpenAckPayloadTypeComponent,
+    ConnectionOpenConfirmPayloadTypeComponent, ConnectionOpenInitPayloadTypeComponent,
+    ConnectionOpenTryPayloadTypeComponent, InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::{
     ConsensusStateTypeComponent, RawConsensusStateTypeComponent,
@@ -223,7 +230,12 @@ delegate_components! {
 
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
-            ConnectionHandshakePayloadTypeComponent,
+
+            ConnectionOpenInitPayloadTypeComponent,
+            ConnectionOpenTryPayloadTypeComponent,
+            ConnectionOpenAckPayloadTypeComponent,
+            ConnectionOpenConfirmPayloadTypeComponent,
+
             ChannelHandshakePayloadTypeComponent,
             ReceivePacketPayloadTypeComponent,
             AckPacketPayloadTypeComponent,
@@ -252,8 +264,16 @@ delegate_components! {
             UpdateClientMessageBuilderComponent,
             UpdateClientPayloadBuilderComponent,
             CounterpartyChainIdQuerierComponent,
-            ConnectionHandshakeMessageBuilderComponent,
-            ConnectionHandshakePayloadBuilderComponent,
+
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+            ConnectionOpenInitPayloadBuilderComponent,
+            ConnectionOpenTryPayloadBuilderComponent,
+            ConnectionOpenAckPayloadBuilderComponent,
+            ConnectionOpenConfirmPayloadBuilderComponent,
+
             ChannelHandshakePayloadBuilderComponent,
             ChannelHandshakeMessageBuilderComponent,
             PacketCommitmentsQuerierComponent,

--- a/crates/cosmos/cosmos-relayer/src/lib.rs
+++ b/crates/cosmos/cosmos-relayer/src/lib.rs
@@ -1,5 +1,5 @@
 //! A relayer instance for relaying between Cosmos chains.
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::let_and_return)]

--- a/crates/relayer/relayer-components/src/chain/impls/delegate/message_builders/connection_handshake.rs
+++ b/crates/relayer/relayer-components/src/chain/impls/delegate/message_builders/connection_handshake.rs
@@ -3,22 +3,27 @@ use core::marker::PhantomData;
 use cgp_core::prelude::HasErrorType;
 use cgp_core::DelegateComponent;
 
-use crate::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
+use crate::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
+    ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
+};
 use crate::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 
 pub struct DelegateBuildConnectionHandshakeMessage<Components>(pub PhantomData<Components>);
 
 impl<Chain, Counterparty, Components, Delegate>
-    ConnectionHandshakeMessageBuilder<Chain, Counterparty>
+    ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for DelegateBuildConnectionHandshakeMessage<Components>
 where
     Chain:
         HasInitConnectionOptionsType<Counterparty> + HasIbcChainTypes<Counterparty> + HasErrorType,
-    Counterparty: HasConnectionHandshakePayloadTypes<Chain> + HasIbcChainTypes<Chain>,
-    Delegate: ConnectionHandshakeMessageBuilder<Chain, Counterparty>,
+    Counterparty: HasConnectionOpenInitPayloadType<Chain> + HasIbcChainTypes<Chain>,
+    Delegate: ConnectionOpenInitMessageBuilder<Chain, Counterparty>,
     Components: DelegateComponent<Counterparty, Delegate = Delegate>,
 {
     async fn build_connection_open_init_message(
@@ -37,7 +42,16 @@ where
         )
         .await
     }
+}
 
+impl<Chain, Counterparty, Components, Delegate> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
+    for DelegateBuildConnectionHandshakeMessage<Components>
+where
+    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
+    Counterparty: HasConnectionOpenTryPayloadType<Chain> + HasIbcChainTypes<Chain>,
+    Delegate: ConnectionOpenTryMessageBuilder<Chain, Counterparty>,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+{
     async fn build_connection_open_try_message(
         chain: &Chain,
         client_id: &Chain::ClientId,
@@ -54,7 +68,16 @@ where
         )
         .await
     }
+}
 
+impl<Chain, Counterparty, Components, Delegate> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
+    for DelegateBuildConnectionHandshakeMessage<Components>
+where
+    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
+    Counterparty: HasConnectionOpenAckPayloadType<Chain> + HasIbcChainTypes<Chain>,
+    Delegate: ConnectionOpenAckMessageBuilder<Chain, Counterparty>,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+{
     async fn build_connection_open_ack_message(
         chain: &Chain,
         connection_id: &Chain::ConnectionId,
@@ -69,7 +92,17 @@ where
         )
         .await
     }
+}
 
+impl<Chain, Counterparty, Components, Delegate>
+    ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
+    for DelegateBuildConnectionHandshakeMessage<Components>
+where
+    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
+    Counterparty: HasConnectionOpenConfirmPayloadType<Chain> + HasIbcChainTypes<Chain>,
+    Delegate: ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+{
     async fn build_connection_open_confirm_message(
         chain: &Chain,
         connection_id: &Chain::ConnectionId,

--- a/crates/relayer/relayer-components/src/chain/impls/forward/message_builders/connection_handshake.rs
+++ b/crates/relayer/relayer-components/src/chain/impls/forward/message_builders/connection_handshake.rs
@@ -1,10 +1,15 @@
 use cgp_core::{Async, CanRaiseError, HasInner};
 
 use crate::chain::traits::message_builders::connection_handshake::{
-    CanBuildConnectionHandshakeMessages, ConnectionHandshakeMessageBuilder,
+    CanBuildConnectionOpenAckMessage, CanBuildConnectionOpenConfirmMessage,
+    CanBuildConnectionOpenInitMessage, CanBuildConnectionOpenTryMessage,
+    ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
+    ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
 };
 use crate::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 
@@ -19,10 +24,7 @@ impl<
         ConnectionId,
         InitConnectionOptions,
         ConnectionOpenInitPayload,
-        ConnectionOpenTryPayload,
-        ConnectionOpenAckPayload,
-        ConnectionOpenConfirmPayload,
-    > ConnectionHandshakeMessageBuilder<Chain, Counterparty> for ForwardConnectionHandshakeBuilder
+    > ConnectionOpenInitMessageBuilder<Chain, Counterparty> for ForwardConnectionHandshakeBuilder
 where
     Chain: HasInitConnectionOptionsType<Counterparty, InitConnectionOptions = InitConnectionOptions>
         + HasIbcChainTypes<
@@ -32,21 +34,15 @@ where
             ConnectionId = ConnectionId,
         > + HasInner<Inner = InChain>
         + CanRaiseError<InChain::Error>,
-    Counterparty: HasConnectionHandshakePayloadTypes<
+    Counterparty: HasConnectionOpenInitPayloadType<
             Chain,
             ConnectionOpenInitPayload = ConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = ConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = ConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = ConnectionOpenConfirmPayload,
-        > + HasConnectionHandshakePayloadTypes<
+        > + HasConnectionOpenInitPayloadType<
             InChain,
             ConnectionOpenInitPayload = ConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = ConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = ConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = ConnectionOpenConfirmPayload,
         > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasIbcChainTypes<InChain, ClientId = ClientId, ConnectionId = ConnectionId>,
-    InChain: CanBuildConnectionHandshakeMessages<
+    InChain: CanBuildConnectionOpenInitMessage<
             Counterparty,
             InitConnectionOptions = InitConnectionOptions,
         > + HasIbcChainTypes<
@@ -58,9 +54,6 @@ where
     ClientId: Async,
     ConnectionId: Async,
     ConnectionOpenInitPayload: Async,
-    ConnectionOpenTryPayload: Async,
-    ConnectionOpenAckPayload: Async,
-    ConnectionOpenConfirmPayload: Async,
     Message: Async,
     InitConnectionOptions: Async,
 {
@@ -82,7 +75,36 @@ where
             .await
             .map_err(Chain::raise_error)
     }
+}
 
+impl<Chain, Counterparty, InChain, Message, ClientId, ConnectionId, ConnectionOpenTryPayload>
+    ConnectionOpenTryMessageBuilder<Chain, Counterparty> for ForwardConnectionHandshakeBuilder
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = Message,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasInner<Inner = InChain>
+        + CanRaiseError<InChain::Error>,
+    Counterparty: HasConnectionOpenTryPayloadType<Chain, ConnectionOpenTryPayload = ConnectionOpenTryPayload>
+        + HasConnectionOpenTryPayloadType<
+            InChain,
+            ConnectionOpenTryPayload = ConnectionOpenTryPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasIbcChainTypes<InChain, ClientId = ClientId, ConnectionId = ConnectionId>,
+    InChain: CanBuildConnectionOpenTryMessage<Counterparty>
+        + HasIbcChainTypes<
+            Counterparty,
+            Message = Message,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        >,
+    ClientId: Async,
+    ConnectionId: Async,
+    ConnectionOpenTryPayload: Async,
+    Message: Async,
+{
     async fn build_connection_open_try_message(
         chain: &Chain,
         client_id: &ClientId,
@@ -101,7 +123,36 @@ where
             .await
             .map_err(Chain::raise_error)
     }
+}
 
+impl<Chain, Counterparty, InChain, Message, ClientId, ConnectionId, ConnectionOpenAckPayload>
+    ConnectionOpenAckMessageBuilder<Chain, Counterparty> for ForwardConnectionHandshakeBuilder
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = Message,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasInner<Inner = InChain>
+        + CanRaiseError<InChain::Error>,
+    Counterparty: HasConnectionOpenAckPayloadType<Chain, ConnectionOpenAckPayload = ConnectionOpenAckPayload>
+        + HasConnectionOpenAckPayloadType<
+            InChain,
+            ConnectionOpenAckPayload = ConnectionOpenAckPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasIbcChainTypes<InChain, ClientId = ClientId, ConnectionId = ConnectionId>,
+    InChain: CanBuildConnectionOpenAckMessage<Counterparty>
+        + HasIbcChainTypes<
+            Counterparty,
+            Message = Message,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        >,
+    ClientId: Async,
+    ConnectionId: Async,
+    ConnectionOpenAckPayload: Async,
+    Message: Async,
+{
     async fn build_connection_open_ack_message(
         chain: &Chain,
         connection_id: &Chain::ConnectionId,
@@ -118,7 +169,45 @@ where
             .await
             .map_err(Chain::raise_error)
     }
+}
 
+impl<
+        Chain,
+        Counterparty,
+        InChain,
+        Message,
+        ClientId,
+        ConnectionId,
+        ConnectionOpenConfirmPayload,
+    > ConnectionOpenConfirmMessageBuilder<Chain, Counterparty> for ForwardConnectionHandshakeBuilder
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = Message,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasInner<Inner = InChain>
+        + CanRaiseError<InChain::Error>,
+    Counterparty: HasConnectionOpenConfirmPayloadType<
+            Chain,
+            ConnectionOpenConfirmPayload = ConnectionOpenConfirmPayload,
+        > + HasConnectionOpenConfirmPayloadType<
+            InChain,
+            ConnectionOpenConfirmPayload = ConnectionOpenConfirmPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasIbcChainTypes<InChain, ClientId = ClientId, ConnectionId = ConnectionId>,
+    InChain: CanBuildConnectionOpenConfirmMessage<Counterparty>
+        + HasIbcChainTypes<
+            Counterparty,
+            Message = Message,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        >,
+    ClientId: Async,
+    ConnectionId: Async,
+    ConnectionOpenConfirmPayload: Async,
+    Message: Async,
+{
     async fn build_connection_open_confirm_message(
         chain: &Chain,
         connection_id: &Chain::ConnectionId,

--- a/crates/relayer/relayer-components/src/chain/traits/message_builders/connection_handshake.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/message_builders/connection_handshake.rs
@@ -1,15 +1,15 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasConnectionOpenAckPayloadType,
-    HasConnectionOpenConfirmPayloadType, HasConnectionOpenInitPayloadType,
-    HasConnectionOpenTryPayloadType, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 
 #[derive_component(ConnectionOpenInitMessageBuilderComponent, ConnectionOpenInitMessageBuilder<Chain>)]
 #[async_trait]
-pub trait CanBuildConnectionOpenInitMessages<Counterparty>:
+pub trait CanBuildConnectionOpenInitMessage<Counterparty>:
     HasInitConnectionOptionsType<Counterparty> + HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasConnectionOpenInitPayloadType<Self> + HasIbcChainTypes<Self>,
@@ -25,7 +25,7 @@ where
 
 #[derive_component(ConnectionOpenTryMessageBuilderComponent, ConnectionOpenTryMessageBuilder<Chain>)]
 #[async_trait]
-pub trait CanBuildConnectionOpenTryMessages<Counterparty>:
+pub trait CanBuildConnectionOpenTryMessage<Counterparty>:
     HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasConnectionOpenTryPayloadType<Self> + HasIbcChainTypes<Self>,
@@ -41,7 +41,7 @@ where
 
 #[derive_component(ConnectionOpenAckMessageBuilderComponent, ConnectionOpenAckMessageBuilder<Chain>)]
 #[async_trait]
-pub trait CanBuildConnectionOpenAckMessages<Counterparty>:
+pub trait CanBuildConnectionOpenAckMessage<Counterparty>:
     HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasConnectionOpenAckPayloadType<Self> + HasIbcChainTypes<Self>,
@@ -56,48 +56,11 @@ where
 
 #[derive_component(ConnectionOpenConfirmMessageBuilderComponent, ConnectionOpenConfirmMessageBuilder<Chain>)]
 #[async_trait]
-pub trait CanBuildConnectionOpenConfirmMessages<Counterparty>:
+pub trait CanBuildConnectionOpenConfirmMessage<Counterparty>:
     HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasConnectionOpenConfirmPayloadType<Self> + HasIbcChainTypes<Self>,
 {
-    async fn build_connection_open_confirm_message(
-        &self,
-        connection_id: &Self::ConnectionId,
-        counterparty_payload: Counterparty::ConnectionOpenConfirmPayload,
-    ) -> Result<Self::Message, Self::Error>;
-}
-
-#[derive_component(ConnectionHandshakeMessageBuilderComponent, ConnectionHandshakeMessageBuilder<Chain>)]
-#[async_trait]
-pub trait CanBuildConnectionHandshakeMessages<Counterparty>:
-    HasInitConnectionOptionsType<Counterparty> + HasIbcChainTypes<Counterparty> + HasErrorType
-where
-    Counterparty: HasConnectionHandshakePayloadTypes<Self> + HasIbcChainTypes<Self>,
-{
-    async fn build_connection_open_init_message(
-        &self,
-        client_id: &Self::ClientId,
-        counterparty_client_id: &Counterparty::ClientId,
-        init_connection_options: &Self::InitConnectionOptions,
-        counterparty_payload: Counterparty::ConnectionOpenInitPayload,
-    ) -> Result<Self::Message, Self::Error>;
-
-    async fn build_connection_open_try_message(
-        &self,
-        client_id: &Self::ClientId,
-        counterparty_client_id: &Counterparty::ClientId,
-        counterparty_connection_id: &Counterparty::ConnectionId,
-        counterparty_payload: Counterparty::ConnectionOpenTryPayload,
-    ) -> Result<Self::Message, Self::Error>;
-
-    async fn build_connection_open_ack_message(
-        &self,
-        connection_id: &Self::ConnectionId,
-        counterparty_connection_id: &Counterparty::ConnectionId,
-        counterparty_payload: Counterparty::ConnectionOpenAckPayload,
-    ) -> Result<Self::Message, Self::Error>;
-
     async fn build_connection_open_confirm_message(
         &self,
         connection_id: &Self::ConnectionId,

--- a/crates/relayer/relayer-components/src/chain/traits/message_builders/connection_handshake.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/message_builders/connection_handshake.rs
@@ -1,9 +1,72 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionHandshakePayloadTypes, HasConnectionOpenAckPayloadType,
+    HasConnectionOpenConfirmPayloadType, HasConnectionOpenInitPayloadType,
+    HasConnectionOpenTryPayloadType, HasInitConnectionOptionsType,
 };
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+
+#[derive_component(ConnectionOpenInitMessageBuilderComponent, ConnectionOpenInitMessageBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenInitMessages<Counterparty>:
+    HasInitConnectionOptionsType<Counterparty> + HasIbcChainTypes<Counterparty> + HasErrorType
+where
+    Counterparty: HasConnectionOpenInitPayloadType<Self> + HasIbcChainTypes<Self>,
+{
+    async fn build_connection_open_init_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        init_connection_options: &Self::InitConnectionOptions,
+        counterparty_payload: Counterparty::ConnectionOpenInitPayload,
+    ) -> Result<Self::Message, Self::Error>;
+}
+
+#[derive_component(ConnectionOpenTryMessageBuilderComponent, ConnectionOpenTryMessageBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenTryMessages<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasErrorType
+where
+    Counterparty: HasConnectionOpenTryPayloadType<Self> + HasIbcChainTypes<Self>,
+{
+    async fn build_connection_open_try_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenTryPayload,
+    ) -> Result<Self::Message, Self::Error>;
+}
+
+#[derive_component(ConnectionOpenAckMessageBuilderComponent, ConnectionOpenAckMessageBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenAckMessages<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasErrorType
+where
+    Counterparty: HasConnectionOpenAckPayloadType<Self> + HasIbcChainTypes<Self>,
+{
+    async fn build_connection_open_ack_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenAckPayload,
+    ) -> Result<Self::Message, Self::Error>;
+}
+
+#[derive_component(ConnectionOpenConfirmMessageBuilderComponent, ConnectionOpenConfirmMessageBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenConfirmMessages<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasErrorType
+where
+    Counterparty: HasConnectionOpenConfirmPayloadType<Self> + HasIbcChainTypes<Self>,
+{
+    async fn build_connection_open_confirm_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenConfirmPayload,
+    ) -> Result<Self::Message, Self::Error>;
+}
 
 #[derive_component(ConnectionHandshakeMessageBuilderComponent, ConnectionHandshakeMessageBuilder<Chain>)]
 #[async_trait]

--- a/crates/relayer/relayer-components/src/chain/traits/payload_builders/connection_handshake.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/payload_builders/connection_handshake.rs
@@ -2,9 +2,8 @@ use cgp_core::prelude::*;
 
 use crate::chain::traits::types::client_state::HasClientStateType;
 use crate::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasConnectionOpenAckPayloadType,
-    HasConnectionOpenConfirmPayloadType, HasConnectionOpenInitPayloadType,
-    HasConnectionOpenTryPayloadType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
 };
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 
@@ -61,44 +60,6 @@ pub trait CanBuildConnectionOpenConfirmPayload<Counterparty>:
     + HasClientStateType<Counterparty>
     + HasErrorType
 {
-    async fn build_connection_open_confirm_payload(
-        &self,
-        client_state: &Self::ClientState,
-        height: &Self::Height,
-        client_id: &Self::ClientId,
-        connection_id: &Self::ConnectionId,
-    ) -> Result<Self::ConnectionOpenConfirmPayload, Self::Error>;
-}
-
-#[derive_component(ConnectionHandshakePayloadBuilderComponent, ConnectionHandshakePayloadBuilder<Chain>)]
-#[async_trait]
-pub trait CanBuildConnectionHandshakePayloads<Counterparty>:
-    HasIbcChainTypes<Counterparty>
-    + HasConnectionHandshakePayloadTypes<Counterparty>
-    + HasClientStateType<Counterparty>
-    + HasErrorType
-{
-    async fn build_connection_open_init_payload(
-        &self,
-        client_state: &Self::ClientState,
-    ) -> Result<Self::ConnectionOpenInitPayload, Self::Error>;
-
-    async fn build_connection_open_try_payload(
-        &self,
-        client_state: &Self::ClientState,
-        height: &Self::Height,
-        client_id: &Self::ClientId,
-        connection_id: &Self::ConnectionId,
-    ) -> Result<Self::ConnectionOpenTryPayload, Self::Error>;
-
-    async fn build_connection_open_ack_payload(
-        &self,
-        client_state: &Self::ClientState,
-        height: &Self::Height,
-        client_id: &Self::ClientId,
-        connection_id: &Self::ConnectionId,
-    ) -> Result<Self::ConnectionOpenAckPayload, Self::Error>;
-
     async fn build_connection_open_confirm_payload(
         &self,
         client_state: &Self::ClientState,

--- a/crates/relayer/relayer-components/src/chain/traits/payload_builders/connection_handshake.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/payload_builders/connection_handshake.rs
@@ -1,8 +1,74 @@
 use cgp_core::prelude::*;
 
 use crate::chain::traits::types::client_state::HasClientStateType;
-use crate::chain::traits::types::connection::HasConnectionHandshakePayloadTypes;
+use crate::chain::traits::types::connection::{
+    HasConnectionHandshakePayloadTypes, HasConnectionOpenAckPayloadType,
+    HasConnectionOpenConfirmPayloadType, HasConnectionOpenInitPayloadType,
+    HasConnectionOpenTryPayloadType,
+};
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+
+#[derive_component(ConnectionOpenInitPayloadBuilderComponent, ConnectionOpenInitPayloadBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenInitPayload<Counterparty>:
+    HasConnectionOpenInitPayloadType<Counterparty> + HasClientStateType<Counterparty> + HasErrorType
+{
+    async fn build_connection_open_init_payload(
+        &self,
+        client_state: &Self::ClientState,
+    ) -> Result<Self::ConnectionOpenInitPayload, Self::Error>;
+}
+
+#[derive_component(ConnectionOpenTryPayloadBuilderComponent, ConnectionOpenTryPayloadBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenTryPayload<Counterparty>:
+    HasIbcChainTypes<Counterparty>
+    + HasConnectionOpenTryPayloadType<Counterparty>
+    + HasClientStateType<Counterparty>
+    + HasErrorType
+{
+    async fn build_connection_open_try_payload(
+        &self,
+        client_state: &Self::ClientState,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenTryPayload, Self::Error>;
+}
+
+#[derive_component(ConnectionOpenAckPayloadBuilderComponent, ConnectionOpenAckPayloadBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenAckPayload<Counterparty>:
+    HasIbcChainTypes<Counterparty>
+    + HasConnectionOpenAckPayloadType<Counterparty>
+    + HasClientStateType<Counterparty>
+    + HasErrorType
+{
+    async fn build_connection_open_ack_payload(
+        &self,
+        client_state: &Self::ClientState,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenAckPayload, Self::Error>;
+}
+
+#[derive_component(ConnectionOpenConfirmPayloadBuilderComponent, ConnectionOpenConfirmPayloadBuilder<Chain>)]
+#[async_trait]
+pub trait CanBuildConnectionOpenConfirmPayload<Counterparty>:
+    HasIbcChainTypes<Counterparty>
+    + HasConnectionOpenConfirmPayloadType<Counterparty>
+    + HasClientStateType<Counterparty>
+    + HasErrorType
+{
+    async fn build_connection_open_confirm_payload(
+        &self,
+        client_state: &Self::ClientState,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenConfirmPayload, Self::Error>;
+}
 
 #[derive_component(ConnectionHandshakePayloadBuilderComponent, ConnectionHandshakePayloadBuilder<Chain>)]
 #[async_trait]

--- a/crates/relayer/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/connection.rs
@@ -28,21 +28,6 @@ pub trait HasConnectionOpenConfirmPayloadType<Counterparty>: Async {
     type ConnectionOpenConfirmPayload: Async;
 }
 
-/**
-    Payload that contains necessary counterparty information such as proofs and parameters
-    in order for a self chain to build a connection handshake message.
-*/
-#[derive_component(ConnectionHandshakePayloadTypeComponent, ProvideConnectionHandshakePayloadTypes<Chain>)]
-pub trait HasConnectionHandshakePayloadTypes<Counterparty>: Async {
-    type ConnectionOpenInitPayload: Async;
-
-    type ConnectionOpenTryPayload: Async;
-
-    type ConnectionOpenAckPayload: Async;
-
-    type ConnectionOpenConfirmPayload: Async;
-}
-
 #[derive_component(ConnectionEndTypeComponent, ProvideConnectionEndType<Chain>)]
 pub trait HasConnectionEndType<Counterparty>: Async {
     type ConnectionEnd: Async;

--- a/crates/relayer/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/connection.rs
@@ -8,6 +8,26 @@ pub trait HasInitConnectionOptionsType<Counterparty>: Async {
 pub type InitConnectionOptionsOf<Chain, Counterparty> =
     <Chain as HasInitConnectionOptionsType<Counterparty>>::InitConnectionOptions;
 
+#[derive_component(ConnectionOpenInitPayloadTypeComponent, ProvideConnectionOpenInitPayloadType<Chain>)]
+pub trait HasConnectionOpenInitPayloadType<Counterparty>: Async {
+    type ConnectionOpenInitPayload: Async;
+}
+
+#[derive_component(ConnectionOpenTryPayloadTypeComponent, ProvideConnectionOpenTryPayloadType<Chain>)]
+pub trait HasConnectionOpenTryPayloadType<Counterparty>: Async {
+    type ConnectionOpenTryPayload: Async;
+}
+
+#[derive_component(ConnectionOpenAckPayloadTypeComponent, ProvideConnectionOpenAckPayloadType<Chain>)]
+pub trait HasConnectionOpenAckPayloadType<Counterparty>: Async {
+    type ConnectionOpenAckPayload: Async;
+}
+
+#[derive_component(ConnectionOpenConfirmPayloadTypeComponent, ProvideConnectionOpenConfirmPayloadType<Chain>)]
+pub trait HasConnectionOpenConfirmPayloadType<Counterparty>: Async {
+    type ConnectionOpenConfirmPayload: Async;
+}
+
 /**
     Payload that contains necessary counterparty information such as proofs and parameters
     in order for a self chain to build a connection handshake message.

--- a/crates/relayer/relayer-components/src/relay/impls/connection/open_ack.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/connection/open_ack.rs
@@ -1,7 +1,5 @@
-use cgp_core::async_trait;
-
-use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
-use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
+use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionOpenAckMessage;
+use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionOpenAckPayload;
 use crate::chain::traits::queries::chain_status::CanQueryChainHeight;
 use crate::chain::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
@@ -23,16 +21,15 @@ use crate::relay::traits::update_client_message_builder::CanSendTargetUpdateClie
 */
 pub struct RelayConnectionOpenAck;
 
-#[async_trait]
 impl<Relay, SrcChain, DstChain> ConnectionOpenAckRelayer<Relay> for RelayConnectionOpenAck
 where
     Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
         + CanSendTargetUpdateClientMessage<DestinationTarget>
         + CanSendSingleIbcMessage<MainSink, SourceTarget>
         + CanRaiseRelayChainErrors,
-    SrcChain: CanBuildConnectionHandshakeMessages<DstChain>
-        + CanQueryClientStateWithLatestHeight<DstChain>,
-    DstChain: CanQueryChainHeight + CanBuildConnectionHandshakePayloads<SrcChain>,
+    SrcChain:
+        CanBuildConnectionOpenAckMessage<DstChain> + CanQueryClientStateWithLatestHeight<DstChain>,
+    DstChain: CanQueryChainHeight + CanBuildConnectionOpenAckPayload<SrcChain>,
     DstChain::ConnectionId: Clone,
 {
     async fn relay_connection_open_ack(

--- a/crates/relayer/relayer-components/src/relay/impls/connection/open_confirm.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/connection/open_confirm.rs
@@ -1,7 +1,5 @@
-use cgp_core::async_trait;
-
-use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
-use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
+use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionOpenConfirmMessage;
+use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionOpenConfirmPayload;
 use crate::chain::traits::queries::chain_status::CanQueryChainHeight;
 use crate::chain::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
@@ -23,15 +21,14 @@ use crate::relay::traits::update_client_message_builder::CanBuildTargetUpdateCli
 */
 pub struct RelayConnectionOpenConfirm;
 
-#[async_trait]
 impl<Relay, SrcChain, DstChain> ConnectionOpenConfirmRelayer<Relay> for RelayConnectionOpenConfirm
 where
     Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
         + CanBuildTargetUpdateClientMessage<DestinationTarget>
         + CanSendSingleIbcMessage<MainSink, DestinationTarget>
         + CanRaiseRelayChainErrors,
-    SrcChain: CanQueryChainHeight + CanBuildConnectionHandshakePayloads<DstChain>,
-    DstChain: CanBuildConnectionHandshakeMessages<SrcChain>
+    SrcChain: CanQueryChainHeight + CanBuildConnectionOpenConfirmPayload<DstChain>,
+    DstChain: CanBuildConnectionOpenConfirmMessage<SrcChain>
         + CanQueryClientStateWithLatestHeight<SrcChain>,
     DstChain::ConnectionId: Clone,
 {

--- a/crates/relayer/relayer-components/src/relay/impls/connection/open_init.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/connection/open_init.rs
@@ -3,11 +3,12 @@ use core::iter::Iterator;
 
 use cgp_core::CanRaiseError;
 
-use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
-use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
+use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionOpenInitMessage;
+use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionOpenInitPayload;
 use crate::chain::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
 use crate::chain::traits::send_message::CanSendSingleMessage;
 use crate::chain::traits::types::connection::HasInitConnectionOptionsType;
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenInitEvent;
 use crate::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
 use crate::relay::traits::connection::open_init::ConnectionInitializer;
@@ -31,10 +32,10 @@ where
         + CanRaiseRelayChainErrors,
     SrcChain: CanSendSingleMessage
         + HasInitConnectionOptionsType<DstChain>
-        + CanBuildConnectionHandshakeMessages<DstChain>
+        + CanBuildConnectionOpenInitMessage<DstChain>
         + CanQueryClientStateWithLatestHeight<DstChain>
         + HasConnectionOpenInitEvent<DstChain>,
-    DstChain: CanBuildConnectionHandshakePayloads<SrcChain>,
+    DstChain: HasIbcChainTypes<SrcChain> + CanBuildConnectionOpenInitPayload<SrcChain>,
     SrcChain::ConnectionId: Clone,
 {
     async fn init_connection(

--- a/crates/relayer/relayer-components/src/relay/impls/connection/open_try.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/connection/open_try.rs
@@ -3,8 +3,8 @@ use core::iter::Iterator;
 
 use cgp_core::CanRaiseError;
 
-use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
-use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
+use crate::chain::traits::message_builders::connection_handshake::CanBuildConnectionOpenTryMessage;
+use crate::chain::traits::payload_builders::connection_handshake::CanBuildConnectionOpenTryPayload;
 use crate::chain::traits::queries::chain_status::CanQueryChainHeight;
 use crate::chain::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
 use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenTryEvent;
@@ -43,9 +43,9 @@ where
         + CanSendSingleIbcMessage<MainSink, DestinationTarget>
         + for<'a> CanRaiseError<MissingConnectionTryEventError<'a, Relay>>
         + CanRaiseRelayChainErrors,
-    SrcChain: CanQueryChainHeight + CanBuildConnectionHandshakePayloads<DstChain>,
+    SrcChain: CanQueryChainHeight + CanBuildConnectionOpenTryPayload<DstChain>,
     DstChain: CanQueryClientStateWithLatestHeight<SrcChain>
-        + CanBuildConnectionHandshakeMessages<SrcChain>
+        + CanBuildConnectionOpenTryMessage<SrcChain>
         + HasConnectionOpenTryEvent<SrcChain>,
     DstChain::ConnectionId: Clone,
 {

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/component.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/component.rs
@@ -11,14 +11,20 @@ use hermes_encoding_components::traits::has_encoding::{
 use hermes_relayer_components::chain::impls::queries::query_and_convert_client_state::QueryAndConvertRawClientState;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_consensus_state::QueryAndConvertRawConsensusState;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::timeout_unordered_packet::TimeoutUnorderedPacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::packet::fields::PacketFieldsReaderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::channel_handshake::ChannelHandshakePayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
-    CanBuildConnectionHandshakePayloads, ConnectionHandshakePayloadBuilderComponent,
+    CanBuildConnectionOpenAckPayload, CanBuildConnectionOpenConfirmPayload,
+    CanBuildConnectionOpenInitPayload, CanBuildConnectionOpenTryPayload,
+    ConnectionOpenAckPayloadBuilderComponent, ConnectionOpenConfirmPayloadBuilderComponent,
+    ConnectionOpenInitPayloadBuilderComponent, ConnectionOpenTryPayloadBuilderComponent,
 };
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::receive_packet::ReceivePacketPayloadBuilderComponent;
@@ -93,7 +99,12 @@ delegate_components! {
             QueryAndConvertRawConsensusState,
         CreateClientMessageBuilderComponent:
             BuildCreateSolomachineClientMessage,
-        ConnectionHandshakeMessageBuilderComponent:
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             BuildSolomachineConnectionHandshakeMessagesForCosmos,
     }
 }
@@ -137,10 +148,22 @@ delegate_components! {
             BuildSolomachineChannelHandshakePayloads,
         ChannelHandshakeMessageBuilderComponent:
             BuildCosmosToSolomachineChannelHandshakeMessage,
-        ConnectionHandshakePayloadBuilderComponent:
+        [
+            ConnectionOpenInitPayloadBuilderComponent,
+            ConnectionOpenTryPayloadBuilderComponent,
+            ConnectionOpenAckPayloadBuilderComponent,
+            ConnectionOpenConfirmPayloadBuilderComponent,
+        ]:
             BuildSolomachineConnectionHandshakePayloads,
-        ConnectionHandshakeMessageBuilderComponent:
+
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             BuildCosmosToSolomachineConnectionHandshakeMessage,
+
         CreateClientPayloadBuilderComponent:
             BuildSolomachineCreateClientPayload,
         CreateClientMessageBuilderComponent:
@@ -168,7 +191,10 @@ pub trait CanUseCosmosChainWithSolomachine<Chain>:
     CanQueryClientState<SolomachineChain<Chain>>
     + CanQueryClientStateWithProofs<SolomachineChain<Chain>>
     + CanQueryConsensusStateWithProofs<SolomachineChain<Chain>>
-    + CanBuildConnectionHandshakePayloads<SolomachineChain<Chain>>
+    + CanBuildConnectionOpenInitPayload<SolomachineChain<Chain>>
+    + CanBuildConnectionOpenTryPayload<SolomachineChain<Chain>>
+    + CanBuildConnectionOpenAckPayload<SolomachineChain<Chain>>
+    + CanBuildConnectionOpenConfirmPayload<SolomachineChain<Chain>>
 where
     Chain: Solomachine,
 {

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/connection_handshake_message.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/cosmos_components/connection_handshake_message.rs
@@ -3,9 +3,14 @@ use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMes
 use hermes_cosmos_chain_components::types::messages::connection::open_try::CosmosConnectionOpenTryMessage;
 use hermes_cosmos_relayer::types::error::Error;
 use hermes_protobuf_encoding_components::types::Any;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
+    ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
+};
 use hermes_relayer_components::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_proto::google::protobuf::Any as IbcProtoAny;
@@ -19,8 +24,7 @@ use crate::types::payloads::connection::{
 
 pub struct BuildSolomachineConnectionHandshakeMessagesForCosmos;
 
-#[async_trait]
-impl<Chain, Counterparty> ConnectionHandshakeMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildSolomachineConnectionHandshakeMessagesForCosmos
 where
     Chain: HasInitConnectionOptionsType<Counterparty>
@@ -30,12 +34,9 @@ where
             ConnectionId = ConnectionId,
             Message = CosmosMessage,
         > + HasErrorType<Error = Error>,
-    Counterparty: HasConnectionHandshakePayloadTypes<
+    Counterparty: HasConnectionOpenInitPayloadType<
             Chain,
             ConnectionOpenInitPayload = SolomachineConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = SolomachineConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = SolomachineConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = SolomachineConnectionOpenConfirmPayload,
         > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
 {
     async fn build_connection_open_init_message(
@@ -47,7 +48,22 @@ where
     ) -> Result<CosmosMessage, Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
+    for BuildSolomachineConnectionHandshakeMessagesForCosmos
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasErrorType<Error = Error>,
+    Counterparty: HasConnectionOpenTryPayloadType<
+            Chain,
+            ConnectionOpenTryPayload = SolomachineConnectionOpenTryPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_try_message(
         _chain: &Chain,
         client_id: &ClientId,
@@ -85,7 +101,22 @@ where
 
         Ok(message.to_cosmos_message())
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
+    for BuildSolomachineConnectionHandshakeMessagesForCosmos
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasErrorType<Error = Error>,
+    Counterparty: HasConnectionOpenAckPayloadType<
+            Chain,
+            ConnectionOpenAckPayload = SolomachineConnectionOpenAckPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_ack_message(
         _chain: &Chain,
         _connection_id: &ConnectionId,
@@ -94,7 +125,22 @@ where
     ) -> Result<CosmosMessage, Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
+    for BuildSolomachineConnectionHandshakeMessagesForCosmos
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasErrorType<Error = Error>,
+    Counterparty: HasConnectionOpenConfirmPayloadType<
+            Chain,
+            ConnectionOpenConfirmPayload = SolomachineConnectionOpenConfirmPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_confirm_message(
         _chain: &Chain,
         _connection_id: &ConnectionId,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/connection_handshake_message.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/connection_handshake_message.rs
@@ -1,13 +1,17 @@
-use cgp_core::prelude::*;
 use cgp_core::HasErrorType;
 use hermes_cosmos_chain_components::types::payloads::connection::{
     CosmosConnectionOpenAckPayload, CosmosConnectionOpenConfirmPayload,
     CosmosConnectionOpenInitPayload, CosmosConnectionOpenTryPayload,
 };
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
-use hermes_relayer_components::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
-};
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionOpenAckMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionOpenConfirmMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionOpenInitMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionOpenTryMessageBuilder;
+use hermes_relayer_components::chain::traits::types::connection::HasConnectionOpenAckPayloadType;
+use hermes_relayer_components::chain::traits::types::connection::HasConnectionOpenConfirmPayloadType;
+use hermes_relayer_components::chain::traits::types::connection::HasConnectionOpenInitPayloadType;
+use hermes_relayer_components::chain::traits::types::connection::HasConnectionOpenTryPayloadType;
+use hermes_relayer_components::chain::traits::types::connection::HasInitConnectionOptionsType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 
@@ -15,8 +19,7 @@ use crate::types::message::SolomachineMessage;
 
 pub struct BuildCosmosToSolomachineConnectionHandshakeMessage;
 
-#[async_trait]
-impl<Chain, Counterparty> ConnectionHandshakeMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildCosmosToSolomachineConnectionHandshakeMessage
 where
     Chain: HasInitConnectionOptionsType<Counterparty>
@@ -26,12 +29,9 @@ where
             ClientId = ClientId,
             ConnectionId = ConnectionId,
         > + HasErrorType,
-    Counterparty: HasConnectionHandshakePayloadTypes<
+    Counterparty: HasConnectionOpenInitPayloadType<
             Chain,
             ConnectionOpenInitPayload = CosmosConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
         > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
 {
     async fn build_connection_open_init_message(
@@ -45,7 +45,22 @@ where
 
         Ok(message)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
+    for BuildCosmosToSolomachineConnectionHandshakeMessage
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = SolomachineMessage,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasErrorType,
+    Counterparty: HasConnectionOpenTryPayloadType<
+            Chain,
+            ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_try_message(
         _chain: &Chain,
         _client_id: &ClientId,
@@ -57,7 +72,22 @@ where
 
         Ok(message)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
+    for BuildCosmosToSolomachineConnectionHandshakeMessage
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = SolomachineMessage,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasErrorType,
+    Counterparty: HasConnectionOpenAckPayloadType<
+            Chain,
+            ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_ack_message(
         _chain: &Chain,
         _connection_id: &ConnectionId,
@@ -68,7 +98,22 @@ where
 
         Ok(message)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
+    for BuildCosmosToSolomachineConnectionHandshakeMessage
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = SolomachineMessage,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasErrorType,
+    Counterparty: HasConnectionOpenConfirmPayloadType<
+            Chain,
+            ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_confirm_message(
         _chain: &Chain,
         _connection_id: &ConnectionId,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/connection_handshake_payload.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/solomachine_components/connection_handshake_payload.rs
@@ -1,5 +1,7 @@
-use cgp_core::prelude::*;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilder;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    ConnectionOpenAckPayloadBuilder, ConnectionOpenConfirmPayloadBuilder,
+    ConnectionOpenInitPayloadBuilder, ConnectionOpenTryPayloadBuilder,
+};
 use ibc_relayer_types::core::ics03_connection::connection::State as ConnectionState;
 use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 use ibc_relayer_types::Height;
@@ -17,8 +19,7 @@ use crate::types::payloads::connection::{
 
 pub struct BuildSolomachineConnectionHandshakePayloads;
 
-#[async_trait]
-impl<Chain, Counterparty> ConnectionHandshakePayloadBuilder<SolomachineChain<Chain>, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitPayloadBuilder<SolomachineChain<Chain>, Counterparty>
     for BuildSolomachineConnectionHandshakePayloads
 where
     Chain: Solomachine,
@@ -35,7 +36,13 @@ where
 
         Ok(payload)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryPayloadBuilder<SolomachineChain<Chain>, Counterparty>
+    for BuildSolomachineConnectionHandshakePayloads
+where
+    Chain: Solomachine,
+{
     async fn build_connection_open_try_payload(
         chain: &SolomachineChain<Chain>,
         solo_client_state: &SolomachineClientState,
@@ -108,7 +115,13 @@ where
 
         Ok(payload)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckPayloadBuilder<SolomachineChain<Chain>, Counterparty>
+    for BuildSolomachineConnectionHandshakePayloads
+where
+    Chain: Solomachine,
+{
     async fn build_connection_open_ack_payload(
         chain: &SolomachineChain<Chain>,
         client_state: &SolomachineClientState,
@@ -182,7 +195,13 @@ where
 
         Ok(payload)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmPayloadBuilder<SolomachineChain<Chain>, Counterparty>
+    for BuildSolomachineConnectionHandshakePayloads
+where
+    Chain: Solomachine,
+{
     async fn build_connection_open_confirm_payload(
         chain: &SolomachineChain<Chain>,
         client_state: &SolomachineClientState,

--- a/crates/solomachine/solomachine-relayer/src/impls/chain/types.rs
+++ b/crates/solomachine/solomachine-relayer/src/impls/chain/types.rs
@@ -11,7 +11,9 @@ use hermes_relayer_components::chain::traits::types::client_state::{
     ClientStateFieldsGetter, ProvideClientStateType,
 };
 use hermes_relayer_components::chain::traits::types::connection::{
-    ProvideConnectionHandshakePayloadTypes, ProvideInitConnectionOptionsType,
+    ProvideConnectionOpenAckPayloadType, ProvideConnectionOpenConfirmPayloadType,
+    ProvideConnectionOpenInitPayloadType, ProvideConnectionOpenTryPayloadType,
+    ProvideInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::ProvideConsensusStateType;
 use hermes_relayer_components::chain::traits::types::create_client::{
@@ -172,17 +174,35 @@ where
     type InitChannelOptions = ();
 }
 
-impl<Chain, Counterparty> ProvideConnectionHandshakePayloadTypes<Chain, Counterparty>
+impl<Chain, Counterparty> ProvideConnectionOpenInitPayloadType<Chain, Counterparty>
     for SolomachineChainComponents
 where
     Chain: Async,
 {
     type ConnectionOpenInitPayload = SolomachineConnectionOpenInitPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenTryPayloadType<Chain, Counterparty>
+    for SolomachineChainComponents
+where
+    Chain: Async,
+{
     type ConnectionOpenTryPayload = SolomachineConnectionOpenTryPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenAckPayloadType<Chain, Counterparty>
+    for SolomachineChainComponents
+where
+    Chain: Async,
+{
     type ConnectionOpenAckPayload = SolomachineConnectionOpenAckPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenConfirmPayloadType<Chain, Counterparty>
+    for SolomachineChainComponents
+where
+    Chain: Async,
+{
     type ConnectionOpenConfirmPayload = SolomachineConnectionOpenConfirmPayload;
 }
 

--- a/crates/solomachine/solomachine-relayer/src/types/chain.rs
+++ b/crates/solomachine/solomachine-relayer/src/types/chain.rs
@@ -1,7 +1,10 @@
 use cgp_core::Async;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    CanBuildConnectionOpenAckMessage, CanBuildConnectionOpenConfirmMessage,
+    CanBuildConnectionOpenInitMessage, CanBuildConnectionOpenTryMessage,
+};
 use hermes_relayer_components::chain::traits::queries::client_state::CanQueryClientState;
 use hermes_relayer_components::chain::traits::types::connection::HasInitConnectionOptionsType;
 
@@ -22,7 +25,10 @@ impl<Chain: Solomachine> SolomachineChain<Chain> {
 pub trait CanUseSolomachineChain:
     HasEncoding<Encoding = SolomachineEncoding>
     + HasInitConnectionOptionsType<CosmosChain>
-    + CanBuildConnectionHandshakeMessages<CosmosChain>
+    + CanBuildConnectionOpenInitMessage<CosmosChain>
+    + CanBuildConnectionOpenTryMessage<CosmosChain>
+    + CanBuildConnectionOpenAckMessage<CosmosChain>
+    + CanBuildConnectionOpenConfirmMessage<CosmosChain>
     + CanQueryClientState<CosmosChain>
 {
 }

--- a/crates/sovereign/sovereign-chain-components/src/cosmos/components.rs
+++ b/crates/sovereign/sovereign-chain-components/src/cosmos/components.rs
@@ -2,7 +2,10 @@ use cgp_core::prelude::*;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_client_state::QueryAndConvertRawClientState;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_consensus_state::QueryAndConvertRawConsensusState;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::queries::client_state::ClientStateQuerierComponent;
@@ -28,7 +31,12 @@ delegate_components! {
             BuildUpdateSovereignClientMessageOnCosmos,
         CreateClientMessageBuilderComponent:
             BuildCreateSovereignClientMessageOnCosmos,
-        ConnectionHandshakeMessageBuilderComponent:
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             BuildSovereignConnectionHandshakeMessageOnCosmos,
         ChannelHandshakeMessageBuilderComponent:
             BuildSovereignChannelHandshakeMessageOnCosmos,

--- a/crates/sovereign/sovereign-chain-components/src/cosmos/impls/sovereign_to_cosmos/connection_handshake_message.rs
+++ b/crates/sovereign/sovereign-chain-components/src/cosmos/impls/sovereign_to_cosmos/connection_handshake_message.rs
@@ -2,9 +2,14 @@ use cgp_core::HasErrorType;
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::connection::CosmosInitConnectionOptions;
 use hermes_cosmos_chain_components::types::messages::connection::open_init::CosmosConnectionOpenInitMessage;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
+    ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
+};
 use hermes_relayer_components::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_relayer_types::core::ics03_connection::version::Version;
@@ -17,7 +22,7 @@ use crate::sovereign::types::payloads::connection::{
 
 pub struct BuildSovereignConnectionHandshakeMessageOnCosmos;
 
-impl<Chain, Counterparty> ConnectionHandshakeMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildSovereignConnectionHandshakeMessageOnCosmos
 where
     Chain: HasInitConnectionOptionsType<
@@ -30,12 +35,9 @@ where
             Message = CosmosMessage,
         > + HasErrorType,
     Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
-        + HasConnectionHandshakePayloadTypes<
+        + HasConnectionOpenInitPayloadType<
             Chain,
             ConnectionOpenInitPayload = SovereignConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = SovereignConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = SovereignConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmPayload,
         >,
 {
     async fn build_connection_open_init_message(
@@ -61,7 +63,23 @@ where
 
         Ok(message.to_cosmos_message())
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakeMessageOnCosmos
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasErrorType,
+    Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasConnectionOpenTryPayloadType<
+            Chain,
+            ConnectionOpenTryPayload = SovereignConnectionOpenTryPayload,
+        >,
+{
     async fn build_connection_open_try_message(
         _chain: &Chain,
         _client_id: &Chain::ClientId,
@@ -71,7 +89,23 @@ where
     ) -> Result<CosmosMessage, Chain::Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakeMessageOnCosmos
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasErrorType,
+    Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasConnectionOpenAckPayloadType<
+            Chain,
+            ConnectionOpenAckPayload = SovereignConnectionOpenAckPayload,
+        >,
+{
     async fn build_connection_open_ack_message(
         _chain: &Chain,
         _connection_id: &Chain::ConnectionId,
@@ -95,7 +129,23 @@ where
 
         // Ok(message.to_cosmos_message())
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakeMessageOnCosmos
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+            Message = CosmosMessage,
+        > + HasErrorType,
+    Counterparty: HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasConnectionOpenConfirmPayloadType<
+            Chain,
+            ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmPayload,
+        >,
+{
     async fn build_connection_open_confirm_message(
         _chain: &Chain,
         _connection_id: &Chain::ConnectionId,

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/components.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/components.rs
@@ -6,11 +6,17 @@ use hermes_relayer_components::chain::impls::forward::queries::client_state::For
 use hermes_relayer_components::chain::impls::forward::queries::consensus_state::ForwardQueryConsensusState;
 use hermes_relayer_components::chain::impls::forward::queries::consensus_state_height::ForwardQueryConsensusStateHeight;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::channel_handshake::ChannelHandshakePayloadBuilderComponent;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    ConnectionOpenAckPayloadBuilderComponent, ConnectionOpenConfirmPayloadBuilderComponent,
+    ConnectionOpenInitPayloadBuilderComponent, ConnectionOpenTryPayloadBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::UpdateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::queries::chain_status::ChainStatusQuerierComponent;
@@ -25,7 +31,9 @@ use hermes_relayer_components::chain::traits::types::client_state::{
     ClientStateFieldsGetterComponent, ClientStateTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::connection::{
-    ConnectionHandshakePayloadTypeComponent, InitConnectionOptionsTypeComponent,
+    ConnectionOpenAckPayloadTypeComponent, ConnectionOpenConfirmPayloadTypeComponent,
+    ConnectionOpenInitPayloadTypeComponent, ConnectionOpenTryPayloadTypeComponent,
+    InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::ConsensusStateTypeComponent;
 use hermes_relayer_components::chain::traits::types::create_client::{
@@ -87,7 +95,12 @@ delegate_components! {
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
             InitConnectionOptionsTypeComponent,
-            ConnectionHandshakePayloadTypeComponent,
+
+            ConnectionOpenInitPayloadTypeComponent,
+            ConnectionOpenTryPayloadTypeComponent,
+            ConnectionOpenAckPayloadTypeComponent,
+            ConnectionOpenConfirmPayloadTypeComponent,
+
             InitChannelOptionsTypeComponent,
             ChannelHandshakePayloadTypeComponent,
         ]:
@@ -116,10 +129,23 @@ delegate_components! {
             BuildSovereignUpdateClientPayload,
         UpdateClientMessageBuilderComponent:
             BuildUpdateCosmosClientMessageOnSovereign,
-        ConnectionHandshakePayloadBuilderComponent:
+
+        [
+            ConnectionOpenInitPayloadBuilderComponent,
+            ConnectionOpenTryPayloadBuilderComponent,
+            ConnectionOpenAckPayloadBuilderComponent,
+            ConnectionOpenConfirmPayloadBuilderComponent,
+        ]:
             BuildSovereignConnectionHandshakePayload,
-        ConnectionHandshakeMessageBuilderComponent:
+
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             ForwardConnectionHandshakeBuilder,
+
         ChannelHandshakePayloadBuilderComponent:
             BuildSovereignChannelHandshakePayload,
         ChannelHandshakeMessageBuilderComponent:

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/impls/sovereign_to_cosmos/connection/connection_handshake_payload.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/impls/sovereign_to_cosmos/connection/connection_handshake_payload.rs
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl<Chain, Counterparty, Rollup> ConnectionOpenTryPayloadBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenTryPayloadBuilder<Chain, Counterparty>
     for BuildSovereignConnectionHandshakePayload
 where
     Chain: HasConnectionOpenTryPayloadType<
@@ -74,16 +74,8 @@ where
             ConnectionOpenTryPayload = SovereignConnectionOpenTryPayload,
         > + HasIbcChainTypes<Counterparty, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasHeightType<Height = RollupHeight>
-        + HasRollup<Rollup = Rollup>
         + HasClientStateType<Counterparty, ClientState = SovereignClientState>
-        + HasErrorType
-        + CanRaiseError<ClientError>
-        + CanRaiseError<RelayerClientError>
-        + CanRaiseError<ProofError>
-        + CanRaiseError<ConnectionError>
-        + CanRaiseError<Rollup::Error>,
-    Rollup: CanQueryChainHeight<Height = RollupHeight> + HasJsonRpcClient,
-    Rollup::JsonRpcClient: ClientT,
+        + HasErrorType,
 {
     async fn build_connection_open_try_payload(
         _chain: &Chain,
@@ -106,7 +98,6 @@ where
         + HasHeightType<Height = RollupHeight>
         + HasRollup<Rollup = Rollup>
         + HasClientStateType<Counterparty, ClientState = SovereignClientState>
-        + HasErrorType
         + CanRaiseError<ClientError>
         + CanRaiseError<RelayerClientError>
         + CanRaiseError<ProofError>
@@ -197,7 +188,7 @@ where
     }
 }
 
-impl<Chain, Counterparty, Rollup> ConnectionOpenConfirmPayloadBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenConfirmPayloadBuilder<Chain, Counterparty>
     for BuildSovereignConnectionHandshakePayload
 where
     Chain: HasConnectionOpenConfirmPayloadType<
@@ -205,16 +196,8 @@ where
             ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmPayload,
         > + HasIbcChainTypes<Counterparty, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasHeightType<Height = RollupHeight>
-        + HasRollup<Rollup = Rollup>
         + HasClientStateType<Counterparty, ClientState = SovereignClientState>
-        + HasErrorType
-        + CanRaiseError<ClientError>
-        + CanRaiseError<RelayerClientError>
-        + CanRaiseError<ProofError>
-        + CanRaiseError<ConnectionError>
-        + CanRaiseError<Rollup::Error>,
-    Rollup: CanQueryChainHeight<Height = RollupHeight> + HasJsonRpcClient,
-    Rollup::JsonRpcClient: ClientT,
+        + HasErrorType,
 {
     async fn build_connection_open_confirm_payload(
         _chain: &Chain,

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/impls/sovereign_to_cosmos/connection/connection_handshake_payload.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/impls/sovereign_to_cosmos/connection/connection_handshake_payload.rs
@@ -1,8 +1,14 @@
 use cgp_core::{CanRaiseError, HasErrorType};
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilder;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    ConnectionOpenAckPayloadBuilder, ConnectionOpenConfirmPayloadBuilder,
+    ConnectionOpenInitPayloadBuilder, ConnectionOpenTryPayloadBuilder,
+};
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainHeight;
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
-use hermes_relayer_components::chain::traits::types::connection::HasConnectionHandshakePayloadTypes;
+use hermes_relayer_components::chain::traits::types::connection::{
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+};
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_sovereign_rollup_components::traits::json_rpc_client::HasJsonRpcClient;
@@ -31,15 +37,12 @@ use crate::sovereign::types::payloads::connection::{
 
 pub struct BuildSovereignConnectionHandshakePayload;
 
-impl<Chain, Counterparty, Rollup> ConnectionHandshakePayloadBuilder<Chain, Counterparty>
+impl<Chain, Counterparty, Rollup> ConnectionOpenInitPayloadBuilder<Chain, Counterparty>
     for BuildSovereignConnectionHandshakePayload
 where
-    Chain: HasConnectionHandshakePayloadTypes<
+    Chain: HasConnectionOpenInitPayloadType<
             Counterparty,
             ConnectionOpenInitPayload = SovereignConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = SovereignConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = SovereignConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmPayload,
         > + HasIbcChainTypes<Counterparty, ClientId = ClientId, ConnectionId = ConnectionId>
         + HasHeightType<Height = RollupHeight>
         + HasRollup<Rollup = Rollup>
@@ -61,7 +64,27 @@ where
         let commitment_prefix = "ibc".into();
         Ok(SovereignConnectionOpenInitPayload { commitment_prefix })
     }
+}
 
+impl<Chain, Counterparty, Rollup> ConnectionOpenTryPayloadBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakePayload
+where
+    Chain: HasConnectionOpenTryPayloadType<
+            Counterparty,
+            ConnectionOpenTryPayload = SovereignConnectionOpenTryPayload,
+        > + HasIbcChainTypes<Counterparty, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasHeightType<Height = RollupHeight>
+        + HasRollup<Rollup = Rollup>
+        + HasClientStateType<Counterparty, ClientState = SovereignClientState>
+        + HasErrorType
+        + CanRaiseError<ClientError>
+        + CanRaiseError<RelayerClientError>
+        + CanRaiseError<ProofError>
+        + CanRaiseError<ConnectionError>
+        + CanRaiseError<Rollup::Error>,
+    Rollup: CanQueryChainHeight<Height = RollupHeight> + HasJsonRpcClient,
+    Rollup::JsonRpcClient: ClientT,
+{
     async fn build_connection_open_try_payload(
         _chain: &Chain,
         _client_state: &Chain::ClientState,
@@ -71,7 +94,27 @@ where
     ) -> Result<Chain::ConnectionOpenTryPayload, Chain::Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty, Rollup> ConnectionOpenAckPayloadBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakePayload
+where
+    Chain: HasConnectionOpenAckPayloadType<
+            Counterparty,
+            ConnectionOpenAckPayload = SovereignConnectionOpenAckPayload,
+        > + HasIbcChainTypes<Counterparty, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasHeightType<Height = RollupHeight>
+        + HasRollup<Rollup = Rollup>
+        + HasClientStateType<Counterparty, ClientState = SovereignClientState>
+        + HasErrorType
+        + CanRaiseError<ClientError>
+        + CanRaiseError<RelayerClientError>
+        + CanRaiseError<ProofError>
+        + CanRaiseError<ConnectionError>
+        + CanRaiseError<Rollup::Error>,
+    Rollup: CanQueryChainHeight<Height = RollupHeight> + HasJsonRpcClient,
+    Rollup::JsonRpcClient: ClientT,
+{
     async fn build_connection_open_ack_payload(
         chain: &Chain,
         _client_state: &Chain::ClientState,
@@ -152,7 +195,27 @@ where
             proof_consensus,
         })
     }
+}
 
+impl<Chain, Counterparty, Rollup> ConnectionOpenConfirmPayloadBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakePayload
+where
+    Chain: HasConnectionOpenConfirmPayloadType<
+            Counterparty,
+            ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmPayload,
+        > + HasIbcChainTypes<Counterparty, ClientId = ClientId, ConnectionId = ConnectionId>
+        + HasHeightType<Height = RollupHeight>
+        + HasRollup<Rollup = Rollup>
+        + HasClientStateType<Counterparty, ClientState = SovereignClientState>
+        + HasErrorType
+        + CanRaiseError<ClientError>
+        + CanRaiseError<RelayerClientError>
+        + CanRaiseError<ProofError>
+        + CanRaiseError<ConnectionError>
+        + CanRaiseError<Rollup::Error>,
+    Rollup: CanQueryChainHeight<Height = RollupHeight> + HasJsonRpcClient,
+    Rollup::JsonRpcClient: ClientT,
+{
     async fn build_connection_open_confirm_payload(
         _chain: &Chain,
         _client_state: &Chain::ClientState,

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/impls/types/payload.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/impls/types/payload.rs
@@ -3,7 +3,9 @@ use hermes_relayer_components::chain::traits::types::channel::{
     ProvideChannelHandshakePayloadTypes, ProvideInitChannelOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::connection::{
-    ProvideConnectionHandshakePayloadTypes, ProvideInitConnectionOptionsType,
+    ProvideConnectionOpenAckPayloadType, ProvideConnectionOpenConfirmPayloadType,
+    ProvideConnectionOpenInitPayloadType, ProvideConnectionOpenTryPayloadType,
+    ProvideInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::create_client::{
     ProvideCreateClientOptionsType, ProvideCreateClientPayloadType,
@@ -64,17 +66,35 @@ where
     type InitConnectionOptions = SovereignInitConnectionOptions;
 }
 
-impl<Chain, Counterparty> ProvideConnectionHandshakePayloadTypes<Chain, Counterparty>
+impl<Chain, Counterparty> ProvideConnectionOpenInitPayloadType<Chain, Counterparty>
     for ProvideSovereignPayloadTypes
 where
     Chain: Async,
 {
     type ConnectionOpenInitPayload = SovereignConnectionOpenInitPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenTryPayloadType<Chain, Counterparty>
+    for ProvideSovereignPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenTryPayload = SovereignConnectionOpenTryPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenAckPayloadType<Chain, Counterparty>
+    for ProvideSovereignPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenAckPayload = SovereignConnectionOpenAckPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenConfirmPayloadType<Chain, Counterparty>
+    for ProvideSovereignPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmPayload;
 }
 

--- a/crates/sovereign/sovereign-integration-tests/tests/sovereign_to_cosmos.rs
+++ b/crates/sovereign/sovereign-integration-tests/tests/sovereign_to_cosmos.rs
@@ -15,10 +15,10 @@ use hermes_cosmos_relayer::contexts::builder::CosmosBuilder;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_relayer::types::error::Error;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::CanBuildChannelHandshakeMessages;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionOpenInitMessage;
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::message_builders::update_client::CanBuildUpdateClientMessage;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionOpenInitPayload;
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainHeight;
@@ -230,7 +230,7 @@ pub fn test_sovereign_to_cosmos() -> Result<(), Error> {
 
         info!("client ID of Cosmos on Sovereign: {:?}", sovereign_client_id);
 
-        let connection_init_payload = <SovereignChain as CanBuildConnectionHandshakePayloads<CosmosChain>>::build_connection_open_init_payload(&sovereign_chain, &sovereign_client_state).await?;
+        let connection_init_payload = <SovereignChain as CanBuildConnectionOpenInitPayload<CosmosChain>>::build_connection_open_init_payload(&sovereign_chain, &sovereign_client_state).await?;
 
         let options = CosmosInitConnectionOptions {
             delay_period: Duration::from_secs(0),
@@ -239,18 +239,18 @@ pub fn test_sovereign_to_cosmos() -> Result<(), Error> {
 
         // Assert that the connection Init fails with an invalid client
         {
-            let connection_init_payload = <SovereignChain as CanBuildConnectionHandshakePayloads<CosmosChain>>::build_connection_open_init_payload(&sovereign_chain, &sovereign_client_state).await?;
+            let connection_init_payload = <SovereignChain as CanBuildConnectionOpenInitPayload<CosmosChain>>::build_connection_open_init_payload(&sovereign_chain, &sovereign_client_state).await?;
 
             let wrong_wasm_client_id = ClientId::from_str("08-wasm-12").map_err(|e| eyre!("Failed to create a Client ID from string '08-wasm-0': {e}"))?;
 
-            let connection_init_message = <CosmosChain as CanBuildConnectionHandshakeMessages<SovereignChain>>::build_connection_open_init_message(cosmos_chain, &wrong_wasm_client_id, &sovereign_client_id, &options, connection_init_payload).await?;
+            let connection_init_message = <CosmosChain as CanBuildConnectionOpenInitMessage<SovereignChain>>::build_connection_open_init_message(cosmos_chain, &wrong_wasm_client_id, &sovereign_client_id, &options, connection_init_payload).await?;
 
             let connection_init_event = cosmos_chain.send_message(connection_init_message).await;
 
             assert!(connection_init_event.is_err());
         }
 
-        let connection_init_message = <CosmosChain as CanBuildConnectionHandshakeMessages<SovereignChain>>::build_connection_open_init_message(cosmos_chain, &wasm_client_id, &sovereign_client_id, &options, connection_init_payload).await?;
+        let connection_init_message = <CosmosChain as CanBuildConnectionOpenInitMessage<SovereignChain>>::build_connection_open_init_message(cosmos_chain, &wasm_client_id, &sovereign_client_id, &options, connection_init_payload).await?;
 
         let events = cosmos_chain.send_message(connection_init_message).await?;
 

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -10,10 +10,16 @@ use hermes_logging_components::traits::has_logger::{
     GlobalLoggerGetterComponent, LoggerGetterComponent, LoggerTypeComponent,
 };
 use hermes_relayer_components::chain::impls::wait_chain_reach_height::CanWaitChainReachHeight;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    CanBuildConnectionOpenAckMessage, CanBuildConnectionOpenConfirmMessage,
+    CanBuildConnectionOpenInitMessage, CanBuildConnectionOpenTryMessage,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::channel_handshake::CanBuildChannelHandshakePayloads;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::CanBuildConnectionHandshakePayloads;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    CanBuildConnectionOpenAckPayload, CanBuildConnectionOpenConfirmPayload,
+    CanBuildConnectionOpenInitPayload, CanBuildConnectionOpenTryPayload,
+};
 use hermes_relayer_components::chain::traits::payload_builders::update_client::CanBuildUpdateClientPayload;
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::queries::client_state::CanQueryClientState;
@@ -167,8 +173,14 @@ pub trait CanUseSovereignChain:
     + CanQueryConsensusStateHeight<CosmosChain>
     + HasClientStateFields<CosmosChain>
     + HasInitConnectionOptionsType<CosmosChain>
-    + CanBuildConnectionHandshakePayloads<CosmosChain>
-    + CanBuildConnectionHandshakeMessages<CosmosChain>
+    + CanBuildConnectionOpenInitPayload<CosmosChain>
+    + CanBuildConnectionOpenTryPayload<CosmosChain>
+    + CanBuildConnectionOpenAckPayload<CosmosChain>
+    + CanBuildConnectionOpenConfirmPayload<CosmosChain>
+    + CanBuildConnectionOpenInitMessage<CosmosChain>
+    + CanBuildConnectionOpenTryMessage<CosmosChain>
+    + CanBuildConnectionOpenAckMessage<CosmosChain>
+    + CanBuildConnectionOpenConfirmMessage<CosmosChain>
     + HasChannelHandshakePayloadTypes<CosmosChain>
     + HasInitChannelOptionsType<CosmosChain>
     + CanBuildChannelHandshakePayloads<CosmosChain>

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -18,8 +18,12 @@ use hermes_relayer_components::chain::traits::message_builders::ack_packet::{
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::{
     CanBuildChannelHandshakeMessages, ChannelHandshakeMessageBuilderComponent,
 };
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    CanBuildConnectionOpenAckMessage, CanBuildConnectionOpenConfirmMessage,
+    CanBuildConnectionOpenInitMessage, CanBuildConnectionOpenTryMessage,
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::{
     CanBuildCreateClientMessage, CreateClientMessageBuilderComponent,
 };
@@ -53,8 +57,9 @@ use hermes_relayer_components::chain::traits::types::channel::ChannelHandshakePa
 use hermes_relayer_components::chain::traits::types::channel::InitChannelOptionsTypeComponent;
 use hermes_relayer_components::chain::traits::types::client_state::RawClientStateTypeComponent;
 use hermes_relayer_components::chain::traits::types::connection::{
-    ConnectionHandshakePayloadTypeComponent, HasInitConnectionOptionsType,
-    InitConnectionOptionsTypeComponent,
+    ConnectionOpenAckPayloadTypeComponent, ConnectionOpenConfirmPayloadTypeComponent,
+    ConnectionOpenInitPayloadTypeComponent, ConnectionOpenTryPayloadTypeComponent,
+    HasInitConnectionOptionsType, InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::RawConsensusStateTypeComponent;
 use hermes_relayer_components::chain::traits::types::create_client::{
@@ -220,7 +225,12 @@ delegate_components! {
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
             InitConnectionOptionsTypeComponent,
-            ConnectionHandshakePayloadTypeComponent,
+
+            ConnectionOpenInitPayloadTypeComponent,
+            ConnectionOpenTryPayloadTypeComponent,
+            ConnectionOpenAckPayloadTypeComponent,
+            ConnectionOpenConfirmPayloadTypeComponent,
+
             InitChannelOptionsTypeComponent,
             ChannelHandshakePayloadTypeComponent,
 
@@ -260,7 +270,11 @@ delegate_components! {
             ReceivePacketMessageBuilderComponent,
             TimeoutUnorderedPacketMessageBuilderComponent,
 
-            ConnectionHandshakeMessageBuilderComponent,
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+
             ChannelHandshakeMessageBuilderComponent,
         ]:
             SovereignRollupClientComponents,
@@ -347,7 +361,10 @@ pub trait CanUseSovereignRollup:
     + CanBuildReceivePacketMessage<CosmosChain>
     + CanBuildTimeoutUnorderedPacketMessage<CosmosChain>
     + HasInitConnectionOptionsType<CosmosChain>
-    + CanBuildConnectionHandshakeMessages<CosmosChain>
+    + CanBuildConnectionOpenInitMessage<CosmosChain>
+    + CanBuildConnectionOpenTryMessage<CosmosChain>
+    + CanBuildConnectionOpenAckMessage<CosmosChain>
+    + CanBuildConnectionOpenConfirmMessage<CosmosChain>
     + CanBuildChannelHandshakeMessages<CosmosChain>
 where
     Self::Runtime: HasMutex,

--- a/crates/sovereign/sovereign-relayer/src/exts/cosmos/chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/exts/cosmos/chain.rs
@@ -2,7 +2,10 @@ use cgp_core::prelude::*;
 use hermes_cosmos_chain_components::components::delegate::DelegateCosmosChainComponents;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::CanBuildChannelHandshakeMessages;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::CanBuildConnectionHandshakeMessages;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    CanBuildConnectionOpenAckMessage, CanBuildConnectionOpenConfirmMessage,
+    CanBuildConnectionOpenInitMessage, CanBuildConnectionOpenTryMessage,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CanBuildCreateClientMessage;
 use hermes_relayer_components::chain::traits::message_builders::update_client::CanBuildUpdateClientMessage;
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
@@ -32,7 +35,10 @@ pub trait CanUseCosmosChainWithSovereign:
     + CanQueryConsensusStateHeights<SovereignChain>
     + CanBuildCreateClientMessage<SovereignChain>
     + CanBuildUpdateClientMessage<SovereignChain>
-    + CanBuildConnectionHandshakeMessages<SovereignChain>
+    + CanBuildConnectionOpenInitMessage<SovereignChain>
+    + CanBuildConnectionOpenTryMessage<SovereignChain>
+    + CanBuildConnectionOpenAckMessage<SovereignChain>
+    + CanBuildConnectionOpenConfirmMessage<SovereignChain>
     + HasCreateClientOptionsType<SovereignChain>
     + CanBuildCreateClientPayload<SovereignChain>
     + CanBuildUpdateClientPayload<SovereignChain>

--- a/crates/sovereign/sovereign-rollup-components/src/components.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/components.rs
@@ -7,7 +7,10 @@ use hermes_relayer_components::chain::impls::queries::query_and_convert_client_s
 use hermes_relayer_components::chain::impls::queries::query_and_convert_consensus_state::QueryAndConvertRawConsensusState;
 use hermes_relayer_components::chain::traits::message_builders::ack_packet::AckPacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::ChannelHandshakeMessageBuilderComponent;
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::receive_packet::ReceivePacketMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::timeout_unordered_packet::TimeoutUnorderedPacketMessageBuilderComponent;
@@ -29,7 +32,9 @@ use hermes_relayer_components::chain::traits::types::channel::{
 };
 use hermes_relayer_components::chain::traits::types::client_state::RawClientStateTypeComponent;
 use hermes_relayer_components::chain::traits::types::connection::{
-    ConnectionHandshakePayloadTypeComponent, InitConnectionOptionsTypeComponent,
+    ConnectionOpenAckPayloadTypeComponent, ConnectionOpenConfirmPayloadTypeComponent,
+    ConnectionOpenInitPayloadTypeComponent, ConnectionOpenTryPayloadTypeComponent,
+    InitConnectionOptionsTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::consensus_state::RawConsensusStateTypeComponent;
 use hermes_relayer_components::chain::traits::types::create_client::{
@@ -113,7 +118,12 @@ delegate_components! {
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
             InitConnectionOptionsTypeComponent,
-            ConnectionHandshakePayloadTypeComponent,
+
+            ConnectionOpenInitPayloadTypeComponent,
+            ConnectionOpenTryPayloadTypeComponent,
+            ConnectionOpenAckPayloadTypeComponent,
+            ConnectionOpenConfirmPayloadTypeComponent,
+
             InitChannelOptionsTypeComponent,
             ChannelHandshakePayloadTypeComponent,
         ]:
@@ -179,8 +189,15 @@ delegate_components! {
             QueryConsensusStateHeightsAndFindHeightBefore,
         AckPacketMessageBuilderComponent:
             BuildAckPacketMessageOnSovereign,
-        ConnectionHandshakeMessageBuilderComponent:
+
+        [
+            ConnectionOpenInitMessageBuilderComponent,
+            ConnectionOpenTryMessageBuilderComponent,
+            ConnectionOpenAckMessageBuilderComponent,
+            ConnectionOpenConfirmMessageBuilderComponent,
+        ]:
             BuildCosmosConnectionHandshakeMessageOnSovereign,
+
         ChannelHandshakeMessageBuilderComponent:
             BuildCosmosChannelHandshakeMessageOnSovereign,
         ReceivePacketMessageBuilderComponent:

--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/connection/connection_handshake_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/connection/connection_handshake_message.rs
@@ -8,9 +8,14 @@ use hermes_cosmos_chain_components::types::payloads::connection::{
     CosmosConnectionOpenAckPayload, CosmosConnectionOpenConfirmPayload,
     CosmosConnectionOpenInitPayload, CosmosConnectionOpenTryPayload,
 };
-use hermes_relayer_components::chain::traits::message_builders::connection_handshake::ConnectionHandshakeMessageBuilder;
+use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
+    ConnectionOpenAckMessageBuilder, ConnectionOpenConfirmMessageBuilder,
+    ConnectionOpenInitMessageBuilder, ConnectionOpenTryMessageBuilder,
+};
 use hermes_relayer_components::chain::traits::types::connection::{
-    HasConnectionHandshakePayloadTypes, HasInitConnectionOptionsType,
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+    HasInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 
@@ -21,7 +26,7 @@ use crate::types::payloads::connection::SovereignInitConnectionOptions;
 
 pub struct BuildCosmosConnectionHandshakeMessageOnSovereign;
 
-impl<Chain, Counterparty> ConnectionHandshakeMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildCosmosConnectionHandshakeMessageOnSovereign
 where
     Chain: HasInitConnectionOptionsType<
@@ -33,12 +38,9 @@ where
             ClientId = ClientId,
             ConnectionId = ConnectionId,
         > + HasErrorType,
-    Counterparty: HasConnectionHandshakePayloadTypes<
+    Counterparty: HasConnectionOpenInitPayloadType<
             Chain,
             ConnectionOpenInitPayload = CosmosConnectionOpenInitPayload,
-            ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
-            ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
-            ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
         > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
 {
     async fn build_connection_open_init_message(
@@ -68,7 +70,22 @@ where
 
         Ok(sovereign_msg)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
+    for BuildCosmosConnectionHandshakeMessageOnSovereign
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = SovereignMessage,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasErrorType,
+    Counterparty: HasConnectionOpenTryPayloadType<
+            Chain,
+            ConnectionOpenTryPayload = CosmosConnectionOpenTryPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_try_message(
         _chain: &Chain,
         client_id: &Chain::ClientId,
@@ -108,7 +125,22 @@ where
 
         Ok(sovereign_msg)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
+    for BuildCosmosConnectionHandshakeMessageOnSovereign
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = SovereignMessage,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasErrorType,
+    Counterparty: HasConnectionOpenAckPayloadType<
+            Chain,
+            ConnectionOpenAckPayload = CosmosConnectionOpenAckPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_ack_message(
         _chain: &Chain,
         connection_id: &Chain::ConnectionId,
@@ -142,7 +174,22 @@ where
 
         Ok(sovereign_msg)
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
+    for BuildCosmosConnectionHandshakeMessageOnSovereign
+where
+    Chain: HasIbcChainTypes<
+            Counterparty,
+            Message = SovereignMessage,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasErrorType,
+    Counterparty: HasConnectionOpenConfirmPayloadType<
+            Chain,
+            ConnectionOpenConfirmPayload = CosmosConnectionOpenConfirmPayload,
+        > + HasIbcChainTypes<Chain, ClientId = ClientId, ConnectionId = ConnectionId>,
+{
     async fn build_connection_open_confirm_message(
         _chain: &Chain,
         connection_id: &Chain::ConnectionId,

--- a/crates/sovereign/sovereign-rollup-components/src/impls/sovereign_to_cosmos/connection/connection_handshake_payload.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/sovereign_to_cosmos/connection/connection_handshake_payload.rs
@@ -1,7 +1,13 @@
 use cgp_core::HasErrorType;
-use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::ConnectionHandshakePayloadBuilder;
+use hermes_relayer_components::chain::traits::payload_builders::connection_handshake::{
+    ConnectionOpenAckPayloadBuilder, ConnectionOpenConfirmPayloadBuilder,
+    ConnectionOpenInitPayloadBuilder, ConnectionOpenTryPayloadBuilder,
+};
 use hermes_relayer_components::chain::traits::types::client_state::HasClientStateType;
-use hermes_relayer_components::chain::traits::types::connection::HasConnectionHandshakePayloadTypes;
+use hermes_relayer_components::chain::traits::types::connection::{
+    HasConnectionOpenAckPayloadType, HasConnectionOpenConfirmPayloadType,
+    HasConnectionOpenInitPayloadType, HasConnectionOpenTryPayloadType,
+};
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 
@@ -13,15 +19,12 @@ use crate::types::payloads::connection::{
 
 pub struct BuildSovereignConnectionHandshakePayload;
 
-impl<Chain, Counterparty> ConnectionHandshakePayloadBuilder<Chain, Counterparty>
+impl<Chain, Counterparty> ConnectionOpenInitPayloadBuilder<Chain, Counterparty>
     for BuildSovereignConnectionHandshakePayload
 where
-    Chain: HasConnectionHandshakePayloadTypes<
+    Chain: HasConnectionOpenInitPayloadType<
             Counterparty,
             ConnectionOpenInitPayload = SovereignConnectionOpenInitRollupPayload,
-            ConnectionOpenTryPayload = SovereignConnectionOpenTryRollupPayload,
-            ConnectionOpenAckPayload = SovereignConnectionOpenAckRollupPayload,
-            ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmRollupPayload,
         > + HasIbcChainTypes<
             Counterparty,
             Height = RollupHeight,
@@ -36,7 +39,22 @@ where
     ) -> Result<Chain::ConnectionOpenInitPayload, Chain::Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenTryPayloadBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakePayload
+where
+    Chain: HasConnectionOpenTryPayloadType<
+            Counterparty,
+            ConnectionOpenTryPayload = SovereignConnectionOpenTryRollupPayload,
+        > + HasIbcChainTypes<
+            Counterparty,
+            Height = RollupHeight,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasClientStateType<Counterparty>
+        + HasErrorType,
+{
     async fn build_connection_open_try_payload(
         _chain: &Chain,
         _client_state: &Chain::ClientState,
@@ -46,7 +64,22 @@ where
     ) -> Result<Chain::ConnectionOpenTryPayload, Chain::Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenAckPayloadBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakePayload
+where
+    Chain: HasConnectionOpenAckPayloadType<
+            Counterparty,
+            ConnectionOpenAckPayload = SovereignConnectionOpenAckRollupPayload,
+        > + HasIbcChainTypes<
+            Counterparty,
+            Height = RollupHeight,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasClientStateType<Counterparty>
+        + HasErrorType,
+{
     async fn build_connection_open_ack_payload(
         _chain: &Chain,
         _client_state: &Chain::ClientState,
@@ -56,7 +89,22 @@ where
     ) -> Result<Chain::ConnectionOpenAckPayload, Chain::Error> {
         todo!()
     }
+}
 
+impl<Chain, Counterparty> ConnectionOpenConfirmPayloadBuilder<Chain, Counterparty>
+    for BuildSovereignConnectionHandshakePayload
+where
+    Chain: HasConnectionOpenConfirmPayloadType<
+            Counterparty,
+            ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmRollupPayload,
+        > + HasIbcChainTypes<
+            Counterparty,
+            Height = RollupHeight,
+            ClientId = ClientId,
+            ConnectionId = ConnectionId,
+        > + HasClientStateType<Counterparty>
+        + HasErrorType,
+{
     async fn build_connection_open_confirm_payload(
         _chain: &Chain,
         _client_state: &Chain::ClientState,

--- a/crates/sovereign/sovereign-rollup-components/src/impls/types/payload.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/types/payload.rs
@@ -3,7 +3,9 @@ use hermes_relayer_components::chain::traits::types::channel::{
     ProvideChannelHandshakePayloadTypes, ProvideInitChannelOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::connection::{
-    ProvideConnectionHandshakePayloadTypes, ProvideInitConnectionOptionsType,
+    ProvideConnectionOpenAckPayloadType, ProvideConnectionOpenConfirmPayloadType,
+    ProvideConnectionOpenInitPayloadType, ProvideConnectionOpenTryPayloadType,
+    ProvideInitConnectionOptionsType,
 };
 use hermes_relayer_components::chain::traits::types::create_client::{
     ProvideCreateClientOptionsType, ProvideCreateClientPayloadType,
@@ -63,17 +65,35 @@ where
     type InitConnectionOptions = SovereignInitConnectionOptions;
 }
 
-impl<Chain, Counterparty> ProvideConnectionHandshakePayloadTypes<Chain, Counterparty>
+impl<Chain, Counterparty> ProvideConnectionOpenInitPayloadType<Chain, Counterparty>
     for ProvideSovereignRollupPayloadTypes
 where
     Chain: Async,
 {
     type ConnectionOpenInitPayload = SovereignConnectionOpenInitRollupPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenTryPayloadType<Chain, Counterparty>
+    for ProvideSovereignRollupPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenTryPayload = SovereignConnectionOpenTryRollupPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenAckPayloadType<Chain, Counterparty>
+    for ProvideSovereignRollupPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenAckPayload = SovereignConnectionOpenAckRollupPayload;
+}
 
+impl<Chain, Counterparty> ProvideConnectionOpenConfirmPayloadType<Chain, Counterparty>
+    for ProvideSovereignRollupPayloadTypes
+where
+    Chain: Async,
+{
     type ConnectionOpenConfirmPayload = SovereignConnectionOpenConfirmRollupPayload;
 }
 


### PR DESCRIPTION
This PR splits up the connection handshake components into smaller components consist of the smaller steps: OpenInit, OpenTry, OpenAck, and OpenConfirm.

This allows for more fine grained implementation of each connection handshake step, and avoid bloating up the dependencies combined from all handshake steps.