### PR TITLE
Delegate all create and update client types and methods based on counterparty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.2.0 (pre-release)
 
+-  Delegate all create and update client types and methods based on counterparty - [#468](https://github.com/informalsystems/hermes-sdk/pull/468)
+  - In `CosmosChainClientComponents`, delegate the following components to `UseDelegate<DelegateCosmosChainComponents>`:
+  `CreateClientPayloadTypeComponent`, `UpdateClientPayloadTypeComponent`,
+  `CreateClientPayloadOptionsTypeComponent`, `CreateClientPayloadBuilderComponent`,
+  `UpdateClientPayloadBuilderComponent`.
+    - To use CosmosChain with a concrete counterparty, the respective components need to be implemented in
+      `<DelegateCosmosChainComponents as DelegateComponent<Counterparty>>::Delegate`.
+
 - Make message senders return new `MessageResponse` type instead of `Vec<Chain::Event>` - [#460](https://github.com/informalsystems/hermes-sdk/pull/460)
   - Introduce `HasMessageResponseType` trait with `Chain::MessageResponse` abstract type,
     to represent the response returned from the blockchain after processing a `Chain::Message`.

--- a/crates/chain/chain-components/src/traits/message_builders/update_client.rs
+++ b/crates/chain/chain-components/src/traits/message_builders/update_client.rs
@@ -2,14 +2,15 @@ use alloc::vec::Vec;
 
 use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
+use hermes_chain_type_components::traits::types::ibc::client_id::HasClientIdType;
+use hermes_chain_type_components::traits::types::message::HasMessageType;
 
-use crate::traits::types::ibc::HasIbcChainTypes;
 use crate::traits::types::update_client::HasUpdateClientPayloadType;
 
 #[derive_component(UpdateClientMessageBuilderComponent, UpdateClientMessageBuilder<Chain>)]
 #[async_trait]
 pub trait CanBuildUpdateClientMessage<Counterparty>:
-    HasIbcChainTypes<Counterparty> + HasErrorType
+    HasClientIdType<Counterparty> + HasMessageType + HasErrorType
 where
     Counterparty: HasUpdateClientPayloadType<Self>,
 {
@@ -23,7 +24,7 @@ where
 impl<Chain, Counterparty, Components, Delegate> UpdateClientMessageBuilder<Chain, Counterparty>
     for UseDelegate<Components>
 where
-    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
+    Chain: HasClientIdType<Counterparty> + HasMessageType + HasErrorType,
     Counterparty: HasUpdateClientPayloadType<Chain>,
     Delegate: UpdateClientMessageBuilder<Chain, Counterparty>,
     Components: DelegateComponent<Counterparty, Delegate = Delegate>,

--- a/crates/chain/chain-components/src/traits/payload_builders/create_client.rs
+++ b/crates/chain/chain-components/src/traits/payload_builders/create_client.rs
@@ -1,3 +1,4 @@
+use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
 
 use crate::traits::types::create_client::{
@@ -15,4 +16,21 @@ pub trait CanBuildCreateClientPayload<Counterparty>:
         &self,
         create_client_options: &Self::CreateClientPayloadOptions,
     ) -> Result<Self::CreateClientPayload, Self::Error>;
+}
+
+impl<Chain, Counterparty, Components, Delegate> CreateClientPayloadBuilder<Chain, Counterparty>
+    for UseDelegate<Components>
+where
+    Chain: HasCreateClientPayloadOptionsType<Counterparty>
+        + HasCreateClientPayloadType<Counterparty>
+        + HasErrorType,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+    Delegate: CreateClientPayloadBuilder<Chain, Counterparty>,
+{
+    async fn build_create_client_payload(
+        chain: &Chain,
+        create_client_options: &Chain::CreateClientPayloadOptions,
+    ) -> Result<Chain::CreateClientPayload, Chain::Error> {
+        Delegate::build_create_client_payload(chain, create_client_options).await
+    }
 }

--- a/crates/chain/chain-components/src/traits/payload_builders/update_client.rs
+++ b/crates/chain/chain-components/src/traits/payload_builders/update_client.rs
@@ -1,3 +1,4 @@
+use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
 
 use crate::traits::types::client_state::HasClientStateType;
@@ -18,4 +19,25 @@ pub trait CanBuildUpdateClientPayload<Counterparty>:
         target_height: &Self::Height,
         client_state: Self::ClientState,
     ) -> Result<Self::UpdateClientPayload, Self::Error>;
+}
+
+impl<Chain, Counterparty, Components, Delegate> UpdateClientPayloadBuilder<Chain, Counterparty>
+    for UseDelegate<Components>
+where
+    Chain: HasUpdateClientPayloadType<Counterparty>
+        + HasClientStateType<Counterparty>
+        + HasHeightType
+        + HasErrorType,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+    Delegate: UpdateClientPayloadBuilder<Chain, Counterparty>,
+{
+    async fn build_update_client_payload(
+        chain: &Chain,
+        trusted_height: &Chain::Height,
+        target_height: &Chain::Height,
+        client_state: Chain::ClientState,
+    ) -> Result<Chain::UpdateClientPayload, Chain::Error> {
+        Delegate::build_update_client_payload(chain, trusted_height, target_height, client_state)
+            .await
+    }
 }

