### PR TITLE
Support sending multiple messages to Sovereign rollup

### DIFF
--- a/crates/relayer/relayer-components/src/chain/impls/forward/mod.rs
+++ b/crates/relayer/relayer-components/src/chain/impls/forward/mod.rs
@@ -1,2 +1,3 @@
 pub mod message_builders;
 pub mod queries;
+pub mod send_message;

--- a/crates/relayer/relayer-components/src/chain/impls/forward/send_message.rs
+++ b/crates/relayer/relayer-components/src/chain/impls/forward/send_message.rs
@@ -1,0 +1,26 @@
+use alloc::vec::Vec;
+use cgp_core::{CanRaiseError, HasInner};
+
+use crate::chain::traits::send_message::{CanSendMessages, MessageSender};
+use crate::chain::traits::types::event::HasEventType;
+use crate::chain::traits::types::message::HasMessageType;
+
+pub struct ForwardSendMessage;
+
+impl<Chain, InChain> MessageSender<Chain> for ForwardSendMessage
+where
+    Chain:
+        HasMessageType + HasEventType + HasInner<Inner = InChain> + CanRaiseError<InChain::Error>,
+    InChain: CanSendMessages<Message = Chain::Message, Event = Chain::Event>,
+{
+    async fn send_messages(
+        chain: &Chain,
+        messages: Vec<Chain::Message>,
+    ) -> Result<Vec<Vec<Chain::Event>>, Chain::Error> {
+        chain
+            .inner()
+            .send_messages(messages)
+            .await
+            .map_err(Chain::raise_error)
+    }
+}

--- a/crates/sovereign/sovereign-chain-components/src/sovereign/components.rs
+++ b/crates/sovereign/sovereign-chain-components/src/sovereign/components.rs
@@ -12,6 +12,7 @@ use hermes_relayer_components::chain::impls::forward::queries::consensus_state_h
 use hermes_relayer_components::chain::impls::forward::queries::packet_acknowledgement::ForwardQueryPacketAcknowledgement;
 use hermes_relayer_components::chain::impls::forward::queries::packet_commitment::ForwardQueryPacketCommitment;
 use hermes_relayer_components::chain::impls::forward::queries::packet_receipt::ForwardQueryPacketReceipt;
+use hermes_relayer_components::chain::impls::forward::send_message::ForwardSendMessage;
 use hermes_relayer_components::chain::impls::payload_builders::channel::BuildChannelHandshakePayload;
 use hermes_relayer_components::chain::impls::payload_builders::connection::BuildConnectionHandshakePayload;
 use hermes_relayer_components::chain::impls::payload_builders::packet::BuildPacketPayloads;
@@ -64,6 +65,7 @@ use hermes_relayer_components::chain::traits::queries::consensus_state_height::C
 use hermes_relayer_components::chain::traits::queries::packet_acknowledgement::PacketAcknowledgementQuerierComponent;
 use hermes_relayer_components::chain::traits::queries::packet_commitment::PacketCommitmentQuerierComponent;
 use hermes_relayer_components::chain::traits::queries::packet_receipt::PacketReceiptQuerierComponent;
