### PR TITLE
Minor refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## v0.2.0 (pre-release)
+
+- Remove unused constraints in `HasTimestampType::Timestamp`. [(#428)](https://github.com/informalsystems/hermes-sdk/pull/428)
+- Update the `header` field in `CosmosUpdateClientMessage` to use `prost_types::Any` instead of `ibc_proto::Any`. [(#428)](https://github.com/informalsystems/hermes-sdk/pull/428)
+- Generalize the `CreateClientMessageBuilder` instance `BuildCosmosCreateClientMessage` to `BuildAnyCreateClientMessage`, and allows generic `CreateClientPayload` that has `client_state: Counterparty::ClientState` and `consensus_state: Counterparty::ConsensusState` fields. [(#428)](https://github.com/informalsystems/hermes-sdk/pull/428)
+- Rename the `ProvideCreateClientMessageOptionsType` instance in Cosmos from `ProvideCosmosCreateClientSettings` to `ProvideNoCreateClientMessageOptionsType`, with `CreateClientMessageOptions = ()`. [(#428)](https://github.com/informalsystems/hermes-sdk/pull/428)
+
+## v0.1.0 (2024-09-03)
+
+- Initial release of Hermes SDK crates on crates.io.

--- a/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
@@ -28,7 +28,7 @@ use crate::impls::client::update_client_message::BuildCosmosUpdateClientMessage;
 use crate::impls::connection::connection_handshake_message::BuildCosmosConnectionHandshakeMessage;
 use crate::impls::message_height::GetCosmosCounterpartyMessageHeight;
 use crate::impls::queries::consensus_state_height::QueryConsensusStateHeightsFromGrpc;
-use crate::impls::types::create_client_options::ProvideCosmosCreateClientSettings;
+use crate::impls::types::create_client_options::ProvideNoCreateClientMessageOptionsType;
 
 define_components! {
     CosmosToCosmosComponents {
@@ -44,7 +44,7 @@ define_components! {
         ]:
             QueryAndConvertRawConsensusState,
         CreateClientMessageOptionsTypeComponent:
-            ProvideCosmosCreateClientSettings,
+            ProvideNoCreateClientMessageOptionsType,
         CreateClientMessageBuilderComponent:
             BuildAnyCreateClientMessage,
         UpdateClientMessageBuilderComponent:

--- a/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
@@ -23,7 +23,7 @@ use hermes_relayer_components::chain::traits::types::create_client::CreateClient
 use hermes_relayer_components::chain::traits::types::ibc::CounterpartyMessageHeightGetterComponent;
 
 use crate::impls::channel::channel_handshake_message::BuildCosmosChannelHandshakeMessage;
-use crate::impls::client::create_client_message::BuildCosmosCreateClientMessage;
+use crate::impls::client::create_client_message::BuildAnyCreateClientMessage;
 use crate::impls::client::update_client_message::BuildCosmosUpdateClientMessage;
 use crate::impls::connection::connection_handshake_message::BuildCosmosConnectionHandshakeMessage;
 use crate::impls::message_height::GetCosmosCounterpartyMessageHeight;
@@ -46,7 +46,7 @@ define_components! {
         CreateClientMessageOptionsTypeComponent:
             ProvideCosmosCreateClientSettings,
         CreateClientMessageBuilderComponent:
-            BuildCosmosCreateClientMessage,
+            BuildAnyCreateClientMessage,
         UpdateClientMessageBuilderComponent:
             BuildCosmosUpdateClientMessage,
         [

--- a/crates/cosmos/cosmos-chain-components/src/impls/client/update_client_message.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/client/update_client_message.rs
@@ -2,7 +2,9 @@ use cgp::core::error::HasErrorType;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
+use ibc_proto::google::protobuf::Any as IbcProtoAny;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
+use prost_types::Any;
 
 use crate::traits::message::{CosmosMessage, ToCosmosMessage};
 use crate::types::messages::client::update::CosmosUpdateClientMessage;
@@ -27,9 +29,14 @@ where
             .headers
             .into_iter()
             .map(|header| {
+                let header_any: IbcProtoAny = header.into();
+
                 let message = CosmosUpdateClientMessage {
                     client_id: client_id.clone(),
-                    header: header.into(),
+                    header: Any {
+                        type_url: header_any.type_url,
+                        value: header_any.value,
+                    },
                 };
 
                 message.to_cosmos_message()

--- a/crates/cosmos/cosmos-chain-components/src/impls/types/create_client_options.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/types/create_client_options.rs
@@ -15,11 +15,12 @@ where
     type CreateClientPayloadOptions = Settings;
 }
 
+pub struct ProvideNoCreateClientMessageOptionsType;
+
 impl<Chain, Counterparty> ProvideCreateClientMessageOptionsType<Chain, Counterparty>
-    for ProvideCosmosCreateClientSettings
+    for ProvideNoCreateClientMessageOptionsType
 where
     Chain: Async,
-    Counterparty: Async,
 {
     type CreateClientMessageOptions = ();
 }

--- a/crates/cosmos/cosmos-chain-components/src/types/messages/client/update.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/messages/client/update.rs
@@ -1,7 +1,8 @@
-use ibc_proto::google::protobuf::Any;
+use ibc_proto::google::protobuf::Any as IbcProtoAny;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 use ibc_relayer_types::signer::Signer;
 use prost::Message;
+use prost_types::Any;
 
 use crate::methods::encode::encode_to_any;
 use crate::traits::message::DynCosmosMessage;
@@ -28,7 +29,7 @@ pub struct ProtoMsgUpdateClient {
 }
 
 impl DynCosmosMessage for CosmosUpdateClientMessage {
-    fn encode_protobuf(&self, signer: &Signer) -> Any {
+    fn encode_protobuf(&self, signer: &Signer) -> IbcProtoAny {
         let proto_message = ProtoMsgUpdateClient {
             client_id: self.client_id.to_string(),
             client_message: Some(self.header.clone()),

--- a/crates/cosmos/cosmos-chain-components/src/types/payloads/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/payloads/client.rs
@@ -1,3 +1,5 @@
+use cgp::prelude::*;
+
 use crate::types::tendermint::{TendermintClientState, TendermintConsensusState, TendermintHeader};
 
 #[derive(Debug)]
@@ -5,7 +7,7 @@ pub struct CosmosUpdateClientPayload {
     pub headers: Vec<TendermintHeader>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, HasField)]
 pub struct CosmosCreateClientPayload {
     pub client_state: TendermintClientState,
     pub consensus_state: TendermintConsensusState,

--- a/crates/cosmos/cosmos-wasm-relayer/src/impls/update_client_message.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/impls/update_client_message.rs
@@ -6,11 +6,12 @@ use hermes_relayer_components::chain::traits::message_builders::update_client::U
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
 use ibc::clients::wasm_types::client_message::{ClientMessage, WASM_CLIENT_MESSAGE_TYPE_URL};
-use ibc_proto::google::protobuf::Any;
+use ibc_proto::google::protobuf::Any as IbcProtoAny;
 use ibc_proto::ibc::lightclients::wasm::v1::ClientMessage as RawClientMessage;
 use ibc_proto::Protobuf;
 use ibc_relayer_types::core::ics24_host::identifier::ClientId;
 use prost::Message;
+use prost_types::Any;
 
 pub struct BuildUpdateWasmTendermintClientMessage;
 
@@ -31,7 +32,7 @@ where
             .headers
             .into_iter()
             .map(|header| {
-                let any_header = Any::from(header);
+                let any_header = IbcProtoAny::from(header);
 
                 let wasm_message = ClientMessage {
                     data: any_header.encode_to_vec(),

--- a/crates/relayer/relayer-components/src/chain/traits/types/timestamp.rs
+++ b/crates/relayer/relayer-components/src/chain/traits/types/timestamp.rs
@@ -2,8 +2,6 @@
    Trait definition for [`HasTimestampType`].
 */
 
-use alloc::borrow::ToOwned;
-use core::fmt::Display;
 use core::time::Duration;
 
 use cgp::prelude::*;
@@ -32,7 +30,7 @@ pub trait HasTimestampType: Async {
        concrete context implementers to decide which exact time type
        they would like to use.
     */
-    type Timestamp: Ord + Display + ToOwned<Owned = Self::Timestamp> + Async;
+    type Timestamp: Ord + Async;
 
     /**
        Returns the amount of time elapsed from an `earlier` instant to a `later` one,

--- a/crates/solomachine/solomachine-chain-components/src/impls/cosmos/update_client_message.rs
+++ b/crates/solomachine/solomachine-chain-components/src/impls/cosmos/update_client_message.rs
@@ -1,6 +1,7 @@
 use cgp::core::error::HasErrorType;
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::messages::client::update::CosmosUpdateClientMessage;
+use hermes_protobuf_encoding_components::types::Any;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilder;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
@@ -28,7 +29,10 @@ where
 
         let message = CosmosUpdateClientMessage {
             client_id: client_id.clone(),
-            header,
+            header: Any {
+                type_url: header.type_url,
+                value: header.value,
+            },
         };
 
         Ok(vec![message.to_cosmos_message()])


### PR DESCRIPTION
- Remove unused constraints in `HasTimestampType::Timestamp`.
- Update the `header` field in `CosmosUpdateClientMessage` to use `prost_types::Any` instead of `ibc_proto::Any`.
- Generalize the `CreateClientMessageBuilder` instance `BuildCosmosCreateClientMessage` to `BuildAnyCreateClientMessage`, and allows generic `CreateClientPayload` that has `client_state: Counterparty::ClientState` and `consensus_state: Counterparty::ConsensusState` fields.
- Rename the `ProvideCreateClientMessageOptionsType` instance in Cosmos from `ProvideCosmosCreateClientSettings` to `ProvideNoCreateClientMessageOptionsType`, with `CreateClientMessageOptions = ()`.