--- a/crates/chain/chain-components/src/traits/types/create_client.rs
+++ b/crates/chain/chain-components/src/traits/types/create_client.rs
@@ -1,4 +1,5 @@
-use cgp::core::component::UseDelegate;
+use cgp::core::component::{UseDelegate, WithProvider};
+use cgp::core::types::traits::ProvideType;
 use cgp::prelude::*;
 use hermes_chain_type_components::traits::types::ibc::client_id::HasClientIdType;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
@@ -65,4 +66,36 @@ where
     Delegate: ProvideCreateClientPayloadType<Chain, Counterparty>,
 {
     type CreateClientPayload = Delegate::CreateClientPayload;
+}
+
+impl<Chain, Counterparty, Provider, CreateClientMessageOptions>
+    ProvideCreateClientMessageOptionsType<Chain, Counterparty> for WithProvider<Provider>
+where
+    Chain: Async,
+    CreateClientMessageOptions: Async,
+    Provider:
+        ProvideType<Chain, CreateClientPayloadTypeComponent, Type = CreateClientMessageOptions>,
+{
+    type CreateClientMessageOptions = CreateClientMessageOptions;
+}
+
+impl<Chain, Counterparty, Provider, CreateClientPayloadOptions>
+    ProvideCreateClientPayloadOptionsType<Chain, Counterparty> for WithProvider<Provider>
+where
+    Chain: Async,
+    CreateClientPayloadOptions: Async,
+    Provider:
+        ProvideType<Chain, CreateClientPayloadTypeComponent, Type = CreateClientPayloadOptions>,
+{
+    type CreateClientPayloadOptions = CreateClientPayloadOptions;
+}
+
+impl<Chain, Counterparty, Provider, CreateClientPayload>
+    ProvideCreateClientPayloadType<Chain, Counterparty> for WithProvider<Provider>
+where
+    Chain: Async,
+    CreateClientPayload: Async,
+    Provider: ProvideType<Chain, CreateClientPayloadTypeComponent, Type = CreateClientPayload>,
+{
+    type CreateClientPayload = CreateClientPayload;
 }

--- a/crates/chain/chain-components/src/traits/types/create_client.rs
+++ b/crates/chain/chain-components/src/traits/types/create_client.rs
@@ -46,3 +46,13 @@ where
 {
     type CreateClientMessageOptions = Delegate::CreateClientMessageOptions;
 }
