### PR TITLE
fn exec_command_with_envs() error now outputs missing command

### DIFF
--- a/crates/runtime/tokio-runtime-components/Cargo.toml
+++ b/crates/runtime/tokio-runtime-components/Cargo.toml
@@ -19,4 +19,5 @@ hermes-async-runtime-components     = { workspace = true }
 tokio           = { workspace = true, features = ["full"] }
 futures         = { workspace = true }
 rand            = { workspace = true }
+tracing         = { workspace = true }
 tokio-stream    = { version = "0.1" }


### PR DESCRIPTION
## Description

Replace generic missing file error with a message that better describes the problem. i.e. what specific command is missing.

Before:
```
Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

After:
```
2024-10-01T19:26:09.669752Z ERROR hermes_tokio_runtime_components::impls::os::exec_command: "simd" cannot be found
```

I've found myself needing to debug missing executables on several occasions and this change would considerably improve the time to resolution.

If tracing and/or this PR is not desirable, please let me know how best to improve it :)

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
