### PR TITLE
Simplify some use of HasMutex bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ license         = "Apache-2.0"
 keywords        = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository      = "https://github.com/informalsystems/hermes-sdk"
 authors         = ["Informal Systems <hello@informal.systems>"]
-rust-version    = "1.72"
+rust-version    = "1.79"
 
 [workspace.dependencies]
 async-trait                     = { version = "0.1.80" }

--- a/crates/relayer/relayer-components-extra/src/batch/worker.rs
+++ b/crates/relayer/relayer-components-extra/src/batch/worker.rs
@@ -108,8 +108,7 @@ where
 trait CanRunLoop<Target>: HasRelayChains
 where
     Target: ChainTarget<Self>,
-    Target::TargetChain: HasRuntime,
-    RuntimeOf<Target::TargetChain>: HasChannelTypes + HasChannelOnceTypes,
+    Target::TargetChain: HasRuntime<Runtime: HasChannelTypes + HasChannelOnceTypes>,
 {
     async fn run_loop(
         &self,
@@ -118,7 +117,6 @@ where
     );
 }
 
-#[async_trait]
 impl<Relay, Target, Runtime> CanRunLoop<Target> for Relay
 where
     Relay: CanProcessMessageBatches<Target> + HasLogger,

--- a/crates/relayer/relayer-components-extra/src/build/components/relay/batch.rs
+++ b/crates/relayer/relayer-components-extra/src/build/components/relay/batch.rs
@@ -49,7 +49,6 @@ where
     DstChain: HasRuntime<Runtime = DstRuntime> + HasChainId,
     SrcRuntime: HasChannelTypes + HasChannelOnceTypes + HasErrorType,
     DstRuntime: HasChannelTypes + HasChannelOnceTypes + HasErrorType,