+
+impl<Chain, Counterparty, Components, Delegate> ProvideCreateClientPayloadType<Chain, Counterparty>
+    for UseDelegate<Components>
+where
+    Chain: Async,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+    Delegate: ProvideCreateClientPayloadType<Chain, Counterparty>,
+{
+    type CreateClientPayload = Delegate::CreateClientPayload;
+}

--- a/crates/chain/chain-components/src/traits/types/create_client.rs
+++ b/crates/chain/chain-components/src/traits/types/create_client.rs
@@ -47,6 +47,16 @@ where
     type CreateClientMessageOptions = Delegate::CreateClientMessageOptions;
 }
 
+impl<Chain, Counterparty, Components, Delegate>
+    ProvideCreateClientPayloadOptionsType<Chain, Counterparty> for UseDelegate<Components>
+where
+    Chain: Async,
+    Delegate: ProvideCreateClientPayloadOptionsType<Chain, Counterparty>,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+{
+    type CreateClientPayloadOptions = Delegate::CreateClientPayloadOptions;
+}
+
 impl<Chain, Counterparty, Components, Delegate> ProvideCreateClientPayloadType<Chain, Counterparty>
     for UseDelegate<Components>
 where

--- a/crates/chain/chain-components/src/traits/types/update_client.rs
+++ b/crates/chain/chain-components/src/traits/types/update_client.rs
@@ -1,4 +1,5 @@
-use cgp::core::component::UseDelegate;
+use cgp::core::component::{UseDelegate, WithProvider};
+use cgp::core::types::traits::ProvideType;
 use cgp::prelude::*;
 
 #[derive_component(UpdateClientPayloadTypeComponent, ProvideUpdateClientPayloadType<Chain>)]
@@ -14,4 +15,14 @@ where
     Delegate: ProvideUpdateClientPayloadType<Chain, Counterparty>,
 {
     type UpdateClientPayload = Delegate::UpdateClientPayload;
+}
+
+impl<Chain, Counterparty, Provider, UpdateClientPayload>
+    ProvideUpdateClientPayloadType<Chain, Counterparty> for WithProvider<Provider>
+where
+    Chain: Async,
+    UpdateClientPayload: Async,
+    Provider: ProvideType<Chain, UpdateClientPayloadTypeComponent, Type = UpdateClientPayload>,
+{
+    type UpdateClientPayload = UpdateClientPayload;
 }

--- a/crates/chain/chain-components/src/traits/types/update_client.rs
+++ b/crates/chain/chain-components/src/traits/types/update_client.rs
@@ -1,6 +1,17 @@
+use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
 
 #[derive_component(UpdateClientPayloadTypeComponent, ProvideUpdateClientPayloadType<Chain>)]
 pub trait HasUpdateClientPayloadType<Counterparty>: Async {
     type UpdateClientPayload: Async;
+}
+
+impl<Chain, Counterparty, Components, Delegate> ProvideUpdateClientPayloadType<Chain, Counterparty>
+    for UseDelegate<Components>
+where
+    Chain: Async,
+    Components: DelegateComponent<Counterparty, Delegate = Delegate>,
+    Delegate: ProvideUpdateClientPayloadType<Chain, Counterparty>,
+{
+    type UpdateClientPayload = Delegate::UpdateClientPayload;
 }

--- a/crates/cosmos/cosmos-chain-components/src/components/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/client.rs
@@ -137,8 +137,6 @@ pub use hermes_relayer_components::chain::traits::types::update_client::UpdateCl
 
 use crate::components::delegate::DelegateCosmosChainComponents;
 use crate::impls::channel::init_channel_options::ProvideCosmosInitChannelOptionsType;
-use crate::impls::client::create_client_payload::BuildCreateClientPayloadWithChainHandle;
-use crate::impls::client::update_client_payload::BuildUpdateClientPayloadWithChainHandle;
 use crate::impls::connection::init_connection_options::ProvideCosmosInitConnectionOptionsType;
 use crate::impls::events::ProvideCosmosEvents;
 use crate::impls::packet::packet_fields::CosmosPacketFieldReader;
