### PR TITLE
Add counterparty proof height for IBC SovereignMessage

### DIFF
--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/create_client_message.rs
@@ -59,7 +59,7 @@ where
 
         let any_message = encode_to_any(TYPE_URL, &proto_message);
 
-        let message = IbcMessageWithHeight::new(any_message).into();
+        let message = IbcMessageWithHeight::new(any_message, None).into();
 
         Ok(message)
     }

--- a/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/update_client_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/cosmos_to_sovereign/client/update_client_message.rs
@@ -51,5 +51,5 @@ pub fn encode_tendermint_header(
 
     let any_message = encode_to_any(TYPE_URL, &proto_message);
 
-    IbcMessageWithHeight::new(any_message).into()
+    IbcMessageWithHeight::new(any_message, None).into()
 }

--- a/crates/sovereign/sovereign-rollup-components/src/types/message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/types/message.rs
@@ -16,6 +16,12 @@ impl From<CosmosMessage> for SovereignMessage {
     fn from(cosmos_message: CosmosMessage) -> Self {
         let cosmos_message_any = cosmos_message.message.encode_protobuf(&Signer::dummy());
 
-        IbcMessageWithHeight::new(cosmos_message_any).into()
+        IbcMessageWithHeight::new(
+            cosmos_message_any,
+            cosmos_message
+                .message
+                .counterparty_message_height_for_update_client(),
+        )
+        .into()
     }
 }

--- a/crates/sovereign/sovereign-rollup-components/src/types/messages/ibc.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/types/messages/ibc.rs
@@ -16,17 +16,10 @@ pub struct IbcMessageWithHeight {
 }
 
 impl IbcMessageWithHeight {
-    pub fn new(message: Any) -> Self {
+    pub fn new(message: Any, counterparty_height: Option<Height>) -> Self {
         Self {
             message,
-            counterparty_height: None,
-        }
-    }
-
-    pub fn new_with_height(message: Any, height: Height) -> Self {
-        Self {
-            message,
-            counterparty_height: Some(height),
+            counterparty_height,
         }
     }
 }


### PR DESCRIPTION
The previous refactoring caused IBC messages that are embedded inside `SovereignMessage` to return `None` when retrieving the counterparty proof height. This causes the UpdateClient message to not be built by the relayer when submitting the IBC messages.