-    Build::Runtime: HasMutex,
 {
     async fn build_relay_from_chains(
         build: &Build,
@@ -137,7 +136,6 @@ where
     >;
 }
 
-#[async_trait]
 impl<Build, Target, Chain, Counterparty, Runtime> CanBuildBatchChannel<Target> for Build
 where
     Build: HasBiRelayType + HasRuntime + HasErrorType,

--- a/crates/relayer/relayer-components-extra/src/build/traits/cache.rs
+++ b/crates/relayer/relayer-components-extra/src/build/traits/cache.rs
@@ -25,10 +25,9 @@ pub trait HasBatchSenderCacheType<Build, Error>: Async {
 impl<Target, Build, Error> HasBatchSenderCacheType<Build, Error> for Target
 where
     Error: Async,
-    Build: HasBiRelayType + HasRuntime,
+    Build: HasBiRelayType + HasRuntime<Runtime: HasMutex>,
     Target: ChainBuildTarget<Build>,
     Target::TargetChain: HasMessageBatchSenderType<Error>,
-    Build::Runtime: HasMutex,
 {
     type BatchSenderCache = MutexOf<
         RuntimeOf<Build>,

--- a/crates/relayer/relayer-components-extra/src/components/extra/build.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/build.rs
@@ -22,7 +22,6 @@ use hermes_relayer_components::components::default::build::DefaultBuildComponent
 use hermes_relayer_components::relay::traits::chains::{CanRaiseRelayChainErrors, HasRelayChains};
 use hermes_runtime_components::traits::channel::{CanCloneSender, CanCreateChannels};
 use hermes_runtime_components::traits::channel_once::CanUseChannelsOnce;
-use hermes_runtime_components::traits::mutex::HasMutex;
 use hermes_runtime_components::traits::runtime::HasRuntime;
 
 use crate::batch::traits::config::HasBatchConfig;
@@ -98,7 +97,6 @@ where
     ChainB::ClientId: Ord + Clone,
     ChainA::Runtime: CanCreateChannels + CanUseChannelsOnce + CanCloneSender,
     ChainB::Runtime: CanCreateChannels + CanUseChannelsOnce + CanCloneSender,
-    Build::Runtime: HasMutex,
     Components: HasComponents<Components = BaseComponents>
         + DelegatesToExtraBuildComponents<BaseComponents>
         + BiRelayFromRelayBuilder<Build>

--- a/crates/relayer/relayer-components/src/build/components/chain/cache.rs
+++ b/crates/relayer/relayer-components/src/build/components/chain/cache.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use cgp_core::{async_trait, HasErrorType};
+use cgp_core::HasErrorType;
 use hermes_runtime_components::traits::mutex::HasMutex;
 
 use crate::build::traits::cache::HasChainCache;
@@ -10,7 +10,6 @@ use crate::build::types::aliases::{TargetChain, TargetChainId};
 
 pub struct BuildChainWithCache<InBuilder>(pub PhantomData<InBuilder>);
 
-#[async_trait]
 impl<InBuilder, Build, Target> ChainBuilder<Build, Target> for BuildChainWithCache<InBuilder>
 where
     TargetChain<Build, Target>: Clone,
@@ -18,7 +17,6 @@ where
     Build: HasChainCache<Target> + HasErrorType,
     InBuilder: ChainBuilder<Build, Target>,
     Target: ChainBuildTarget<Build>,
-    Build::Runtime: HasMutex,
 {
     async fn build_chain(
         build: &Build,

--- a/crates/relayer/relayer-components/src/build/components/relay/cache.rs
+++ b/crates/relayer/relayer-components/src/build/components/relay/cache.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use cgp_core::{async_trait, HasErrorType};
+use cgp_core::HasErrorType;
 use hermes_runtime_components::traits::mutex::HasMutex;
 
 use crate::build::traits::cache::HasRelayCache;
@@ -12,7 +12,6 @@ use crate::build::types::aliases::{
 
 pub struct BuildRelayWithCache<InBuilder>(pub PhantomData<InBuilder>);
 
-#[async_trait]
 impl<InBuilder, Build, Target> RelayBuilder<Build, Target> for BuildRelayWithCache<InBuilder>
 where
     TargetSrcChainId<Build, Target>: Ord + Clone,
@@ -23,7 +22,6 @@ where
     Build: HasRelayCache<Target> + HasErrorType,
     InBuilder: RelayBuilder<Build, Target>,
     Target: RelayBuildTarget<Build>,
-    Build::Runtime: HasMutex,
 {
     async fn build_relay(
         build: &Build,

--- a/crates/relayer/relayer-components/src/build/traits/cache.rs
+++ b/crates/relayer/relayer-components/src/build/traits/cache.rs
@@ -6,18 +6,16 @@ use crate::build::traits::target::chain::ChainBuildTarget;
 use crate::build::traits::target::relay::RelayBuildTarget;
 use crate::build::types::aliases::{TargetChainCache, TargetRelayCache};
 
-pub trait HasChainCache<Target>: HasBiRelayType + HasRuntime
+pub trait HasChainCache<Target>: HasBiRelayType + HasRuntime<Runtime: HasMutex>
 where
     Target: ChainBuildTarget<Self>,
-    Self::Runtime: HasMutex,
 {
     fn chain_cache(&self) -> &TargetChainCache<Self, Target>;
 }
 
-pub trait HasRelayCache<Target>: HasBiRelayType + HasRuntime
+pub trait HasRelayCache<Target>: HasBiRelayType + HasRuntime<Runtime: HasMutex>
 where
     Target: RelayBuildTarget<Self>,
-    Self::Runtime: HasMutex,
 {
     fn relay_cache(&self) -> &TargetRelayCache<Self, Target>;
 }

--- a/crates/relayer/relayer-components/src/components/default/build.rs
+++ b/crates/relayer/relayer-components/src/components/default/build.rs
@@ -1,7 +1,6 @@
 use core::marker::PhantomData;
 
 use cgp_core::prelude::*;
-use hermes_runtime_components::traits::mutex::HasMutex;
 
 use crate::birelay::traits::two_way::{HasTwoChainTypes, HasTwoWayRelay};
 use crate::build::components::birelay::BuildBiRelayFromRelays;
@@ -66,7 +65,6 @@ where
     ChainB::ChainId: Ord + Clone,
     ChainA::ClientId: Ord + Clone,
     ChainB::ClientId: Ord + Clone,
-    Build::Runtime: HasMutex,
     Components: HasComponents<Components = BaseComponents>
         + DelegatesToDefaultBuildComponents<BaseComponents>
         + BiRelayFromRelayBuilder<Build>

--- a/crates/relayer/relayer-components/src/components/default/transaction.rs
+++ b/crates/relayer/relayer-components/src/components/default/transaction.rs
@@ -2,7 +2,6 @@ use cgp_core::prelude::*;
 use cgp_core::CanRaiseError;
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLog;
-use hermes_runtime_components::traits::mutex::HasMutex;
 use hermes_runtime_components::traits::sleep::CanSleep;
 use hermes_runtime_components::traits::time::HasTime;
 
@@ -99,7 +98,7 @@ where
         + CanParseTxResponseAsEvents
         + for<'a> CanRaiseError<TxNoResponseError<'a, Chain>>
         + HasComponents<Components = Components>,
-    Chain::Runtime: HasMutex + HasTime + CanSleep,
+    Chain::Runtime: HasTime + CanSleep,
     Logger: for<'a> CanLog<LogSendMessagesWithSignerAndNonce<'a, Chain>>
         + for<'a> CanLog<TxNoResponseError<'a, Chain>>
         + for<'a> CanLog<LogRetryQueryTxResponse<'a, Chain>>,

--- a/crates/relayer/relayer-components/src/relay/impls/packet_lock.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/packet_lock.rs
@@ -36,10 +36,7 @@ pub type PacketKey<Relay> = (
 pub type PacketMutex<Relay> = Arc<MutexOf<RuntimeOf<Relay>, BTreeSet<PacketKey<Relay>>>>;
 
 #[derive_component(PacketMutexGetterComponent, PacketMutexGetter<Relay>)]
-pub trait HasPacketMutex: HasRuntime + HasRelayChains
-where
-    Self::Runtime: HasMutex,
-{
+pub trait HasPacketMutex: HasRuntime<Runtime: HasMutex> + HasRelayChains {
     fn packet_mutex(&self) -> &PacketMutex<Self>;
 }
 pub struct ReleasePacketLockTask<Relay>
@@ -71,7 +68,7 @@ where
     Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain, Packet = Packet>
         + HasRuntime<Runtime = Runtime>
         + HasPacketMutex,
-    Runtime: HasMutex + CanUseChannelsOnce + CanCreateChannelsOnce + CanSpawnTask,
+    Runtime: CanUseChannelsOnce + CanCreateChannelsOnce + CanSpawnTask,
     SrcChain: CanReadPacketFields<DstChain, OutgoingPacket = Packet>,
     DstChain: HasIbcChainTypes<SrcChain>,
     SrcChain::ChannelId: Clone + Ord,

--- a/crates/relayer/relayer-components/src/transaction/impls/allocate_nonce_with_mutex.rs
+++ b/crates/relayer/relayer-components/src/transaction/impls/allocate_nonce_with_mutex.rs
@@ -9,7 +9,6 @@ pub struct AllocateNonceWithMutex;
 impl<Context> NonceAllocator<Context> for AllocateNonceWithMutex
 where
     Context: CanQueryNonce + HasMutexForNonceAllocation,
-    Context::Runtime: HasMutex,
 {
     async fn allocate_nonce<'a>(
         context: &'a Context,

--- a/crates/relayer/relayer-components/src/transaction/traits/nonce/nonce_mutex.rs
+++ b/crates/relayer/relayer-components/src/transaction/traits/nonce/nonce_mutex.rs
@@ -15,9 +15,8 @@ use crate::transaction::traits::types::signer::HasSignerType;
    allocator only allows one transaction to be submitted at a time.
 */
 #[derive_component(MutexForNonceAllocationComponent, ProvideMutexForNonceAllocation<Chain>)]
-pub trait HasMutexForNonceAllocation: HasRuntime + HasNonceGuard + HasSignerType
-where
-    Self::Runtime: HasMutex,
+pub trait HasMutexForNonceAllocation:
+    HasRuntime<Runtime: HasMutex> + HasNonceGuard + HasSignerType
 {
     fn mutex_for_nonce_allocation<'a>(
         &'a self,

--- a/crates/runtime/async-runtime-components/src/subscription/impls/stream.rs
+++ b/crates/runtime/async-runtime-components/src/subscription/impls/stream.rs
@@ -41,7 +41,6 @@ where
     pub task_senders: Arc<Runtime::Mutex<Option<Vec<Runtime::Sender<T>>>>>,
 }
 
-#[async_trait]
 impl<Runtime, S, T> Task for StreamSubscriptionTask<Runtime, S, T>
 where
     Runtime: HasMutex + CanCreateChannels + CanUseChannels + CanStreamReceiver + HasBoxedStreamType,

--- a/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
+++ b/crates/sovereign/sovereign-relayer/src/contexts/sovereign_rollup.rs
@@ -170,7 +170,7 @@ use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionH
 use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
 use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
-use hermes_runtime_components::traits::mutex::{HasMutex, MutexGuardOf};
+use hermes_runtime_components::traits::mutex::MutexGuardOf;
 use hermes_runtime_components::traits::runtime::{RuntimeGetter, RuntimeTypeComponent};
 use hermes_sovereign_rollup_components::components::SovereignRollupClientComponents;
 use hermes_sovereign_rollup_components::traits::chain_status::{
@@ -473,8 +473,6 @@ pub trait CanUseSovereignRollup:
     + CanBuildConnectionOpenAckMessage<CosmosChain>
     + CanBuildConnectionOpenConfirmMessage<CosmosChain>
     + CanBuildChannelOpenInitMessage<CosmosChain>
-where
-    Self::Runtime: HasMutex,
 {
 }
 


### PR DESCRIPTION
With the release of [Rust v1.79](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html), it is now possible to use _associated type item bounds_, which would propagate the use of trait bounds in associated types, without requiring them to be added to the `where` clause on the use site.

This PR serves as a proof of concept that makes use of associated item bounds to simplify some of the use of `Runtime: HasMutex` in Hermes SDK.