### PR TITLE
Implement placeholder query of latest client state height as consensus state heights

### DIFF
--- a/crates/chain/chain-components/src/impls/queries/consensus_state_height.rs
+++ b/crates/chain/chain-components/src/impls/queries/consensus_state_height.rs
@@ -1,6 +1,7 @@
 use core::fmt::Debug;
 
 use cgp::core::error::CanRaiseError;
+use hermes_chain_type_components::traits::types::ibc::client_id::HasClientIdType;
 
 use crate::traits::queries::consensus_state_height::{
     CanQueryConsensusStateHeights, ConsensusStateHeightQuerier,
@@ -12,7 +13,7 @@ pub struct QueryConsensusStateHeightsAndFindHeightBefore;
 
 pub struct NoConsensusStateAtLessThanHeight<'a, Chain, Counterparty>
 where
-    Chain: HasIbcChainTypes<Counterparty>,
+    Chain: HasClientIdType<Counterparty>,
     Counterparty: HasHeightType,
 {
     pub chain: &'a Chain,

--- a/crates/chain/chain-components/src/impls/queries/consensus_state_heights.rs
+++ b/crates/chain/chain-components/src/impls/queries/consensus_state_heights.rs
@@ -1,0 +1,45 @@
+use core::marker::PhantomData;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use hermes_chain_type_components::traits::types::height::HasHeightType;
+
+use crate::traits::queries::client_state::CanQueryClientStateWithLatestHeight;
+use crate::traits::queries::consensus_state_height::ConsensusStateHeightsQuerier;
+use crate::traits::types::client_state::HasClientStateFields;
+
+/**
+   This is a placeholder implementation for querying all consensus state heights,
+   by returning only the latest client state height to be used as the trusted height.
+
+   This would not work in the corner case when the relayer tries to perform
+   UpdateClient with a target height that is lower than the latest height.
+   In that case, if this is used together with `QueryConsensusStateHeightsAndFindHeightBefore`,
+   then the error `NoConsensusStateAtLessThanHeight` would be returned.
+   With retry logic, the relayer should be able to retry relaying the packet,
+   and use an updated target height that should be higher than the latest height.
+
+   However, in normal cases, this should work fine, in particular when there
+   is only one instance of relayer performing the client update.
+*/
+pub struct QueryLatestConsensusStateHeightAsHeights;
+
+impl<Chain, Counterparty> ConsensusStateHeightsQuerier<Chain, Counterparty>
+    for QueryLatestConsensusStateHeightAsHeights
+where
+    Chain: CanQueryClientStateWithLatestHeight<Counterparty>,
+    Counterparty: HasHeightType + HasClientStateFields<Chain>,
+{
+    async fn query_consensus_state_heights(
+        chain: &Chain,
+        client_id: &Chain::ClientId,
+    ) -> Result<Vec<Counterparty::Height>, Chain::Error> {
+        let client_state = chain
+            .query_client_state_with_latest_height(PhantomData, client_id)
+            .await?;
+
+        let latest_height = Counterparty::client_state_latest_height(&client_state);
+
+        Ok(vec![latest_height])
+    }
+}

--- a/crates/chain/chain-components/src/impls/queries/mod.rs
+++ b/crates/chain/chain-components/src/impls/queries/mod.rs
@@ -1,4 +1,5 @@
 pub mod consensus_state_height;
+pub mod consensus_state_heights;
 pub mod query_and_convert_client_state;
 pub mod query_and_convert_consensus_state;
 pub mod query_and_decode_consensus_state;

--- a/crates/chain/chain-components/src/traits/queries/consensus_state_height.rs
+++ b/crates/chain/chain-components/src/traits/queries/consensus_state_height.rs
@@ -2,14 +2,14 @@ use alloc::vec::Vec;
 
 use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
+use hermes_chain_type_components::traits::types::ibc::client_id::HasClientIdType;
 
 use crate::traits::types::height::HasHeightType;
-use crate::traits::types::ibc::HasIbcChainTypes;
 
 #[derive_component(ConsensusStateHeightQuerierComponent, ConsensusStateHeightQuerier<Chain>)]
 #[async_trait]
 pub trait CanQueryConsensusStateHeight<Counterparty>:
-    HasIbcChainTypes<Counterparty> + HasErrorType
+    HasClientIdType<Counterparty> + HasErrorType
 where
     Counterparty: HasHeightType,
 {
@@ -31,7 +31,7 @@ where
 #[derive_component(ConsensusStateHeightsQuerierComponent, ConsensusStateHeightsQuerier<Chain>)]
 #[async_trait]
 pub trait CanQueryConsensusStateHeights<Counterparty>:
-    HasIbcChainTypes<Counterparty> + HasErrorType
+    HasClientIdType<Counterparty> + HasErrorType
 where
     Counterparty: HasHeightType,
 {
@@ -44,7 +44,7 @@ where
 impl<Chain, Counterparty, Components, Delegate> ConsensusStateHeightsQuerier<Chain, Counterparty>
     for UseDelegate<Components>
 where
-    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
+    Chain: HasClientIdType<Counterparty> + HasErrorType,
     Counterparty: HasHeightType,
     Delegate: ConsensusStateHeightsQuerier<Chain, Counterparty>,
     Components: DelegateComponent<Counterparty, Delegate = Delegate>,

--- a/crates/cli/cli-components/src/impls/commands/queries/consensus_state.rs
+++ b/crates/cli/cli-components/src/impls/commands/queries/consensus_state.rs
@@ -6,6 +6,7 @@ use hermes_relayer_components::build::traits::builders::chain_builder::CanBuildC
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainHeight;
 use hermes_relayer_components::chain::traits::queries::consensus_state::CanQueryConsensusState;
 use hermes_relayer_components::chain::traits::queries::consensus_state_height::CanQueryConsensusStateHeights;
+use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
 use hermes_relayer_components::chain::traits::types::consensus_state::HasConsensusStateType;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::multi::traits::chain_at::HasChainTypeAt;
@@ -67,6 +68,7 @@ where
         + CanRaiseError<String>,
     Build: CanBuildChain<0, Chain = Chain> + HasChainTypeAt<1, Chain = Counterparty>,
     Chain: CanQueryChainHeight
+        + HasChainIdType
         + CanQueryConsensusState<Counterparty>
         + CanQueryConsensusStateHeights<Counterparty>,
     Counterparty: HasHeightType + HasConsensusStateType<Chain>,

--- a/crates/relayer/relayer-components-extra/src/components/extra/closures/chain/channel_handshake.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/closures/chain/channel_handshake.rs
@@ -41,7 +41,8 @@ where
 impl<Chain, Counterparty, Components> UseExtraChainComponentsForChannelHandshake<Counterparty>
     for Chain
 where
-    Chain: HasChannelOpenInitEvent<Counterparty>
+    Chain: HasIbcChainTypes<Counterparty>
+        + HasChannelOpenInitEvent<Counterparty>
         + HasChannelOpenTryEvent<Counterparty>
         + HasInitChannelOptionsType<Counterparty>
         + HasChannelOpenTryPayloadType<Counterparty>

--- a/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/ack_packet_relayer.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/ack_packet_relayer.rs
@@ -57,6 +57,7 @@ where
         + HasChainId
         + CanSendMessages
         + CanQueryChainStatus
+        + HasIbcChainTypes<DstChain>
         + HasConsensusStateType<DstChain>
         + HasCounterpartyMessageHeight<DstChain>
         + CanReadOutgoingPacketFields<DstChain>

--- a/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/message_sender.rs
+++ b/crates/relayer/relayer-components-extra/src/components/extra/closures/relay/message_sender.rs
@@ -2,6 +2,7 @@ use cgp::core::component::HasComponents;
 use cgp::core::error::{CanRaiseError, ErrorOf, ErrorRaiser};
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLog;
+use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
 use hermes_relayer_components::relay::impls::update_client::skip::LogSkipBuildUpdateClientMessage;
 use hermes_relayer_components::relay::impls::update_client::wait::LogWaitUpdateClientHeightStatus;
@@ -34,10 +35,12 @@ where
         + HasMessageBatchSender<SourceTarget>
         + HasMessageBatchSender<DestinationTarget>
         + HasComponents<Components = Components>,
-    SrcChain: HasOutgoingPacketType<DstChain>
+    SrcChain: HasIbcChainTypes<DstChain>
+        + HasOutgoingPacketType<DstChain>
         + UseExtraChainComponentsForIbcMessageSender<DstChain>
         + CanRaiseError<ErrorOf<SrcChain::Runtime>>,
-    DstChain: UseExtraChainComponentsForIbcMessageSender<SrcChain>
+    DstChain: HasIbcChainTypes<SrcChain>
+        + UseExtraChainComponentsForIbcMessageSender<SrcChain>
         + CanRaiseError<ErrorOf<DstChain::Runtime>>,
     SrcChain::Height: Clone,
     DstChain::Height: Clone,

--- a/crates/relayer/relayer-components/src/components/default/closures/relay/ack_packet_relayer.rs
+++ b/crates/relayer/relayer-components/src/components/default/closures/relay/ack_packet_relayer.rs
@@ -45,6 +45,7 @@ where
         + CanSendMessages
         + HasMessageResponseEvents
         + CanQueryChainStatus
+        + HasIbcChainTypes<DstChain>
         + CanReadOutgoingPacketFields<DstChain>
         + HasConsensusStateType<DstChain>
         + HasCounterpartyMessageHeight<DstChain>

--- a/crates/relayer/relayer-components/src/components/default/closures/relay/packet_relayer.rs
+++ b/crates/relayer/relayer-components/src/components/default/closures/relay/packet_relayer.rs
@@ -1,6 +1,7 @@
 use cgp::core::component::HasComponents;
 use cgp::core::error::{ErrorRaiser, HasErrorType};
 use hermes_chain_components::traits::send_message::EmptyMessageResponse;
+use hermes_chain_components::traits::types::ibc::HasIbcChainTypes;
 use hermes_chain_type_components::traits::fields::message_response_events::HasMessageResponseEvents;
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLog;
@@ -55,6 +56,7 @@ where
         + CanSendMessages
         + HasMessageResponseEvents
         + CanQueryChainStatus
+        + HasIbcChainTypes<DstChain>
         + HasClientStateFields<DstChain>
         + HasConsensusStateType<DstChain>
         + HasCounterpartyMessageHeight<DstChain>


### PR DESCRIPTION
Add `QueryLatestConsensusStateHeightAsHeights` as a placeholder implementation for querying all consensus state heights using `ConsensusStateHeightsQuerier`, by returning only the latest client state height to be used as the trusted height. This can be used for partial chain implementations, where the query method for getting all consensus state heights is not available.

This would not work in the corner case when the relayer tries to perform UpdateClient with a target height that is lower than the latest height. In that case, if this is used together with `QueryConsensusStateHeightsAndFindHeightBefore`, then the error `NoConsensusStateAtLessThanHeight` would be returned. With retry logic, the relayer should be able to retry relaying the packet, and use an updated target height that should be higher than the latest height.

However, in normal cases, this should work fine, in particular when there is only one instance of relayer performing the client update.

This PR also simplifies the trait bound for `ConsensusStateHeightsQuerier` to require only `HasClientIdType` instead of `HasIbcChainTypes`.