@@ -168,7 +166,6 @@ use crate::impls::queries::write_ack_event::QueryWriteAckEventFromChainHandle;
 use crate::impls::types::chain::ProvideCosmosChainTypes;
 use crate::impls::types::client_state::ProvideAnyRawClientState;
 use crate::impls::types::consensus_state::ProvideAnyRawConsensusState;
-use crate::impls::types::create_client_options::ProvideCosmosCreateClientSettings;
 use crate::impls::types::payload::ProvideCosmosPayloadTypes;
 pub use crate::traits::abci_query::AbciQuerierComponent;
 
@@ -252,12 +249,6 @@ define_components! {
             RawConsensusStateWithProofsQuerierComponent,
         ]:
             QueryCosmosConsensusStateFromAbci,
-        CreateClientPayloadOptionsTypeComponent:
-            ProvideCosmosCreateClientSettings,
-        CreateClientPayloadBuilderComponent:
-            BuildCreateClientPayloadWithChainHandle,
-        UpdateClientPayloadBuilderComponent:
-            BuildUpdateClientPayloadWithChainHandle,
         CounterpartyChainIdQuerierComponent:
             QueryChainIdWithChainHandle,
 
@@ -347,6 +338,7 @@ define_components! {
 
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
+            CreateClientPayloadOptionsTypeComponent,
 
             ConsensusStateHeightsQuerierComponent,
             CounterpartyMessageHeightGetterComponent,
@@ -355,6 +347,9 @@ define_components! {
 
             CreateClientMessageBuilderComponent,
             CreateClientMessageOptionsTypeComponent,
+
+            CreateClientPayloadBuilderComponent,
+            UpdateClientPayloadBuilderComponent,
 
             ClientStateQuerierComponent,
             ClientStateWithProofsQuerierComponent,

--- a/crates/cosmos/cosmos-chain-components/src/components/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/client.rs
@@ -219,8 +219,6 @@ define_components! {
         ]:
             ProvideCosmosEvents,
         [
-            CreateClientPayloadTypeComponent,
-            UpdateClientPayloadTypeComponent,
             ConnectionOpenInitPayloadTypeComponent,
             ConnectionOpenTryPayloadTypeComponent,
             ConnectionOpenAckPayloadTypeComponent,
@@ -346,6 +344,9 @@ define_components! {
 
             ConsensusStateTypeComponent,
             ConsensusStateFieldComponent,
+
+            CreateClientPayloadTypeComponent,
+            UpdateClientPayloadTypeComponent,
 
             ConsensusStateHeightsQuerierComponent,
             CounterpartyMessageHeightGetterComponent,

--- a/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
@@ -11,6 +11,8 @@ use hermes_relayer_components::chain::traits::message_builders::connection_hands
 };
 use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::update_client::UpdateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::queries::client_state::{
     AllClientStatesQuerierComponent, ClientStateQuerierComponent,
     ClientStateWithProofsQuerierComponent,
@@ -26,20 +28,25 @@ use hermes_relayer_components::chain::traits::types::consensus_state::{
     ConsensusStateFieldComponent, ConsensusStateTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::create_client::{
-    CreateClientMessageOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    CreateClientMessageOptionsTypeComponent, CreateClientPayloadOptionsTypeComponent,
+    CreateClientPayloadTypeComponent,
 };
 use hermes_relayer_components::chain::traits::types::ibc::CounterpartyMessageHeightGetterComponent;
 use hermes_relayer_components::chain::traits::types::update_client::UpdateClientPayloadTypeComponent;
 
 use crate::impls::channel::channel_handshake_message::BuildCosmosChannelHandshakeMessage;
 use crate::impls::client::create_client_message::BuildAnyCreateClientMessage;
+use crate::impls::client::create_client_payload::BuildCreateClientPayloadWithChainHandle;
 use crate::impls::client::update_client_message::BuildCosmosUpdateClientMessage;
+use crate::impls::client::update_client_payload::BuildUpdateClientPayloadWithChainHandle;
 use crate::impls::connection::connection_handshake_message::BuildCosmosConnectionHandshakeMessage;
 use crate::impls::message_height::GetCosmosCounterpartyMessageHeight;
 use crate::impls::queries::consensus_state_height::QueryConsensusStateHeightsFromGrpc;
 use crate::impls::types::client_state::ProvideTendermintClientState;
 use crate::impls::types::consensus_state::ProvideTendermintConsensusState;
-use crate::impls::types::create_client_options::ProvideNoCreateClientMessageOptionsType;
+use crate::impls::types::create_client_options::{
+    ProvideCosmosCreateClientSettings, ProvideNoCreateClientMessageOptionsType,
+};
 use crate::impls::types::payload::ProvideCosmosPayloadTypes;
 
 define_components! {
@@ -59,6 +66,8 @@ define_components! {
             UpdateClientPayloadTypeComponent,
         ]:
             ProvideCosmosPayloadTypes,
+        CreateClientPayloadOptionsTypeComponent:
+            ProvideCosmosCreateClientSettings,
         [
             ClientStateQuerierComponent,
             ClientStateWithProofsQuerierComponent,
@@ -76,6 +85,10 @@ define_components! {
             BuildAnyCreateClientMessage,
         UpdateClientMessageBuilderComponent:
             BuildCosmosUpdateClientMessage,
+        CreateClientPayloadBuilderComponent:
+            BuildCreateClientPayloadWithChainHandle,
+        UpdateClientPayloadBuilderComponent:
+            BuildUpdateClientPayloadWithChainHandle,
         [
             ConnectionOpenInitMessageBuilderComponent,
             ConnectionOpenTryMessageBuilderComponent,

--- a/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/cosmos_to_cosmos.rs
@@ -25,8 +25,11 @@ use hermes_relayer_components::chain::traits::types::client_state::{
 use hermes_relayer_components::chain::traits::types::consensus_state::{
     ConsensusStateFieldComponent, ConsensusStateTypeComponent,
 };
-use hermes_relayer_components::chain::traits::types::create_client::CreateClientMessageOptionsTypeComponent;
+use hermes_relayer_components::chain::traits::types::create_client::{
+    CreateClientMessageOptionsTypeComponent, CreateClientPayloadTypeComponent,
+};
 use hermes_relayer_components::chain::traits::types::ibc::CounterpartyMessageHeightGetterComponent;
+use hermes_relayer_components::chain::traits::types::update_client::UpdateClientPayloadTypeComponent;
 
 use crate::impls::channel::channel_handshake_message::BuildCosmosChannelHandshakeMessage;
 use crate::impls::client::create_client_message::BuildAnyCreateClientMessage;
@@ -37,6 +40,7 @@ use crate::impls::queries::consensus_state_height::QueryConsensusStateHeightsFro
 use crate::impls::types::client_state::ProvideTendermintClientState;
 use crate::impls::types::consensus_state::ProvideTendermintConsensusState;
 use crate::impls::types::create_client_options::ProvideNoCreateClientMessageOptionsType;
+use crate::impls::types::payload::ProvideCosmosPayloadTypes;
 
 define_components! {
     CosmosToCosmosComponents {
@@ -50,6 +54,11 @@ define_components! {
             ConsensusStateFieldComponent,
         ]:
             ProvideTendermintConsensusState,
+        [
+            CreateClientPayloadTypeComponent,
+            UpdateClientPayloadTypeComponent,
+        ]:
+            ProvideCosmosPayloadTypes,
         [
             ClientStateQuerierComponent,
             ClientStateWithProofsQuerierComponent,

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -1,8 +1,13 @@
 use alloc::sync::Arc;
 use core::ops::Deref;
-use hermes_cosmos_chain_components::types::payloads::client::CosmosUpdateClientPayload;
-use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayloadType;
+use hermes_cosmos_chain_components::types::payloads::client::{
+    CosmosCreateClientPayload, CosmosUpdateClientPayload,
+};
+use hermes_relayer_components::chain::traits::types::create_client::{
+    HasCreateClientPayloadOptionsType, HasCreateClientPayloadType,
+};
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
+use ibc_relayer::chain::cosmos::client::Settings;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
 use cgp::prelude::*;
@@ -371,7 +376,9 @@ pub trait CanUseCosmosChain:
     + HasCommitmentProofType<CommitmentProof = CosmosCommitmentProof>
     + HasMessageResponseType<MessageResponse = Vec<Arc<AbciEvent>>>
     + HasEventType<Event = Arc<AbciEvent>>
+    + HasCreateClientPayloadType<CosmosChain, CreateClientPayload = CosmosCreateClientPayload>
     + HasUpdateClientPayloadType<CosmosChain, UpdateClientPayload = CosmosUpdateClientPayload>
+    + HasCreateClientPayloadOptionsType<CosmosChain, CreateClientPayloadOptions = Settings>
     + CanQueryBalance
     + CanIbcTransferToken<CosmosChain>
     + CanBuildIbcTokenTransferMessage<CosmosChain>

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -1,5 +1,8 @@
 use alloc::sync::Arc;
 use core::ops::Deref;
+use hermes_cosmos_chain_components::types::payloads::client::CosmosUpdateClientPayload;
+use hermes_relayer_components::chain::traits::types::create_client::HasCreateClientPayloadType;
+use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
 use cgp::prelude::*;
@@ -368,6 +371,7 @@ pub trait CanUseCosmosChain:
     + HasCommitmentProofType<CommitmentProof = CosmosCommitmentProof>
     + HasMessageResponseType<MessageResponse = Vec<Arc<AbciEvent>>>
     + HasEventType<Event = Arc<AbciEvent>>
+    + HasUpdateClientPayloadType<CosmosChain, UpdateClientPayload = CosmosUpdateClientPayload>
     + CanQueryBalance
     + CanIbcTransferToken<CosmosChain>
     + CanBuildIbcTokenTransferMessage<CosmosChain>
@@ -400,7 +404,10 @@ pub trait CanUseCosmosChain:
     + HasMessageResponseEvents
     + HasSendPacketEvent<CosmosChain>
 where
-    CosmosChain: HasClientStateType<Self> + HasConsensusStateType<Self>,
+    CosmosChain: HasClientStateType<Self>
+        + HasConsensusStateType<Self>
+        + HasCreateClientPayloadType<Self>
+        + HasUpdateClientPayloadType<Self>,
 {
 }
 

--- a/crates/cosmos/cosmos-wasm-relayer/src/components/cosmos_to_wasm_cosmos.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/components/cosmos_to_wasm_cosmos.rs
@@ -1,8 +1,9 @@
 use cgp::prelude::*;
 use hermes_cosmos_chain_components::components::client::{
     ClientStateFieldsComponent, ClientStateTypeComponent, ConsensusStateFieldComponent,
-    ConsensusStateTypeComponent, CreateClientPayloadTypeComponent,
-    UpdateClientPayloadTypeComponent,
+    ConsensusStateTypeComponent, CreateClientPayloadBuilderComponent,
+    CreateClientPayloadOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    UpdateClientPayloadBuilderComponent, UpdateClientPayloadTypeComponent,
 };
 use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::{
@@ -45,9 +46,12 @@ define_components! {
             ConsensusStateFieldComponent,
             CreateClientPayloadTypeComponent,
             UpdateClientPayloadTypeComponent,
+            CreateClientPayloadOptionsTypeComponent,
             ClientStateQuerierComponent,
             ClientStateWithProofsQuerierComponent,
             AllClientStatesQuerierComponent,
+            CreateClientPayloadBuilderComponent,
+            UpdateClientPayloadBuilderComponent,
             ConsensusStateQuerierComponent,
             ConsensusStateWithProofsQuerierComponent,
             ConnectionOpenInitMessageBuilderComponent,

--- a/crates/cosmos/cosmos-wasm-relayer/src/components/cosmos_to_wasm_cosmos.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/components/cosmos_to_wasm_cosmos.rs
@@ -1,7 +1,8 @@
 use cgp::prelude::*;
 use hermes_cosmos_chain_components::components::client::{
     ClientStateFieldsComponent, ClientStateTypeComponent, ConsensusStateFieldComponent,
-    ConsensusStateTypeComponent,
+    ConsensusStateTypeComponent, CreateClientPayloadTypeComponent,
+    UpdateClientPayloadTypeComponent,
 };
 use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
 use hermes_relayer_components::chain::traits::message_builders::channel_handshake::{
@@ -42,6 +43,8 @@ define_components! {
             ClientStateFieldsComponent,
             ConsensusStateTypeComponent,
             ConsensusStateFieldComponent,
+            CreateClientPayloadTypeComponent,
+            UpdateClientPayloadTypeComponent,
             ClientStateQuerierComponent,
             ClientStateWithProofsQuerierComponent,
             AllClientStatesQuerierComponent,

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/chain.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/chain.rs
@@ -22,6 +22,9 @@ use hermes_cosmos_chain_components::traits::grpc_address::GrpcAddressGetter;
 use hermes_cosmos_chain_components::traits::rpc_client::RpcClientGetter;
 use hermes_cosmos_chain_components::traits::tx_extension_options::TxExtensionOptionsGetter;
 use hermes_cosmos_chain_components::types::nonce_guard::NonceGuard;
+use hermes_cosmos_chain_components::types::payloads::client::{
+    CosmosCreateClientPayload, CosmosUpdateClientPayload,
+};
 use hermes_cosmos_chain_components::types::tendermint::{
     TendermintClientState, TendermintConsensusState,
 };
@@ -166,7 +169,7 @@ use hermes_relayer_components::chain::traits::types::consensus_state::{
 use hermes_relayer_components::chain::traits::types::create_client::{
     CreateClientEventComponent, CreateClientMessageOptionsTypeComponent,
     CreateClientPayloadOptionsTypeComponent, CreateClientPayloadTypeComponent,
-    HasCreateClientMessageOptionsType,
+    HasCreateClientMessageOptionsType, HasCreateClientPayloadType,
 };
 use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
 use hermes_relayer_components::chain::traits::types::height::{
@@ -200,7 +203,9 @@ use hermes_relayer_components::chain::traits::types::proof::{
 };
 use hermes_relayer_components::chain::traits::types::status::ChainStatusTypeComponent;
 use hermes_relayer_components::chain::traits::types::timestamp::TimeoutTypeComponent;
-use hermes_relayer_components::chain::traits::types::update_client::UpdateClientPayloadTypeComponent;
+use hermes_relayer_components::chain::traits::types::update_client::{
+    HasUpdateClientPayloadType, UpdateClientPayloadTypeComponent,
+};
 use hermes_relayer_components::error::traits::retry::{HasRetryableError, RetryableErrorComponent};
 use hermes_relayer_components::transaction::impls::poll_tx_response::HasPollTimeout;
 use hermes_relayer_components::transaction::traits::default_signer::DefaultSignerGetter;
@@ -575,6 +580,8 @@ impl HasEventSubscription for WasmCosmosChain {
 pub trait CanUseWasmCosmosChain:
     HasClientStateType<WasmCosmosChain, ClientState = WasmTendermintClientState>
     + HasConsensusStateType<WasmCosmosChain, ConsensusState = TendermintConsensusState>
+    + HasCreateClientPayloadType<WasmCosmosChain, CreateClientPayload = CosmosCreateClientPayload>
+    + HasUpdateClientPayloadType<WasmCosmosChain, UpdateClientPayload = CosmosUpdateClientPayload>
     + CanQueryBalance
     // + CanIbcTransferToken<WasmCosmosChain>
     // + CanBuildIbcTokenTransferMessage<WasmCosmosChain>
@@ -638,8 +645,13 @@ pub trait CanUseWasmCosmosChain:
     + CanUploadWasmClientCode
 where
     CosmosChain: HasClientStateType<Self, ClientState = TendermintClientState>
-        + HasConsensusStateType<Self, ConsensusState = TendermintConsensusState>,
+        + HasConsensusStateType<Self, ConsensusState = TendermintConsensusState>
+        + HasUpdateClientPayloadType<Self>
+        + HasCreateClientPayloadType<Self>
+        ,
     WasmCosmosChain: HasConsensusStateType<Self>
+        + HasUpdateClientPayloadType<Self>
+        + HasCreateClientPayloadType<Self>
 {
 }
 
@@ -670,7 +682,9 @@ pub trait CanUseCosmosChainWithWasmCosmosChain:
     + HasInitConnectionOptionsType<WasmCosmosChain>
     + CanBuildCreateClientMessage<WasmCosmosChain>
 where
-    WasmCosmosChain: HasConsensusStateType<Self>,
+    WasmCosmosChain: HasConsensusStateType<Self>
+        + HasCreateClientPayloadType<Self>
+        + HasUpdateClientPayloadType<Self>,
 {
 }
 

--- a/crates/solomachine/solomachine-chain-components/src/components/cosmos.rs
+++ b/crates/solomachine/solomachine-chain-components/src/components/cosmos.rs
@@ -1,10 +1,10 @@
 use cgp::prelude::*;
 use hermes_cosmos_chain_components::components::client::{
-    ClientStateFieldsComponent, ClientStateTypeComponent,
+    ClientStateFieldsComponent, ClientStateTypeComponent, CreateClientPayloadBuilderComponent,
+    CreateClientPayloadOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    UpdateClientPayloadBuilderComponent, UpdateClientPayloadTypeComponent,
 };
-use hermes_cosmos_chain_components::impls::types::client_state::ProvideTendermintClientState;
-use hermes_relayer_components::chain::impls::queries::query_and_convert_client_state::QueryAndConvertRawClientState;
-use hermes_relayer_components::chain::impls::queries::query_and_convert_consensus_state::QueryAndConvertRawConsensusState;
+use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
 use hermes_relayer_components::chain::traits::message_builders::connection_handshake::{
     ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
     ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
@@ -26,18 +26,17 @@ define_components! {
         [
             ClientStateTypeComponent,
             ClientStateFieldsComponent,
-        ]:
-            ProvideTendermintClientState,
-        [
             ClientStateQuerierComponent,
             ClientStateWithProofsQuerierComponent,
-        ]:
-            QueryAndConvertRawClientState,
-        [
             ConsensusStateQuerierComponent,
             ConsensusStateWithProofsQuerierComponent,
+            CreateClientPayloadTypeComponent,
+            UpdateClientPayloadTypeComponent,
+            CreateClientPayloadOptionsTypeComponent,
+            CreateClientPayloadBuilderComponent,
+            UpdateClientPayloadBuilderComponent,
         ]:
-            QueryAndConvertRawConsensusState,
+            CosmosToCosmosComponents,
         [
             CreateClientMessageBuilderComponent,
             CreateClientMessageOptionsTypeComponent,


### PR DESCRIPTION
- In `CosmosChainClientComponents`, delegate the following components to `UseDelegate<DelegateCosmosChainComponents>`:
`CreateClientPayloadTypeComponent`, `UpdateClientPayloadTypeComponent`,
`CreateClientPayloadOptionsTypeComponent`, `CreateClientPayloadBuilderComponent`,
`UpdateClientPayloadBuilderComponent`.
  - To use CosmosChain with a concrete counterparty, the respective components need to be implemented in
    `<DelegateCosmosChainComponents as DelegateComponent<Counterparty>>::Delegate`.