+use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
 use hermes_relayer_components::chain::traits::types::channel::{
     ChannelEndTypeComponent, ChannelOpenAckPayloadTypeComponent,
@@ -211,6 +213,8 @@ delegate_components! {
             ProvideSovereignIbcCommitmentPrefix,
         PacketFieldsReaderComponent:
             CosmosPacketFieldReader,
+        MessageSenderComponent:
+            ForwardSendMessage,
         CreateClientPayloadBuilderComponent:
             BuildSovereignCreateClientPayload,
         CreateClientMessageBuilderComponent:

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_chain.rs
@@ -1,7 +1,6 @@
 use cgp_core::prelude::*;
 use cgp_core::{delegate_all, ErrorRaiserComponent, ErrorTypeComponent, ProvideInner};
 use cgp_error_eyre::{ProvideEyreError, RaiseDebugError};
-use eyre::Error;
 use hermes_cosmos_chain_components::types::channel::CosmosInitChannelOptions;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_encoding_components::traits::has_encoding::{
@@ -52,7 +51,7 @@ use hermes_relayer_components::chain::traits::queries::consensus_state_height::C
 use hermes_relayer_components::chain::traits::queries::packet_acknowledgement::CanQueryPacketAcknowledgement;
 use hermes_relayer_components::chain::traits::queries::packet_commitment::CanQueryPacketCommitment;
 use hermes_relayer_components::chain::traits::queries::packet_receipt::CanQueryPacketReceipt;
-use hermes_relayer_components::chain::traits::send_message::{CanSendMessages, MessageSender};
+use hermes_relayer_components::chain::traits::send_message::CanSendMessages;
 use hermes_relayer_components::chain::traits::types::chain_id::{
     ChainIdGetter, HasChainId, HasChainIdType,
 };
@@ -96,7 +95,6 @@ use hermes_sovereign_chain_components::sovereign::traits::chain::rollup::{
 use hermes_sovereign_rollup_components::traits::chain_status::CanQueryChainStatusAtHeight;
 use hermes_sovereign_rollup_components::types::client_state::WrappedSovereignClientState;
 use hermes_sovereign_rollup_components::types::consensus_state::SovereignConsensusState;
-use hermes_sovereign_rollup_components::types::event::SovereignEvent;
 use hermes_sovereign_rollup_components::types::height::RollupHeight;
 use hermes_sovereign_rollup_components::types::message::SovereignMessage;
 use ibc::core::channel::types::channel::ChannelEnd;
@@ -183,15 +181,6 @@ impl RuntimeGetter<SovereignChain> for SovereignChainComponents {
 impl ChainIdGetter<SovereignChain> for SovereignChainComponents {
     fn chain_id(chain: &SovereignChain) -> &ChainId {
         chain.data_chain.chain_id()
-    }
-}
-
-impl MessageSender<SovereignChain> for SovereignChainComponents {
-    async fn send_messages(
-        chain: &SovereignChain,
-        messages: Vec<SovereignMessage>,
-    ) -> Result<Vec<Vec<SovereignEvent>>, Error> {
-        chain.rollup.send_messages(messages).await
     }
 }
 

--- a/crates/sovereign/sovereign-rollup-components/src/components.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/components.rs
@@ -1,5 +1,6 @@
 use crate::impls::queries::chain_status::QuerySovereignRollupStatusAtHeight;
 use crate::impls::queries::packet_acknowledgement::QueryPacketAcknowledgementFromSovereign;
+use crate::impls::send_message::SendMessagesInSequence;
 use cgp_core::prelude::*;
 use hermes_cosmos_chain_components::impls::channel::channel_handshake_message::BuildCosmosChannelHandshakeMessage;
 use hermes_cosmos_chain_components::impls::connection::connection_handshake_message::BuildCosmosConnectionHandshakeMessage;
@@ -211,12 +212,13 @@ delegate_components! {
             ProvideSovereignTransactionTypes,
         [
             NonceAllocatorComponent,
-            MessageSenderComponent,
             MessagesWithSignerSenderComponent,
             MessagesWithSignerAndNonceSenderComponent,
             TxResponsePollerComponent,
         ]:
             DefaultTxComponents,
+        MessageSenderComponent:
+            SendMessagesInSequence<DefaultTxComponents>,
         IbcCommitmentPrefixGetterComponent:
             ProvideSovereignIbcCommitmentPrefix,
         JsonRpcClientTypeComponent:

--- a/crates/sovereign/sovereign-rollup-components/src/impls/mod.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/mod.rs
@@ -6,5 +6,6 @@ pub mod events;
 pub mod json_rpc_client;
 pub mod message_height;
 pub mod queries;
+pub mod send_message;
 pub mod transaction;
 pub mod types;

--- a/crates/sovereign/sovereign-rollup-components/src/impls/send_message.rs
+++ b/crates/sovereign/sovereign-rollup-components/src/impls/send_message.rs
@@ -1,0 +1,53 @@
+use core::marker::PhantomData;
+
+use cgp_core::CanRaiseError;
+use hermes_relayer_components::chain::traits::send_message::MessageSender;
+use hermes_relayer_components::chain::traits::types::event::HasEventType;
+use hermes_relayer_components::chain::traits::types::message::HasMessageType;
+
+/**
+   As a workaround of Sovereign SDK allowing only one message per transaction,
+   we are sending one message at a time to the rollup, and only send the next
+   message if the previous message succeeded. Although it is very inefficient,
+   this helps us continue development without having to handle multi-transaction
+   failure.
+
+   Although Sovereign SDK allows multiple transactions to be submitted at the
+   same time, the semantics is subtly different from sending multiple messages
+   per transaction. In particular, it is very challenging to recover from
+   faiures, in case only some of the transactions succeed. There are all kinds
+   of corner cases and race conditions that we would have to deal with, to ensure
+   that subsequent transactions do not conflict with the supposingly failed
+   transaction, which could in fact succeeded later without the relayer knowing.
+
+   Because of this, we are deferring in handling such complexity, and opt for the
+   simpler semantics of sending one message at a time for now.
+*/
+pub struct SendMessagesInSequence<InSender>(pub PhantomData<InSender>);
+
+impl<Chain, InSender> MessageSender<Chain> for SendMessagesInSequence<InSender>
+where
+    Chain: HasMessageType + HasEventType + CanRaiseError<&'static str>,
+    InSender: MessageSender<Chain>,
+{
+    async fn send_messages(
+        chain: &Chain,
+        messages: Vec<Chain::Message>,
+    ) -> Result<Vec<Vec<Chain::Event>>, Chain::Error> {
+        let mut events = Vec::new();
+
+        for message in messages {
+            let in_events = InSender::send_messages(chain, vec![message]).await?;
+
+            let [in_events] = <[Vec<Chain::Event>; 1]>::try_from(in_events).map_err(|_| {
+                Chain::raise_error(
+                    "expected inner message sender to return exactly one list of events",
+                )
+            })?;
+
+            events.push(in_events);
+        }
+
+        Ok(events)
+    }
+}


### PR DESCRIPTION
Add partial support for sending multiple messages to Sovereign rollup, by sequentially sending one message at a time.