### PR TITLE
Protobuf encoding improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## v0.2.0 (pre-release)
 
+-  Protobuf encoding improvements [#432](https://github.com/informalsystems/hermes-sdk/pull/432)
+    - Redesign `impl_type_url!` macro to implement `SchemaGetter` on existing component type.
+    - Schema components that only use `impl_type_url!` directly are no longer wrapped with `DelegateEncoding`.
+    - Rename `EncodeWithContext` to `WithContext`.
+    - Rename `WrappedTendermintClientState` to `WasmTendermintClientState`.
+    - Implement Protobuf encoding for `WasmClientMessage`.
+    - Implement `MutEncoder` for `Timestamp` and `CommitmentRoot`.
+    - Relax `MutEncoder` constraint for `EncodeU64ProtoField` to use `TryInto`.
+
 -  Introduce cosmos- and wasm- encoding components crates [#431](https://github.com/informalsystems/hermes-sdk/pull/431)
     - Add new `hermes-cosmos-encoding-components` crate.
     - Add new `hermes-wasm-encoding-components` crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "hermes-encoding-components",
  "hermes-protobuf-encoding-components",
  "ibc",
+ "ibc-proto",
  "prost",
  "prost-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ overflow-checks = true
 
 [workspace.dependencies]
 async-trait                     = { version = "0.1.82" }
-ibc                             = { version = "0.54.0" }
-ibc-proto                       = { version = "0.47.0" }
+ibc                             = { version = "0.54.0", default-features = false }
+ibc-proto                       = { version = "0.47.0", default-features = false }
 ibc-relayer                     = { version = "0.29.2" }
 ibc-relayer-types               = { version = "0.29.2" }
 ibc-telemetry                   = { version = "0.29.2" }

--- a/crates/cosmos/cosmos-chain-components/src/encoding/components.rs
+++ b/crates/cosmos/cosmos-chain-components/src/encoding/components.rs
@@ -40,6 +40,6 @@ define_components! {
         ]:
             CosmosEncodingComponents,
         SchemaGetterComponent:
-            DelegateEncoding<CosmosTypeUrlSchemas>,
+            CosmosTypeUrlSchemas,
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/encoding/convert.rs
+++ b/crates/cosmos/cosmos-chain-components/src/encoding/convert.rs
@@ -1,6 +1,6 @@
 use cgp::prelude::*;
 use hermes_encoding_components::impls::convert::{ConvertFrom, TryConvertFrom};
-use hermes_encoding_components::impls::with_context::EncodeWithContext;
+use hermes_encoding_components::impls::with_context::WithContext;
 use hermes_protobuf_encoding_components::impls::any::{DecodeAsAnyProtobuf, EncodeAsAnyProtobuf};
 use hermes_protobuf_encoding_components::types::strategy::ViaProtobuf;
 use ibc::core::commitment_types::merkle::MerkleProof;
@@ -25,10 +25,10 @@ delegate_components! {
         (MerkleProof, ProtoMerkleProof): ConvertFrom,
         (ProtoMerkleProof, MerkleProof): TryConvertFrom,
 
-        (TendermintClientState, Any): EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (Any, TendermintClientState): DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        (TendermintClientState, Any): EncodeAsAnyProtobuf<ViaProtobuf, WithContext>,
+        (Any, TendermintClientState): DecodeAsAnyProtobuf<ViaProtobuf, WithContext>,
 
-        (TendermintConsensusState, Any): EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (Any, TendermintConsensusState): DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        (TendermintConsensusState, Any): EncodeAsAnyProtobuf<ViaProtobuf, WithContext>,
+        (Any, TendermintConsensusState): DecodeAsAnyProtobuf<ViaProtobuf, WithContext>,
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/encoding/type_url.rs
+++ b/crates/cosmos/cosmos-chain-components/src/encoding/type_url.rs
@@ -1,23 +1,20 @@
-use cgp::prelude::*;
 use hermes_protobuf_encoding_components::impl_type_url;
+use ibc::clients::tendermint::types::{
+    TENDERMINT_CLIENT_STATE_TYPE_URL, TENDERMINT_CONSENSUS_STATE_TYPE_URL,
+};
 
 use crate::types::tendermint::{TendermintClientState, TendermintConsensusState};
 
 pub struct CosmosTypeUrlSchemas;
 
-delegate_components! {
-    CosmosTypeUrlSchemas {
-        TendermintClientState: TendermintClientStateUrl,
-        TendermintConsensusState: TendermintConsensusStateUrl,
-    }
-}
-
 impl_type_url!(
-    TendermintClientStateUrl,
-    "/ibc.lightclients.tendermint.v1.ClientState",
+    CosmosTypeUrlSchemas,
+    TendermintClientState,
+    TENDERMINT_CLIENT_STATE_TYPE_URL,
 );
 
 impl_type_url!(
-    TendermintConsensusStateUrl,
-    "/ibc.lightclients.tendermint.v1.ConsensusState",
+    CosmosTypeUrlSchemas,
+    TendermintConsensusState,
+    TENDERMINT_CONSENSUS_STATE_TYPE_URL,
 );

--- a/crates/cosmos/cosmos-encoding-components/Cargo.toml
+++ b/crates/cosmos/cosmos-encoding-components/Cargo.toml
@@ -17,6 +17,7 @@ hermes-encoding-components              = { workspace = true }
 hermes-protobuf-encoding-components     = { workspace = true }
 
 ibc                                     = { workspace = true }
+ibc-proto                               = { workspace = true }
 
 prost           = { workspace = true }
 prost-types     = { workspace = true }

--- a/crates/cosmos/cosmos-encoding-components/src/components.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/components.rs
@@ -7,9 +7,13 @@ pub use hermes_protobuf_encoding_components::components::{
 };
 use hermes_protobuf_encoding_components::types::strategy::ViaProtobuf;
 use ibc::core::client::types::Height;
+use ibc::core::commitment_types::commitment::CommitmentRoot;
+use ibc::primitives::Timestamp;
 use prost_types::Any;
 
+use crate::impls::commitment_root::EncodeCommitmentRoot;
 use crate::impls::height::EncodeHeight;
+use crate::impls::timestamp::EncodeTimestamp;
 
 define_components! {
     CosmosEncodingComponents {
@@ -54,5 +58,11 @@ delegate_components! {
 
         (ViaProtobuf, Height):
             EncodeHeight,
+
+        (ViaProtobuf, CommitmentRoot):
+            EncodeCommitmentRoot,
+
+        (ViaProtobuf, Timestamp):
+            EncodeTimestamp,
     }
 }

--- a/crates/cosmos/cosmos-encoding-components/src/impls/any.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/any.rs
@@ -1,0 +1,30 @@
+use cgp::prelude::HasErrorType;
+use hermes_encoding_components::traits::convert::Converter;
+use ibc::primitives::proto::Any as IbcAny;
+use prost_types::Any as ProstAny;
+
+pub struct ConvertIbcAny;
+
+impl<Encoding> Converter<Encoding, ProstAny, IbcAny> for ConvertIbcAny
+where
+    Encoding: HasErrorType,
+{
+    fn convert(_encoding: &Encoding, from: &ProstAny) -> Result<IbcAny, Encoding::Error> {
+        Ok(IbcAny {
+            type_url: from.type_url.clone(),
+            value: from.value.clone(),
+        })
+    }
+}
+
+impl<Encoding> Converter<Encoding, IbcAny, ProstAny> for ConvertIbcAny
+where
+    Encoding: HasErrorType,
+{
+    fn convert(_encoding: &Encoding, from: &IbcAny) -> Result<ProstAny, Encoding::Error> {
+        Ok(ProstAny {
+            type_url: from.type_url.clone(),
+            value: from.value.clone(),
+        })
+    }
+}

--- a/crates/cosmos/cosmos-encoding-components/src/impls/commitment_root.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/commitment_root.rs
@@ -1,0 +1,45 @@
+use cgp::prelude::*;
+use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
+use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use hermes_encoding_components::traits::transform::Transformer;
+use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
+use hermes_protobuf_encoding_components::components::MutDecoderComponent;
+use hermes_protobuf_encoding_components::impls::encode_mut::proto_field::bytes::EncodeByteField;
+use ibc::core::commitment_types::commitment::CommitmentRoot;
+
+pub struct EncodeCommitmentRoot;
+
+delegate_components! {
+    EncodeCommitmentRoot {
+        MutDecoderComponent: DecodeFrom<
+            Self,
+            EncodeByteField<1>
+        >,
+    }
+}
+
+impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, CommitmentRoot> for EncodeCommitmentRoot
+where
+    Encoding: HasEncodeBufferType + HasErrorType,
+    EncodeByteField<1>: for<'a> MutEncoder<Encoding, Strategy, &'a [u8]>,
+{
+    fn encode_mut(
+        encoding: &Encoding,
+        value: &CommitmentRoot,
+        buffer: &mut Encoding::EncodeBuffer,
+    ) -> Result<(), Encoding::Error> {
+        EncodeByteField::encode_mut(encoding, &value.as_bytes(), buffer)?;
+
+        Ok(())
+    }
+}
+
+impl Transformer for EncodeCommitmentRoot {
+    type From = Vec<u8>;
+
+    type To = CommitmentRoot;
+
+    fn transform(from: Vec<u8>) -> CommitmentRoot {
+        CommitmentRoot::from(from)
+    }
+}

--- a/crates/cosmos/cosmos-encoding-components/src/impls/height.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/height.rs
@@ -1,11 +1,9 @@
 use cgp::prelude::{CanRaiseError, HasErrorType};
-use hermes_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_encoding_components::impls::encode_mut::pair::EncoderPair;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
-use hermes_encoding_components::HList;
 use hermes_protobuf_encoding_components::impls::encode_mut::proto_field::u64::EncodeU64ProtoField;
 use ibc::core::client::types::error::ClientError;
 use ibc::core::client::types::Height;
@@ -36,15 +34,14 @@ where
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Height> for EncodeHeight
 where
     Encoding: HasDecodeBufferType + CanRaiseError<ClientError>,
-    CombineEncoders<HList![EncodeU64ProtoField<1>, EncodeU64ProtoField<2>,]>:
-        MutDecoder<Encoding, Strategy, HList![u64, u64]>,
+    EncoderPair<EncodeU64ProtoField<1>, EncodeU64ProtoField<2>>:
+        MutDecoder<Encoding, Strategy, (u64, u64)>,
 {
     fn decode_mut(
         encoding: &Encoding,
         buffer: &mut Encoding::DecodeBuffer<'_>,
     ) -> Result<Height, Encoding::Error> {
-        let HList![revision_number, revision_height] =
-            CombineEncoders::decode_mut(encoding, buffer)?;
+        let (revision_number, revision_height) = EncoderPair::decode_mut(encoding, buffer)?;
 
         Height::new(revision_number, revision_height).map_err(Encoding::raise_error)
     }

--- a/crates/cosmos/cosmos-encoding-components/src/impls/mod.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/mod.rs
@@ -1,1 +1,3 @@
+pub mod commitment_root;
 pub mod height;
+pub mod timestamp;

--- a/crates/cosmos/cosmos-encoding-components/src/impls/mod.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/mod.rs
@@ -1,3 +1,4 @@
+pub mod any;
 pub mod commitment_root;
 pub mod height;
 pub mod timestamp;

--- a/crates/cosmos/cosmos-encoding-components/src/impls/timestamp.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/timestamp.rs
@@ -28,7 +28,7 @@ where
         // impossible to get the seconds and nanoseconds without first
         // converting it to ProtoTimestamp.
 
-        let proto_timestamp = ProtoTimestamp::from(value.clone());
+        let proto_timestamp = ProtoTimestamp::from(*value);
 
         EncoderPair::encode_mut(
             encoding,

--- a/crates/cosmos/cosmos-encoding-components/src/impls/timestamp.rs
+++ b/crates/cosmos/cosmos-encoding-components/src/impls/timestamp.rs
@@ -1,0 +1,50 @@
+use cgp::prelude::{CanRaiseError, HasErrorType};
+use hermes_encoding_components::traits::decode_mut::MutDecoder;
+use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
+use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
+use hermes_protobuf_encoding_components::impls::encode_mut::message::EncodeProstMessage;
+use ibc::core::primitives::{Timestamp, TimestampError};
+use ibc_proto::google::protobuf::Timestamp as ProtoTimestamp;
+
+pub struct EncodeTimestamp;
+
+impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, Timestamp> for EncodeTimestamp
+where
+    Encoding: HasEncodeBufferType + HasErrorType,
+    EncodeProstMessage: MutEncoder<Encoding, Strategy, ProtoTimestamp>,
+{
+    fn encode_mut(
+        encoding: &Encoding,
+        value: &Timestamp,
+        buffer: &mut Encoding::EncodeBuffer,
+    ) -> Result<(), Encoding::Error> {
+        // We have no choice but to use ProtoTimestamp to encode for now,
+        // because the Timstamp field is currently private, and it is
+        // impossible to get the seconds and nanoseconds without first
+        // converting it to ProtoTimestamp.
+
+        let proto_timestamp = ProtoTimestamp::from(value.clone());
+
+        EncodeProstMessage::encode_mut(encoding, &proto_timestamp, buffer)?;
+
+        Ok(())
+    }
+}
+
+impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Timestamp> for EncodeTimestamp
+where
+    Encoding: HasDecodeBufferType + CanRaiseError<TimestampError>,
+    EncodeProstMessage: MutDecoder<Encoding, Strategy, ProtoTimestamp>,
+{
+    fn decode_mut(
+        encoding: &Encoding,
+        buffer: &mut Encoding::DecodeBuffer<'_>,
+    ) -> Result<Timestamp, Encoding::Error> {
+        let proto_timestamp = EncodeProstMessage::decode_mut(encoding, buffer)?;
+
+        let timestamp = Timestamp::try_from(proto_timestamp).map_err(Encoding::raise_error)?;
+
+        Ok(timestamp)
+    }
+}

--- a/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
@@ -5,6 +5,7 @@ use hermes_cosmos_chain_components::types::tendermint::TendermintConsensusState;
 use hermes_encoding_components::impls::default_encoding::GetDefaultEncoding;
 use hermes_encoding_components::traits::convert::CanConvertBothWays;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
+use hermes_encoding_components::traits::encode_and_decode_mut::CanEncodeAndDecodeMut;
 use hermes_encoding_components::traits::has_encoding::{
     DefaultEncodingGetter, EncodingGetterComponent, HasEncodingType, ProvideEncodingType,
 };
@@ -15,7 +16,9 @@ use hermes_encoding_components::types::AsBytes;
 use hermes_protobuf_encoding_components::impls::encode_mut::chunk::ProtoChunks;
 use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
 use ibc::core::client::types::Height;
+use ibc::core::commitment_types::commitment::CommitmentRoot;
 use ibc::core::commitment_types::merkle::MerkleProof;
+use ibc::primitives::Timestamp;
 use ibc_relayer_types::clients::ics07_tendermint::client_state::ClientState as TendermintClientState;
 use prost::bytes::BufMut;
 use prost_types::Any;
@@ -85,7 +88,9 @@ pub trait CheckCosmosEncoding:
     + CanEncodeAndDecode<ViaAny, TendermintConsensusState>
     + CanConvertBothWays<Any, TendermintClientState>
     + CanConvertBothWays<Any, TendermintConsensusState>
-    + CanEncodeAndDecode<ViaProtobuf, Height>
+    + CanEncodeAndDecodeMut<ViaProtobuf, Height>
+    + CanEncodeAndDecodeMut<ViaProtobuf, Timestamp>
+    + CanEncodeAndDecodeMut<ViaProtobuf, CommitmentRoot>
 {
 }
 

--- a/crates/cosmos/cosmos-relayer/src/impls/error.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/error.rs
@@ -1,7 +1,7 @@
 use alloc::string::FromUtf8Error;
 use core::array::TryFromSliceError;
 use core::convert::Infallible;
-use core::num::ParseIntError;
+use core::num::{ParseIntError, TryFromIntError};
 use core::str::Utf8Error;
 use hermes_protobuf_encoding_components::impls::encode_mut::chunk::{
     InvalidWireType, UnsupportedWireType,
@@ -136,6 +136,7 @@ delegate_components! {
             ClientError,
             CommitmentError,
             Utf8Error,
+            TryFromIntError,
             TryFromSliceError,
 
             // TODO: make it retryable?

--- a/crates/cosmos/cosmos-relayer/src/impls/error.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/error.rs
@@ -7,6 +7,7 @@ use hermes_protobuf_encoding_components::impls::encode_mut::chunk::{
     InvalidWireType, UnsupportedWireType,
 };
 use hermes_protobuf_encoding_components::impls::encode_mut::proto_field::decode_required::RequiredFieldTagNotFound;
+use ibc::primitives::TimestampError;
 
 use cgp::core::error::{
     DelegateErrorRaiser, ErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent,
@@ -121,6 +122,7 @@ delegate_components! {
             TendermintProtoError,
             TendermintRpcError,
             TendermintClientError,
+            TimestampError,
             Ics02Error,
             Ics03Error,
             Ics23Error,

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/chain.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/chain.rs
@@ -235,7 +235,7 @@ use tendermint_rpc::{HttpClient, Url};
 use crate::components::cosmos_to_wasm_cosmos::CosmosToWasmCosmosComponents;
 use crate::context::encoding::{ProvideWasmCosmosEncoding, WasmCosmosEncoding};
 use crate::impls::client_state::ProvideWrappedTendermintClientState;
-use crate::types::client_state::WrappedTendermintClientState;
+use crate::types::client_state::WasmTendermintClientState;
 
 #[derive(Clone)]
 pub struct WasmCosmosChain {
@@ -564,7 +564,7 @@ impl HasEventSubscription for WasmCosmosChain {
 }
 
 pub trait CanUseWasmCosmosChain:
-    HasClientStateType<WasmCosmosChain, ClientState = WrappedTendermintClientState>
+    HasClientStateType<WasmCosmosChain, ClientState = WasmTendermintClientState>
     + HasConsensusStateType<WasmCosmosChain, ConsensusState = TendermintConsensusState>
     + CanQueryBalance
     // + CanIbcTransferToken<WasmCosmosChain>

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/encoding.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/encoding.rs
@@ -6,13 +6,13 @@ use hermes_encoding_components::impls::default_encoding::GetDefaultEncoding;
 use hermes_encoding_components::traits::convert::{CanConvert, CanConvertBothWays};
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
-use hermes_encoding_components::traits::encode_and_decode_mut::CanEncodeAndDecodeMut;
 use hermes_encoding_components::traits::has_encoding::{
     DefaultEncodingGetter, EncodingGetterComponent, HasEncodingType, ProvideEncodingType,
 };
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use hermes_encoding_components::types::AsBytes;
 use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
+use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
 use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
 use ibc::core::client::types::Height;
@@ -83,14 +83,16 @@ pub trait CheckWasmCosmosEncoding:
     + CanEncode<ViaProtobuf, WasmClientState>
     + CanEncodeAndDecode<ViaAny, WasmClientState>
     + CanEncodeAndDecode<ViaAny, WasmConsensusState>
+    + CanEncodeAndDecode<ViaAny, WasmClientMessage>
     + CanConvertBothWays<Any, WrappedTendermintClientState>
     + CanConvert<WasmClientState, Any>
     + CanConvert<WasmConsensusState, Any>
     + CanEncode<ViaAny, TendermintClientState>
     + CanEncode<ViaAny, TendermintConsensusState>
     + CanEncodeAndDecode<ViaProtobuf, Height>
-    + CanEncodeAndDecodeMut<ViaProtobuf, WasmClientState>
-    + CanEncodeAndDecodeMut<ViaProtobuf, WasmConsensusState>
+    + CanEncodeAndDecode<ViaProtobuf, WasmClientState>
+    + CanEncodeAndDecode<ViaProtobuf, WasmConsensusState>
+    + CanEncodeAndDecode<ViaProtobuf, WasmClientMessage>
 {
 }
 

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/encoding.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/encoding.rs
@@ -20,7 +20,7 @@ use ibc_relayer_types::clients::ics07_tendermint::client_state::ClientState as T
 use prost_types::Any;
 
 use crate::encoding::components::*;
-use crate::types::client_state::WrappedTendermintClientState;
+use crate::types::client_state::WasmTendermintClientState;
 
 pub struct WasmCosmosEncoding;
 
@@ -84,7 +84,7 @@ pub trait CheckWasmCosmosEncoding:
     + CanEncodeAndDecode<ViaAny, WasmClientState>
     + CanEncodeAndDecode<ViaAny, WasmConsensusState>
     + CanEncodeAndDecode<ViaAny, WasmClientMessage>
-    + CanConvertBothWays<Any, WrappedTendermintClientState>
+    + CanConvertBothWays<Any, WasmTendermintClientState>
     + CanConvert<WasmClientState, Any>
     + CanConvert<WasmConsensusState, Any>
     + CanEncode<ViaAny, TendermintClientState>

--- a/crates/cosmos/cosmos-wasm-relayer/src/encoding/convert.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/encoding/convert.rs
@@ -15,9 +15,7 @@ use ibc::core::commitment_types::merkle::MerkleProof;
 use ibc_proto::ibc::core::commitment::v1::MerkleProof as ProtoMerkleProof;
 use prost_types::Any;
 
-use crate::types::client_state::{
-    EncodeWrappedTendermintClientState, WrappedTendermintClientState,
-};
+use crate::types::client_state::{EncodeWasmTendermintClientState, WasmTendermintClientState};
 
 pub struct WasmCosmosConverterComponents;
 
@@ -46,10 +44,10 @@ delegate_components! {
             WasmEncodingComponents,
 
         [
-            (Any, WrappedTendermintClientState),
-            (WrappedTendermintClientState, Any),
+            (Any, WasmTendermintClientState),
+            (WasmTendermintClientState, Any),
         ]:
-            EncodeWrappedTendermintClientState,
+            EncodeWasmTendermintClientState,
 
         (TendermintConsensusState, Any):
             EncodeViaWasmConsensusState,

--- a/crates/cosmos/cosmos-wasm-relayer/src/encoding/convert.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/encoding/convert.rs
@@ -8,6 +8,7 @@ use hermes_wasm_encoding_components::components::WasmEncodingComponents;
 use hermes_wasm_encoding_components::impls::strategies::consensus_state::{
     DecodeViaWasmConsensusState, EncodeViaWasmConsensusState,
 };
+use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
 use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
 use ibc::core::commitment_types::merkle::MerkleProof;
@@ -35,9 +36,12 @@ delegate_components! {
             CosmosClientEncodingComponents,
         [
             (WasmClientState, Any),
-            (Any, WasmClientState),
             (WasmConsensusState, Any),
+            (WasmClientMessage, Any),
+
+            (Any, WasmClientState),
             (Any, WasmConsensusState),
+            (Any, WasmClientMessage),
         ]:
             WasmEncodingComponents,
 

--- a/crates/cosmos/cosmos-wasm-relayer/src/encoding/encode.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/encoding/encode.rs
@@ -7,6 +7,7 @@ use hermes_cosmos_chain_components::types::tendermint::{
 use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
 use hermes_relayer_components::chain::traits::types::proof::ViaCommitmentProof;
 use hermes_wasm_encoding_components::components::WasmEncodingComponents;
+use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
 use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
 use ibc::core::client::types::Height;
@@ -41,9 +42,12 @@ delegate_components! {
             CosmosClientEncodingComponents,
         [
             (ViaAny, WasmClientState),
-            (ViaProtobuf, WasmClientState),
             (ViaAny, WasmConsensusState),
+            (ViaAny, WasmClientMessage),
+
+            (ViaProtobuf, WasmClientState),
             (ViaProtobuf, WasmConsensusState),
+            (ViaProtobuf, WasmClientMessage),
         ]:
             WasmEncodingComponents,
     }

--- a/crates/cosmos/cosmos-wasm-relayer/src/encoding/encode_mut.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/encoding/encode_mut.rs
@@ -1,6 +1,7 @@
 use cgp::prelude::*;
 use hermes_protobuf_encoding_components::types::strategy::ViaProtobuf;
 use hermes_wasm_encoding_components::components::WasmEncodingComponents;
+use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
 use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
 use ibc::core::client::types::Height;
@@ -13,6 +14,7 @@ delegate_components! {
             (ViaProtobuf, Height),
             (ViaProtobuf, WasmClientState),
             (ViaProtobuf, WasmConsensusState),
+            (ViaProtobuf, WasmClientMessage),
         ]: WasmEncodingComponents,
     }
 }

--- a/crates/cosmos/cosmos-wasm-relayer/src/encoding/type_url.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/encoding/type_url.rs
@@ -4,6 +4,7 @@ use hermes_cosmos_chain_components::types::tendermint::{
     TendermintClientState, TendermintConsensusState,
 };
 use hermes_wasm_encoding_components::components::WasmEncodingComponents;
+use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
 use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
 
@@ -19,6 +20,7 @@ delegate_components! {
         [
             WasmClientState,
             WasmConsensusState,
+            WasmClientMessage,
         ]:
             WasmEncodingComponents,
 

--- a/crates/cosmos/cosmos-wasm-relayer/src/impls/client_state.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/impls/client_state.rs
@@ -8,7 +8,7 @@ use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use ibc_relayer_types::core::ics02_client::client_state::ClientState;
 use ibc_relayer_types::Height;
 
-use crate::types::client_state::WrappedTendermintClientState;
+use crate::types::client_state::WasmTendermintClientState;
 
 pub struct ProvideWrappedTendermintClientState;
 
@@ -17,25 +17,25 @@ impl<Chain, Counterparty> ProvideClientStateType<Chain, Counterparty>
 where
     Chain: Async,
 {
-    type ClientState = WrappedTendermintClientState;
+    type ClientState = WasmTendermintClientState;
 }
 
 impl<Chain, Counterparty> ClientStateFieldsGetter<Chain, Counterparty>
     for ProvideWrappedTendermintClientState
 where
-    Chain: HasClientStateType<Counterparty, ClientState = WrappedTendermintClientState>
+    Chain: HasClientStateType<Counterparty, ClientState = WasmTendermintClientState>
         + HasHeightType<Height = Height>,
 {
-    fn client_state_latest_height(client_state: &WrappedTendermintClientState) -> Height {
+    fn client_state_latest_height(client_state: &WasmTendermintClientState) -> Height {
         client_state.tendermint_client_state.latest_height
     }
 
-    fn client_state_is_frozen(client_state: &WrappedTendermintClientState) -> bool {
+    fn client_state_is_frozen(client_state: &WasmTendermintClientState) -> bool {
         client_state.tendermint_client_state.is_frozen()
     }
 
     fn client_state_has_expired(
-        client_state: &WrappedTendermintClientState,
+        client_state: &WasmTendermintClientState,
         elapsed: Duration,
     ) -> bool {
         elapsed > client_state.tendermint_client_state.trusting_period

--- a/crates/cosmos/cosmos-wasm-relayer/src/types/client_state.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/types/client_state.rs
@@ -8,21 +8,21 @@ use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 use ibc::core::client::types::Height;
 use prost_types::Any;
 
-pub struct WrappedTendermintClientState {
+pub struct WasmTendermintClientState {
     pub tendermint_client_state: TendermintClientState,
     pub wasm_code_hash: Vec<u8>,
 }
 
-impl From<WrappedTendermintClientState> for TendermintClientState {
-    fn from(value: WrappedTendermintClientState) -> Self {
+impl From<WasmTendermintClientState> for TendermintClientState {
+    fn from(value: WasmTendermintClientState) -> Self {
         value.tendermint_client_state
     }
 }
 
-pub struct EncodeWrappedTendermintClientState;
+pub struct EncodeWasmTendermintClientState;
 
-impl<Encoding> Converter<Encoding, WrappedTendermintClientState, Any>
-    for EncodeWrappedTendermintClientState
+impl<Encoding> Converter<Encoding, WasmTendermintClientState, Any>
+    for EncodeWasmTendermintClientState
 where
     Encoding: HasEncodedType<Encoded = Vec<u8>>
         + CanEncode<ViaAny, TendermintClientState>
@@ -30,7 +30,7 @@ where
 {
     fn convert(
         encoding: &Encoding,
-        client_state: &WrappedTendermintClientState,
+        client_state: &WasmTendermintClientState,
     ) -> Result<Any, Encoding::Error> {
         let tendermint_client_state_bytes =
             encoding.encode(&client_state.tendermint_client_state)?;
@@ -51,8 +51,8 @@ where
     }
 }
 
-impl<Encoding> Converter<Encoding, Any, WrappedTendermintClientState>
-    for EncodeWrappedTendermintClientState
+impl<Encoding> Converter<Encoding, Any, WasmTendermintClientState>
+    for EncodeWasmTendermintClientState
 where
     Encoding: HasEncodedType<Encoded = Vec<u8>>
         + CanDecode<ViaAny, TendermintClientState>
@@ -61,12 +61,12 @@ where
     fn convert(
         encoding: &Encoding,
         client_state_any: &Any,
-    ) -> Result<WrappedTendermintClientState, Encoding::Error> {
+    ) -> Result<WasmTendermintClientState, Encoding::Error> {
         let wasm_client_state = encoding.convert(client_state_any)?;
 
         let tendermint_client_state = encoding.decode(&wasm_client_state.data)?;
 
-        let wrapped_tendermint_client_state = WrappedTendermintClientState {
+        let wrapped_tendermint_client_state = WasmTendermintClientState {
             tendermint_client_state,
             wasm_code_hash: wasm_client_state.checksum,
         };

--- a/crates/encoding/encoding-components/src/impls/encode_mut/pair.rs
+++ b/crates/encoding/encoding-components/src/impls/encode_mut/pair.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 
 use cgp::core::error::HasErrorType;
 
-use crate::impls::with_context::EncodeWithContext;
+use crate::impls::with_context::WithContext;
 use crate::traits::decode_mut::MutDecoder;
 use crate::traits::encode_mut::MutEncoder;
 use crate::traits::types::decode_buffer::HasDecodeBufferType;
@@ -10,7 +10,7 @@ use crate::traits::types::encode_buffer::HasEncodeBufferType;
 
 pub struct EncoderPair<EncoderA, EncoderB>(pub PhantomData<(EncoderA, EncoderB)>);
 
-pub type EncodeCons<NextEncode> = EncoderPair<EncodeWithContext, NextEncode>;
+pub type EncodeCons<NextEncode> = EncoderPair<WithContext, NextEncode>;
 
 impl<Encoding, Strategy, EncoderA, EncoderB, ValueA, ValueB>
     MutEncoder<Encoding, Strategy, (ValueA, ValueB)> for EncoderPair<EncoderA, EncoderB>

--- a/crates/encoding/encoding-components/src/impls/with_context.rs
+++ b/crates/encoding/encoding-components/src/impls/with_context.rs
@@ -3,9 +3,9 @@ use crate::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use crate::traits::encode::{CanEncode, Encoder};
 use crate::traits::encode_mut::{CanEncodeMut, MutEncoder};
 
-pub struct EncodeWithContext;
+pub struct WithContext;
 
-impl<Encoding, Strategy, Value> Encoder<Encoding, Strategy, Value> for EncodeWithContext
+impl<Encoding, Strategy, Value> Encoder<Encoding, Strategy, Value> for WithContext
 where
     Encoding: CanEncode<Strategy, Value>,
 {
@@ -14,7 +14,7 @@ where
     }
 }
 
-impl<Encoding, Strategy, Value> Decoder<Encoding, Strategy, Value> for EncodeWithContext
+impl<Encoding, Strategy, Value> Decoder<Encoding, Strategy, Value> for WithContext
 where
     Encoding: CanDecode<Strategy, Value>,
 {
@@ -23,7 +23,7 @@ where
     }
 }
 
-impl<Encoding, Strategy, Value> MutEncoder<Encoding, Strategy, Value> for EncodeWithContext
+impl<Encoding, Strategy, Value> MutEncoder<Encoding, Strategy, Value> for WithContext
 where
     Encoding: CanEncodeMut<Strategy, Value>,
 {
@@ -36,7 +36,7 @@ where
     }
 }
 
-impl<Encoding, Strategy, Value> MutDecoder<Encoding, Strategy, Value> for EncodeWithContext
+impl<Encoding, Strategy, Value> MutDecoder<Encoding, Strategy, Value> for WithContext
 where
     Encoding: CanDecodeMut<Strategy, Value>,
 {

--- a/crates/encoding/encoding-components/src/impls/with_context.rs
+++ b/crates/encoding/encoding-components/src/impls/with_context.rs
@@ -1,3 +1,4 @@
+use crate::traits::convert::{CanConvert, Converter};
 use crate::traits::decode::{CanDecode, Decoder};
 use crate::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use crate::traits::encode::{CanEncode, Encoder};
@@ -45,5 +46,14 @@ where
         buffer: &mut Encoding::DecodeBuffer<'_>,
     ) -> Result<Value, Encoding::Error> {
         encoding.decode_mut(buffer)
+    }
+}
+
+impl<Encoding, From, To> Converter<Encoding, From, To> for WithContext
+where
+    Encoding: CanConvert<From, To>,
+{
+    fn convert(encoding: &Encoding, from: &From) -> Result<To, Encoding::Error> {
+        encoding.convert(from)
     }
 }

--- a/crates/encoding/protobuf-encoding-components/src/impls/encode_mut/proto_field/u64.rs
+++ b/crates/encoding/protobuf-encoding-components/src/impls/encode_mut/proto_field/u64.rs
@@ -1,4 +1,4 @@
-use cgp::prelude::{CanRaiseError, HasErrorType};
+use cgp::prelude::CanRaiseError;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
@@ -12,15 +12,15 @@ pub struct EncodeU64ProtoField<const TAG: u32>;
 impl<Encoding, Strategy, Value, const TAG: u32> MutEncoder<Encoding, Strategy, Value>
     for EncodeU64ProtoField<TAG>
 where
-    Encoding: HasEncodeBufferType<EncodeBuffer: BufMut> + HasErrorType,
-    Value: Clone + Into<u64>,
+    Encoding: HasEncodeBufferType<EncodeBuffer: BufMut> + CanRaiseError<Value::Error>,
+    Value: Clone + TryInto<u64>,
 {
     fn encode_mut(
         _encoding: &Encoding,
         value: &Value,
         buffer: &mut Encoding::EncodeBuffer,
     ) -> Result<(), Encoding::Error> {
-        let value2 = value.clone().into();
+        let value2 = value.clone().try_into().map_err(Encoding::raise_error)?;
 
         if value2 != 0 {
             encode_key(TAG, WireType::Varint, buffer);

--- a/crates/encoding/protobuf-encoding-components/src/impls/via_any.rs
+++ b/crates/encoding/protobuf-encoding-components/src/impls/via_any.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use cgp::prelude::*;
-use hermes_encoding_components::impls::with_context::EncodeWithContext;
+use hermes_encoding_components::impls::with_context::WithContext;
 use hermes_encoding_components::traits::decode::Decoder;
 use hermes_encoding_components::traits::encode::Encoder;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -14,11 +14,11 @@ impl<Encoding, Strategy, InStrategy, Value> Encoder<Encoding, Strategy, Value>
     for EncodeViaAny<InStrategy>
 where
     Encoding: HasEncodedType + HasErrorType,
-    EncodeAsAnyProtobuf<InStrategy, EncodeWithContext>: Encoder<Encoding, Strategy, Value>,
+    EncodeAsAnyProtobuf<InStrategy, WithContext>: Encoder<Encoding, Strategy, Value>,
     InStrategy: Async,
 {
     fn encode(encoding: &Encoding, value: &Value) -> Result<Encoding::Encoded, Encoding::Error> {
-        <EncodeAsAnyProtobuf<InStrategy, EncodeWithContext>>::encode(encoding, value)
+        <EncodeAsAnyProtobuf<InStrategy, WithContext>>::encode(encoding, value)
     }
 }
 
@@ -26,12 +26,11 @@ impl<Encoding, Strategy, InStrategy, Value> Decoder<Encoding, Strategy, Value>
     for EncodeViaAny<InStrategy>
 where
     Encoding: HasEncodedType + HasErrorType,
-    DecodeAsAnyProtobuf<InStrategy, EncodeWithContext>: Decoder<Encoding, InStrategy, Value>,
+    DecodeAsAnyProtobuf<InStrategy, WithContext>: Decoder<Encoding, InStrategy, Value>,
     InStrategy: Async,
 {
     fn decode(encoding: &Encoding, encoded: &Encoding::Encoded) -> Result<Value, Encoding::Error> {
-        let value =
-            <DecodeAsAnyProtobuf<InStrategy, EncodeWithContext>>::decode(encoding, encoded)?;
+        let value = <DecodeAsAnyProtobuf<InStrategy, WithContext>>::decode(encoding, encoded)?;
 
         Ok(value)
     }

--- a/crates/encoding/protobuf-encoding-components/src/macros.rs
+++ b/crates/encoding/protobuf-encoding-components/src/macros.rs
@@ -1,15 +1,13 @@
 #[macro_export]
 macro_rules! impl_type_url {
-    ($component:ident, $type_url:literal $(,)?) => {
-        pub struct $component;
-
-        impl<Encoding, Value> $crate::vendor::SchemaGetter<Encoding, Value> for $component
+    ($component:ident, $type:ty, $type_url:tt $(,)?) => {
+        impl<Encoding> $crate::vendor::SchemaGetter<Encoding, $type> for $component
         where
             Encoding: $crate::vendor::HasSchemaType<Schema = &'static str>,
         {
             fn schema(
                 _encoding: &Encoding,
-                _phantom: core::marker::PhantomData<Value>,
+                _phantom: core::marker::PhantomData<$type>,
             ) -> &&'static str {
                 &$type_url
             }

--- a/crates/solomachine/solomachine-chain-components/src/encoding/components.rs
+++ b/crates/solomachine/solomachine-chain-components/src/encoding/components.rs
@@ -27,6 +27,6 @@ define_components! {
         ]:
             DelegateEncoding<SolomachineEncoderComponents>,
         SchemaGetterComponent:
-            DelegateEncoding<SolomachineTypeUrlSchemas>,
+            SolomachineTypeUrlSchemas,
     }
 }

--- a/crates/solomachine/solomachine-chain-components/src/encoding/convert.rs
+++ b/crates/solomachine/solomachine-chain-components/src/encoding/convert.rs
@@ -1,6 +1,6 @@
 use cgp::prelude::*;
 use hermes_encoding_components::impls::convert::{ConvertFrom, TryConvertFrom};
-use hermes_encoding_components::impls::with_context::EncodeWithContext;
+use hermes_encoding_components::impls::with_context::WithContext;
 use hermes_protobuf_encoding_components::impls::any::{DecodeAsAnyProtobuf, EncodeAsAnyProtobuf};
 use hermes_protobuf_encoding_components::types::any::Any;
 use hermes_protobuf_encoding_components::types::strategy::ViaProtobuf;
@@ -14,12 +14,12 @@ delegate_components! {
     SolomachineConverterComponents {
         (SolomachineClientState, ProtoSolomachineClientState): ConvertFrom,
         (ProtoSolomachineClientState, SolomachineClientState): TryConvertFrom,
-        (SolomachineClientState, Any): EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (Any, SolomachineClientState): DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        (SolomachineClientState, Any): EncodeAsAnyProtobuf<ViaProtobuf, WithContext>,
+        (Any, SolomachineClientState): DecodeAsAnyProtobuf<ViaProtobuf, WithContext>,
 
         (SolomachineConsensusState, ProtoSolomachineConsensusState): ConvertFrom,
         (ProtoSolomachineConsensusState, SolomachineConsensusState): TryConvertFrom,
-        (SolomachineConsensusState, Any): EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (Any, SolomachineConsensusState): DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        (SolomachineConsensusState, Any): EncodeAsAnyProtobuf<ViaProtobuf, WithContext>,
+        (Any, SolomachineConsensusState): DecodeAsAnyProtobuf<ViaProtobuf, WithContext>,
     }
 }

--- a/crates/solomachine/solomachine-chain-components/src/encoding/type_url.rs
+++ b/crates/solomachine/solomachine-chain-components/src/encoding/type_url.rs
@@ -1,24 +1,20 @@
-use cgp::prelude::*;
 use hermes_protobuf_encoding_components::impl_type_url;
 
-use crate::types::client_state::SolomachineClientState;
-use crate::types::consensus_state::SolomachineConsensusState;
+use crate::types::client_state::{SolomachineClientState, SOLOMACHINE_CLIENT_STATE_TYPE_URL};
+use crate::types::consensus_state::{
+    SolomachineConsensusState, SOLOMACHINE_CONSENSUS_STATE_TYPE_URL,
+};
 
 pub struct SolomachineTypeUrlSchemas;
 
-delegate_components! {
-    SolomachineTypeUrlSchemas {
-        SolomachineClientState: SolomachineClientStateUrl,
-        SolomachineConsensusState: SolomachineConsensusStateUrl,
-    }
-}
-
 impl_type_url!(
-    SolomachineClientStateUrl,
-    "/ibc.lightclients.solomachine.v3.ClientState"
+    SolomachineTypeUrlSchemas,
+    SolomachineClientState,
+    SOLOMACHINE_CLIENT_STATE_TYPE_URL,
 );
 
 impl_type_url!(
-    SolomachineConsensusStateUrl,
-    "/ibc.lightclients.solomachine.v3.ConsensusState"
+    SolomachineTypeUrlSchemas,
+    SolomachineConsensusState,
+    SOLOMACHINE_CONSENSUS_STATE_TYPE_URL,
 );

--- a/crates/solomachine/solomachine-chain-components/src/types/client_state.rs
+++ b/crates/solomachine/solomachine-chain-components/src/types/client_state.rs
@@ -9,7 +9,7 @@ use prost::Message;
 
 use crate::types::consensus_state::SolomachineConsensusState;
 
-const TYPE_URL: &str = "/ibc.lightclients.solomachine.v3.ClientState";
+pub const SOLOMACHINE_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.solomachine.v3.ClientState";
 
 #[derive(Clone, Debug)]
 pub struct SolomachineClientState {
@@ -33,7 +33,9 @@ impl TryFrom<Any> for SolomachineClientState {
         }
 
         match raw.type_url.as_str() {
-            TYPE_URL => decode_client_state(raw.value.deref()).map_err(Into::into),
+            SOLOMACHINE_CLIENT_STATE_TYPE_URL => {
+                decode_client_state(raw.value.deref()).map_err(Into::into)
+            }
             _ => Err(eyre!("unknown client state: {}", raw.type_url).into()),
         }
     }
@@ -48,7 +50,7 @@ impl Msg for SolomachineClientState {
     }
 
     fn type_url(&self) -> String {
-        TYPE_URL.to_string()
+        SOLOMACHINE_CLIENT_STATE_TYPE_URL.to_string()
     }
 }
 

--- a/crates/solomachine/solomachine-chain-components/src/types/consensus_state.rs
+++ b/crates/solomachine/solomachine-chain-components/src/types/consensus_state.rs
@@ -10,7 +10,8 @@ use crate::methods::encode::public_key::{
     decode_public_key_from_any, encode_public_key, PublicKey,
 };
 
-const TYPE_URL: &str = "/ibc.lightclients.solomachine.v3.ConsensusState";
+pub const SOLOMACHINE_CONSENSUS_STATE_TYPE_URL: &str =
+    "/ibc.lightclients.solomachine.v3.ConsensusState";
 
 #[derive(Clone, Debug)]
 pub struct SolomachineConsensusState {
@@ -28,7 +29,7 @@ impl Msg for SolomachineConsensusState {
     }
 
     fn type_url(&self) -> String {
-        TYPE_URL.to_string()
+        SOLOMACHINE_CONSENSUS_STATE_TYPE_URL.to_string()
     }
 }
 

--- a/crates/wasm/wasm-encoding-components/src/components.rs
+++ b/crates/wasm/wasm-encoding-components/src/components.rs
@@ -20,11 +20,14 @@ use hermes_protobuf_encoding_components::impls::encode::buffer::EncodeProtoWithM
 use hermes_protobuf_encoding_components::impls::via_any::EncodeViaAny;
 pub use hermes_protobuf_encoding_components::traits::length::EncodedLengthGetterComponent;
 use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
+use ibc::clients::wasm_types::client_message::WASM_CLIENT_MESSAGE_TYPE_URL;
 use ibc::core::client::types::Height;
 use prost_types::Any;
 
+use crate::impls::encode::client_message::EncodeWasmClientMessage;
 use crate::impls::encode::client_state::EncodeWasmClientState;
 use crate::impls::encode::consensus_state::EncodeWasmConsensusState;
+use crate::types::client_message::WasmClientMessage;
 use crate::types::client_state::WasmClientState;
 use crate::types::consensus_state::WasmConsensusState;
 
@@ -63,10 +66,15 @@ pub struct WasmEncoderComponents;
 
 delegate_components! {
     WasmConverterComponents {
-        (WasmClientState, Any): EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (Any, WasmClientState): DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (WasmConsensusState, Any): EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
-        (Any, WasmConsensusState): DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        [
+            (WasmClientState, Any),
+            (WasmConsensusState, Any),
+        ]: EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+
+        [
+            (Any, WasmClientState),
+            (Any, WasmConsensusState),
+        ]: DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
     }
 }
 
@@ -81,15 +89,25 @@ delegate_components! {
 
         (ViaProtobuf, WasmConsensusState):
             EncodeWasmConsensusState,
+
+        (ViaProtobuf, WasmClientMessage):
+            EncodeWasmClientMessage,
     }
 }
 
 delegate_components! {
     WasmEncoderComponents {
-        (ViaAny, WasmClientState): EncodeViaAny<ViaProtobuf>,
-        (ViaProtobuf, WasmClientState): EncodeProtoWithMutBuffer,
-        (ViaAny, WasmConsensusState): EncodeViaAny<ViaProtobuf>,
-        (ViaProtobuf, WasmConsensusState): EncodeProtoWithMutBuffer,
+        [
+            (ViaAny, WasmClientState),
+            (ViaAny, WasmConsensusState),
+            (ViaAny, WasmClientMessage),
+        ]: EncodeViaAny<ViaProtobuf>,
+
+        [
+            (ViaProtobuf, WasmClientState),
+            (ViaProtobuf, WasmConsensusState),
+            (ViaProtobuf, WasmClientMessage),
+        ]: EncodeProtoWithMutBuffer,
     }
 }
 
@@ -98,11 +116,17 @@ pub struct WasmTypeUrlSchemas;
 impl_type_url!(
     WasmTypeUrlSchemas,
     WasmClientState,
-    "/ibc.lightclients.wasm.v1.ClientState"
+    "/ibc.lightclients.wasm.v1.ClientState",
 );
 
 impl_type_url!(
     WasmTypeUrlSchemas,
     WasmConsensusState,
-    "/ibc.lightclients.wasm.v1.ConsensusState"
+    "/ibc.lightclients.wasm.v1.ConsensusState",
+);
+
+impl_type_url!(
+    WasmTypeUrlSchemas,
+    WasmClientMessage,
+    WASM_CLIENT_MESSAGE_TYPE_URL,
 );

--- a/crates/wasm/wasm-encoding-components/src/components.rs
+++ b/crates/wasm/wasm-encoding-components/src/components.rs
@@ -5,7 +5,7 @@ pub use hermes_cosmos_encoding_components::components::{
     DecodeBufferTypeComponent, EncodeBufferTypeComponent,
 };
 use hermes_encoding_components::impls::delegate::DelegateEncoding;
-use hermes_encoding_components::impls::with_context::EncodeWithContext;
+use hermes_encoding_components::impls::with_context::WithContext;
 pub use hermes_encoding_components::traits::convert::ConverterComponent;
 pub use hermes_encoding_components::traits::decode::DecoderComponent;
 pub use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
@@ -69,12 +69,12 @@ delegate_components! {
         [
             (WasmClientState, Any),
             (WasmConsensusState, Any),
-        ]: EncodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        ]: EncodeAsAnyProtobuf<ViaProtobuf, WithContext>,
 
         [
             (Any, WasmClientState),
             (Any, WasmConsensusState),
-        ]: DecodeAsAnyProtobuf<ViaProtobuf, EncodeWithContext>,
+        ]: DecodeAsAnyProtobuf<ViaProtobuf, WithContext>,
     }
 }
 

--- a/crates/wasm/wasm-encoding-components/src/components.rs
+++ b/crates/wasm/wasm-encoding-components/src/components.rs
@@ -51,7 +51,7 @@ define_components! {
         ]:
             DelegateEncoding<WasmEncodeMutComponents>,
         SchemaGetterComponent:
-            DelegateEncoding<WasmTypeUrlSchemas>,
+            WasmTypeUrlSchemas,
     }
 }
 
@@ -95,16 +95,14 @@ delegate_components! {
 
 pub struct WasmTypeUrlSchemas;
 
-delegate_components! {
-    WasmTypeUrlSchemas {
-        WasmClientState: WasmClientStateUrl,
-        WasmConsensusState: WasmConsensusStateUrl,
-    }
-}
-
-impl_type_url!(WasmClientStateUrl, "/ibc.lightclients.wasm.v1.ClientState");
+impl_type_url!(
+    WasmTypeUrlSchemas,
+    WasmClientState,
+    "/ibc.lightclients.wasm.v1.ClientState"
+);
 
 impl_type_url!(
-    WasmConsensusStateUrl,
+    WasmTypeUrlSchemas,
+    WasmConsensusState,
     "/ibc.lightclients.wasm.v1.ConsensusState"
 );

--- a/crates/wasm/wasm-encoding-components/src/impls/convert/client_message.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/convert/client_message.rs
@@ -1,0 +1,41 @@
+use hermes_encoding_components::traits::convert::{CanConvert, Converter};
+use hermes_encoding_components::traits::decode::CanDecode;
+use hermes_encoding_components::traits::encode::CanEncode;
+use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use hermes_protobuf_encoding_components::types::strategy::ViaAny;
+use ibc::clients::wasm_types::client_message::ClientMessage;
+use ibc::primitives::proto::Any;
+
+pub struct EncodeViaClientMessage;
+
+impl<Encoding, Value> Converter<Encoding, Value, Any> for EncodeViaClientMessage
+where
+    Encoding: HasEncodedType<Encoded = Vec<u8>>
+        + CanEncode<ViaAny, Value>
+        + CanConvert<ClientMessage, Any>,
+{
+    fn convert(encoding: &Encoding, value: &Value) -> Result<Any, Encoding::Error> {
+        let data = encoding.encode(value)?;
+
+        let client_message = ClientMessage { data };
+
+        encoding.convert(&client_message)
+    }
+}
+
+pub struct DecodeViaClientMessage;
+
+impl<Encoding, Value> Converter<Encoding, Any, Value> for DecodeViaClientMessage
+where
+    Encoding: HasEncodedType<Encoded = Vec<u8>>
+        + CanDecode<ViaAny, Value>
+        + CanConvert<Any, ClientMessage>,
+{
+    fn convert(encoding: &Encoding, any: &Any) -> Result<Value, Encoding::Error> {
+        let message = encoding.convert(any)?;
+
+        let value = encoding.decode(&message.data)?;
+
+        Ok(value)
+    }
+}

--- a/crates/wasm/wasm-encoding-components/src/impls/convert/client_message.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/convert/client_message.rs
@@ -4,7 +4,7 @@ use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use hermes_protobuf_encoding_components::types::strategy::ViaAny;
 use ibc::clients::wasm_types::client_message::ClientMessage;
-use ibc::primitives::proto::Any;
+use prost_types::Any;
 
 pub struct EncodeViaClientMessage;
 

--- a/crates/wasm/wasm-encoding-components/src/impls/convert/mod.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/convert/mod.rs
@@ -1,0 +1,1 @@
+pub mod client_message;

--- a/crates/wasm/wasm-encoding-components/src/impls/encode/client_message.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/encode/client_message.rs
@@ -1,0 +1,46 @@
+use core::marker::PhantomData;
+
+use cgp::prelude::*;
+use hermes_cosmos_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
+use hermes_encoding_components::impls::encode_mut::field::EncodeFieldWithGetter;
+use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
+use hermes_encoding_components::traits::field::FieldGetter;
+use hermes_encoding_components::traits::transform::Transformer;
+use hermes_protobuf_encoding_components::impls::encode_mut::proto_field::bytes::EncodeByteField;
+
+use crate::types::client_message::WasmClientMessage;
+
+pub struct EncodeWasmClientMessage;
+
+delegate_components! {
+    EncodeWasmClientMessage {
+        MutEncoderComponent:
+            EncodeFieldWithGetter<
+                Self,
+                symbol!("data"),
+                EncodeByteField<1>,
+            >,
+        MutDecoderComponent: DecodeFrom<
+            Self,
+            EncodeByteField<1>,
+        >,
+    }
+}
+
+impl FieldGetter<WasmClientMessage, symbol!("data")> for EncodeWasmClientMessage {
+    type Field = Vec<u8>;
+
+    fn get_field(message: &WasmClientMessage, _tag: PhantomData<symbol!("data")>) -> &Vec<u8> {
+        &message.data
+    }
+}
+
+impl Transformer for EncodeWasmClientMessage {
+    type From = Vec<u8>;
+
+    type To = WasmClientMessage;
+
+    fn transform(data: Self::From) -> Self::To {
+        WasmClientMessage { data }
+    }
+}

--- a/crates/wasm/wasm-encoding-components/src/impls/encode/client_state.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/encode/client_state.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 use hermes_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
-use hermes_encoding_components::impls::with_context::EncodeWithContext;
+use hermes_encoding_components::impls::with_context::WithContext;
 use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 use hermes_encoding_components::traits::transform::Transformer;
@@ -30,7 +30,7 @@ delegate_components! {
                 >,
                 EncodeField<
                     symbol!("latest_height"),
-                    EncodeLengthDelimitedProtoField<3, EncodeWithContext>,
+                    EncodeLengthDelimitedProtoField<3, WithContext>,
                 >,
             ]>,
         MutDecoderComponent: DecodeFrom<
@@ -38,7 +38,7 @@ delegate_components! {
             CombineEncoders<HList![
                 EncodeByteField<1>,
                 EncodeByteField<2>,
-                DecodeRequiredProtoField<3, EncodeWithContext>,
+                DecodeRequiredProtoField<3, WithContext>,
             ]>
         >,
     }

--- a/crates/wasm/wasm-encoding-components/src/impls/encode/mod.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/encode/mod.rs
@@ -1,2 +1,3 @@
+pub mod client_message;
 pub mod client_state;
 pub mod consensus_state;

--- a/crates/wasm/wasm-encoding-components/src/impls/mod.rs
+++ b/crates/wasm/wasm-encoding-components/src/impls/mod.rs
@@ -1,2 +1,3 @@
+pub mod convert;
 pub mod encode;
 pub mod strategies;

--- a/crates/wasm/wasm-encoding-components/src/types/client_message.rs
+++ b/crates/wasm/wasm-encoding-components/src/types/client_message.rs
@@ -1,0 +1,3 @@
+use ibc::clients::wasm_types::client_message::ClientMessage;
+
+pub type WasmClientMessage = ClientMessage;

--- a/crates/wasm/wasm-encoding-components/src/types/mod.rs
+++ b/crates/wasm/wasm-encoding-components/src/types/mod.rs
@@ -1,2 +1,3 @@
+pub mod client_message;
 pub mod client_state;
 pub mod consensus_state;


### PR DESCRIPTION
- Redesign `impl_type_url!` macro to implement `SchemaGetter` on existing component type.
- Schema components that only use `impl_type_url!` directly are no longer wrapped with `DelegateEncoding`.
- Rename `EncodeWithContext` to `WithContext`.
- Rename `WrappedTendermintClientState` to `WasmTendermintClientState`.
- Implement Protobuf encoding for `WasmClientMessage`.
- Implement `MutEncoder` for `Timestamp` and `CommitmentRoot`.
- Relax `MutEncoder` constraint for `EncodeU64ProtoField` to use `TryInto`.