### PR TITLE
Bootstrap components improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v0.2.0 (pre-release)
 
+-  Bootstrap components improvements - [#473](https://github.com/informalsystems/hermes-sdk/pull/473)
+  - Introduce `CosmosSdkConfigModifier` trait, which Cosmos bootstrap contexts now required to implement.
+  - Implement `UseContext` for various accessor traits for the bootstrap context.
+  - Pass `Bootstrap::ChainGenesisConfig` to `build_chain_with_node_config` and `build_relayer_chain_config`.
+  - Rename fields in Cosmos bootstrap contexts.
+
 - CLI Components Improvements - [#472](https://github.com/informalsystems/hermes-sdk/pull/472)
   - Implement `WithProvider` for CLI type traits.
   - Implement `UseDelegate` for `ArgParser` and `CommandRunner`.

--- a/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
@@ -25,7 +25,6 @@ use hermes_cosmos_integration_tests::impls::bootstrap::types::ProvideCosmosBoots
 use hermes_cosmos_integration_tests::traits::bootstrap::build_chain::ChainBuilderWithNodeConfigComponent;
 use hermes_cosmos_integration_tests::traits::bootstrap::compat_mode::CompatModeGetter;
 use hermes_cosmos_integration_tests::traits::bootstrap::cosmos_builder::CosmosBuilderGetter;
-use hermes_cosmos_integration_tests::traits::bootstrap::gas_denom::GasDenomGetter;
 use hermes_cosmos_integration_tests::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk_legacy::*;
@@ -195,12 +194,6 @@ impl CompatModeGetter<CelestiaBootstrap> for CelestiaBootstrapComponents {
         const COMPAT_MODE: CompatMode = CompatMode::V0_34;
 
         Some(&COMPAT_MODE)
-    }
-}
-
-impl GasDenomGetter<CelestiaBootstrap> for CelestiaBootstrapComponents {
-    fn gas_denom(_bootstrap: &CelestiaBootstrap) -> &str {
-        "utia"
     }
 }
 

--- a/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/src/contexts/bootstrap.rs
@@ -1,7 +1,9 @@
 use alloc::sync::Arc;
 use cgp::core::component::UseContext;
 use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_comet_config::NoModifyCometConfig;
+use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_cosmos_sdk_config::NoModifyCosmosSdkConfig;
 use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_genesis_config::NoModifyGenesisConfig;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifierComponent;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -118,6 +120,8 @@ delegate_components! {
             NoModifyGenesisConfig,
         CometConfigModifierComponent:
             NoModifyCometConfig,
+        CosmosSdkConfigModifierComponent:
+            NoModifyCosmosSdkConfig,
         RelayerChainConfigBuilderComponent:
             BuildRelayerChainConfig,
         ChainBuilderWithNodeConfigComponent:

--- a/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
+++ b/crates/celestia/celestia-integration-tests/tests/bootstrap.rs
@@ -27,7 +27,7 @@ fn test_celestia_bootstrap() -> Result<(), Error> {
 
     let celestia_bootstrap = CelestiaBootstrap {
         runtime: runtime.clone(),
-        builder: builder.clone(),
+        cosmos_builder: builder.clone(),
         chain_store_dir: store_dir.join("chains"),
         bridge_store_dir: store_dir.join("bridges"),
     };

--- a/crates/celestia/celestia-integration-tests/tests/celestia_integration_tests.rs
+++ b/crates/celestia/celestia-integration-tests/tests/celestia_integration_tests.rs
@@ -26,26 +26,26 @@ fn celestia_integration_tests() -> Result<(), Error> {
 
     let celestia_bootstrap = Arc::new(CosmosBootstrap {
         runtime: runtime.clone(),
-        builder: builder.clone(),
+        cosmos_builder: builder.clone(),
         should_randomize_identifiers: true,
         chain_store_dir: "./test-data/chains".into(),
         chain_command_path: "celestia-appd".into(),
         account_prefix: "celestia".into(),
-        staking_denom: "utia".into(),
-        transfer_denom: "coin".into(),
+        staking_denom_prefix: "utia".into(),
+        transfer_denom_prefix: "coin".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     });
 
     let cosmos_bootstrap = Arc::new(CosmosBootstrap {
         runtime: runtime.clone(),
-        builder,
+        cosmos_builder: builder,
         should_randomize_identifiers: true,
         chain_store_dir: "./test-data/chains".into(),
         chain_command_path: "gaiad".into(),
         account_prefix: "cosmos".into(),
-        staking_denom: "stake".into(),
-        transfer_denom: "coin".into(),
+        staking_denom_prefix: "stake".into(),
+        transfer_denom_prefix: "coin".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     });

--- a/crates/cli/cli/src/commands/bootstrap/chain.rs
+++ b/crates/cli/cli/src/commands/bootstrap/chain.rs
@@ -47,13 +47,13 @@ where
 
         let bootstrap = CosmosBootstrap {
             runtime: runtime.clone(),
-            builder: Arc::new(builder),
+            cosmos_builder: Arc::new(builder),
             should_randomize_identifiers: false,
             chain_store_dir: args.chain_store_dir.clone().into(),
             chain_command_path: args.chain_command_path.clone().into(),
             account_prefix: args.account_prefix.clone(),
-            staking_denom: args.staking_denom.clone(),
-            transfer_denom: args.transfer_denom.clone(),
+            staking_denom_prefix: args.staking_denom.clone(),
+            transfer_denom_prefix: args.transfer_denom.clone(),
             genesis_config_modifier: Box::new(|_| Ok(())),
             comet_config_modifier: Box::new(|_| Ok(())),
         };

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/binary_channel/setup.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/binary_channel/setup.rs
@@ -161,13 +161,13 @@ impl ProvideBootstrapAt<CosmosBinaryChannelSetup, 1> for CosmosBinaryChannelSetu
 
 impl ProvideBuilderAt<CosmosBinaryChannelSetup, 0, 1> for CosmosBinaryChannelSetupComponents {
     fn builder(setup: &CosmosBinaryChannelSetup) -> &CosmosBuilder {
-        &setup.bootstrap_a.builder
+        &setup.bootstrap_a.cosmos_builder
     }
 }
 
 impl ProvideBuilderAt<CosmosBinaryChannelSetup, 1, 0> for CosmosBinaryChannelSetupComponents {
     fn builder(setup: &CosmosBinaryChannelSetup) -> &CosmosBuilder {
-        &setup.bootstrap_b.builder
+        &setup.bootstrap_b.cosmos_builder
     }
 }
 

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
@@ -1,5 +1,7 @@
 use alloc::sync::Arc;
 use cgp::core::component::UseContext;
+use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_cosmos_sdk_config::NoModifyCosmosSdkConfig;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifierComponent;
 use std::path::PathBuf;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
@@ -97,7 +99,10 @@ delegate_components! {
             CosmosGenesisConfigModifierComponent,
         ]:
             UseContext,
-        CompatModeGetterComponent: UseCompatMode37,
+        CompatModeGetterComponent:
+            UseCompatMode37,
+        CosmosSdkConfigModifierComponent:
+            NoModifyCosmosSdkConfig,
         RelayerChainConfigBuilderComponent:
             BuildRelayerChainConfig,
         ChainBuilderWithNodeConfigComponent:

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use cgp::core::component::UseContext;
 use std::path::PathBuf;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
@@ -7,13 +8,11 @@ use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::*;
 use hermes_cosmos_test_components::bootstrap::impls::generator::wallet_config::GenerateStandardWalletConfig;
 use hermes_cosmos_test_components::bootstrap::traits::chain::build_chain_driver::ChainDriverBuilderComponent;
-use hermes_cosmos_test_components::bootstrap::traits::fields::account_prefix::AccountPrefixGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::ChainCommandPathGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::ChainStoreDirGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::denom::{
-    DenomForStaking, DenomForTransfer, DenomPrefixGetter,
-};
-use hermes_cosmos_test_components::bootstrap::traits::fields::random_id::RandomIdFlagGetter;
+use hermes_cosmos_test_components::bootstrap::traits::fields::account_prefix::AccountPrefixGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::ChainCommandPathGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::ChainStoreDirGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::denom::DenomPrefixGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::random_id::RandomIdFlagGetterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::generator::generate_wallet_config::WalletConfigGeneratorComponent;
 use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifier;
 use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifier;
@@ -26,15 +25,14 @@ use hermes_runtime_components::traits::runtime::{
 };
 use hermes_test_components::chain_driver::traits::types::chain::ChainTypeComponent;
 use hermes_test_components::driver::traits::types::chain_driver::ChainDriverTypeComponent;
-use ibc_relayer::config::compat_mode::CompatMode;
 
 use crate::impls::bootstrap::build_cosmos_chain::BuildCosmosChainWithNodeConfig;
 use crate::impls::bootstrap::build_cosmos_chain_driver::BuildCosmosChainDriver;
 use crate::impls::bootstrap::relayer_chain_config::BuildRelayerChainConfig;
 use crate::impls::bootstrap::types::ProvideCosmosBootstrapChainTypes;
 use crate::traits::bootstrap::build_chain::ChainBuilderWithNodeConfigComponent;
-use crate::traits::bootstrap::compat_mode::CompatModeGetter;
-use crate::traits::bootstrap::cosmos_builder::CosmosBuilderGetter;
+use crate::traits::bootstrap::compat_mode::{CompatModeGetterComponent, UseCompatMode37};
+use crate::traits::bootstrap::cosmos_builder::CosmosBuilderGetterComponent;
 use crate::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 
 /**
@@ -44,13 +42,13 @@ use crate::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderCom
 #[derive(HasField)]
 pub struct CosmosBootstrap {
     pub runtime: HermesRuntime,
-    pub builder: Arc<CosmosBuilder>,
+    pub cosmos_builder: Arc<CosmosBuilder>,
     pub should_randomize_identifiers: bool,
     pub chain_store_dir: PathBuf,
     pub chain_command_path: PathBuf,
     pub account_prefix: String,
-    pub staking_denom: String,
-    pub transfer_denom: String,
+    pub staking_denom_prefix: String,
+    pub transfer_denom_prefix: String,
     pub genesis_config_modifier:
         Box<dyn Fn(&mut serde_json::Value) -> Result<(), Error> + Send + Sync + 'static>,
     pub comet_config_modifier:
@@ -88,30 +86,22 @@ delegate_components! {
             ChainDriverTypeComponent,
         ]:
             ProvideCosmosBootstrapChainTypes,
+        [
+            ChainStoreDirGetterComponent,
+            ChainCommandPathGetterComponent,
+            AccountPrefixGetterComponent,
+            DenomPrefixGetterComponent,
+            RandomIdFlagGetterComponent,
+            CosmosBuilderGetterComponent,
+        ]:
+            UseContext,
+        CompatModeGetterComponent: UseCompatMode37,
         RelayerChainConfigBuilderComponent:
             BuildRelayerChainConfig,
         ChainBuilderWithNodeConfigComponent:
             BuildCosmosChainWithNodeConfig,
         ChainDriverBuilderComponent:
             BuildCosmosChainDriver,
-    }
-}
-
-impl ChainStoreDirGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn chain_store_dir(bootstrap: &CosmosBootstrap) -> &PathBuf {
-        &bootstrap.chain_store_dir
-    }
-}
-
-impl ChainCommandPathGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn chain_command_path(bootstrap: &CosmosBootstrap) -> &PathBuf {
-        &bootstrap.chain_command_path
-    }
-}
-
-impl RandomIdFlagGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn should_randomize_identifiers(bootstrap: &CosmosBootstrap) -> bool {
-        bootstrap.should_randomize_identifiers
     }
 }
 
@@ -130,37 +120,5 @@ impl CometConfigModifier<CosmosBootstrap> for CosmosBootstrapComponents {
         comet_config: &mut toml::Value,
     ) -> Result<(), Error> {
         (bootstrap.comet_config_modifier)(comet_config)
-    }
-}
-
-impl DenomPrefixGetter<CosmosBootstrap, DenomForStaking> for CosmosBootstrapComponents {
-    fn denom_prefix(bootstrap: &CosmosBootstrap, _label: DenomForStaking) -> &str {
-        &bootstrap.staking_denom
-    }
-}
-
-impl DenomPrefixGetter<CosmosBootstrap, DenomForTransfer> for CosmosBootstrapComponents {
-    fn denom_prefix(bootstrap: &CosmosBootstrap, _label: DenomForTransfer) -> &str {
-        &bootstrap.transfer_denom
-    }
-}
-
-impl AccountPrefixGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn account_prefix(bootstrap: &CosmosBootstrap) -> &str {
-        &bootstrap.account_prefix
-    }
-}
-
-impl CompatModeGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn compat_mode(_bootstrap: &CosmosBootstrap) -> Option<&CompatMode> {
-        const COMPAT_MODE: CompatMode = CompatMode::V0_37;
-
-        Some(&COMPAT_MODE)
-    }
-}
-
-impl CosmosBuilderGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn cosmos_builder(bootstrap: &CosmosBootstrap) -> &CosmosBuilder {
-        &bootstrap.builder
     }
 }

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
@@ -35,7 +35,6 @@ use crate::impls::bootstrap::types::ProvideCosmosBootstrapChainTypes;
 use crate::traits::bootstrap::build_chain::ChainBuilderWithNodeConfigComponent;
 use crate::traits::bootstrap::compat_mode::CompatModeGetter;
 use crate::traits::bootstrap::cosmos_builder::CosmosBuilderGetter;
-use crate::traits::bootstrap::gas_denom::GasDenomGetter;
 use crate::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 
 /**
@@ -157,12 +156,6 @@ impl CompatModeGetter<CosmosBootstrap> for CosmosBootstrapComponents {
         const COMPAT_MODE: CompatMode = CompatMode::V0_37;
 
         Some(&COMPAT_MODE)
-    }
-}
-
-impl GasDenomGetter<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn gas_denom(bootstrap: &CosmosBootstrap) -> &str {
-        &bootstrap.staking_denom
     }
 }
 

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap.rs
@@ -14,8 +14,8 @@ use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::C
 use hermes_cosmos_test_components::bootstrap::traits::fields::denom::DenomPrefixGetterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::fields::random_id::RandomIdFlagGetterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::generator::generate_wallet_config::WalletConfigGeneratorComponent;
-use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifier;
-use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifier;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifierComponent;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifierComponent;
 use hermes_error::handlers::debug::DebugError;
 use hermes_error::impls::ProvideHermesError;
 use hermes_error::types::Error;
@@ -93,6 +93,8 @@ delegate_components! {
             DenomPrefixGetterComponent,
             RandomIdFlagGetterComponent,
             CosmosBuilderGetterComponent,
+            CometConfigModifierComponent,
+            CosmosGenesisConfigModifierComponent,
         ]:
             UseContext,
         CompatModeGetterComponent: UseCompatMode37,
@@ -102,23 +104,5 @@ delegate_components! {
             BuildCosmosChainWithNodeConfig,
         ChainDriverBuilderComponent:
             BuildCosmosChainDriver,
-    }
-}
-
-impl CosmosGenesisConfigModifier<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn modify_genesis_config(
-        bootstrap: &CosmosBootstrap,
-        config: &mut serde_json::Value,
-    ) -> Result<(), Error> {
-        (bootstrap.genesis_config_modifier)(config)
-    }
-}
-
-impl CometConfigModifier<CosmosBootstrap> for CosmosBootstrapComponents {
-    fn modify_comet_config(
-        bootstrap: &CosmosBootstrap,
-        comet_config: &mut toml::Value,
-    ) -> Result<(), Error> {
-        (bootstrap.comet_config_modifier)(comet_config)
     }
 }

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap_legacy.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap_legacy.rs
@@ -14,8 +14,8 @@ use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::C
 use hermes_cosmos_test_components::bootstrap::traits::fields::denom::DenomPrefixGetterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::fields::random_id::RandomIdFlagGetterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::generator::generate_wallet_config::WalletConfigGeneratorComponent;
-use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifier;
-use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifier;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifierComponent;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifierComponent;
 use hermes_error::handlers::debug::DebugError;
 use hermes_error::impls::ProvideHermesError;
 use hermes_error::types::Error;
@@ -32,7 +32,7 @@ use crate::impls::bootstrap::build_cosmos_chain_driver::BuildCosmosChainDriver;
 use crate::impls::bootstrap::relayer_chain_config::BuildRelayerChainConfig;
 use crate::impls::bootstrap::types::ProvideCosmosBootstrapChainTypes;
 use crate::traits::bootstrap::build_chain::ChainBuilderWithNodeConfigComponent;
-use crate::traits::bootstrap::compat_mode::CompatModeGetter;
+use crate::traits::bootstrap::compat_mode::CompatModeGetterComponent;
 use crate::traits::bootstrap::cosmos_builder::CosmosBuilderGetterComponent;
 use crate::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 
@@ -94,7 +94,10 @@ delegate_components! {
             AccountPrefixGetterComponent,
             DenomPrefixGetterComponent,
             RandomIdFlagGetterComponent,
+            CompatModeGetterComponent,
             CosmosBuilderGetterComponent,
+            CometConfigModifierComponent,
+            CosmosGenesisConfigModifierComponent,
         ]:
             UseContext,
         RelayerChainConfigBuilderComponent:
@@ -103,29 +106,5 @@ delegate_components! {
             BuildCosmosChainWithNodeConfig,
         ChainDriverBuilderComponent:
             BuildCosmosChainDriver,
-    }
-}
-
-impl CosmosGenesisConfigModifier<LegacyCosmosBootstrap> for LegacyCosmosBootstrapComponents {
-    fn modify_genesis_config(
-        bootstrap: &LegacyCosmosBootstrap,
-        config: &mut serde_json::Value,
-    ) -> Result<(), Error> {
-        (bootstrap.genesis_config_modifier)(config)
-    }
-}
-
-impl CometConfigModifier<LegacyCosmosBootstrap> for LegacyCosmosBootstrapComponents {
-    fn modify_comet_config(
-        bootstrap: &LegacyCosmosBootstrap,
-        comet_config: &mut toml::Value,
-    ) -> Result<(), Error> {
-        (bootstrap.comet_config_modifier)(comet_config)
-    }
-}
-
-impl CompatModeGetter<LegacyCosmosBootstrap> for LegacyCosmosBootstrapComponents {
-    fn compat_mode(bootstrap: &LegacyCosmosBootstrap) -> Option<&CompatMode> {
-        bootstrap.compat_mode.as_ref()
     }
 }

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap_legacy.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap_legacy.rs
@@ -1,5 +1,7 @@
 use alloc::sync::Arc;
 use cgp::core::component::UseContext;
+use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_cosmos_sdk_config::NoModifyCosmosSdkConfig;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifierComponent;
 use std::path::PathBuf;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
@@ -100,6 +102,8 @@ delegate_components! {
             CosmosGenesisConfigModifierComponent,
         ]:
             UseContext,
+        CosmosSdkConfigModifierComponent:
+            NoModifyCosmosSdkConfig,
         RelayerChainConfigBuilderComponent:
             BuildRelayerChainConfig,
         ChainBuilderWithNodeConfigComponent:

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap_legacy.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/bootstrap_legacy.rs
@@ -35,7 +35,6 @@ use crate::impls::bootstrap::types::ProvideCosmosBootstrapChainTypes;
 use crate::traits::bootstrap::build_chain::ChainBuilderWithNodeConfigComponent;
 use crate::traits::bootstrap::compat_mode::CompatModeGetter;
 use crate::traits::bootstrap::cosmos_builder::CosmosBuilderGetter;
-use crate::traits::bootstrap::gas_denom::GasDenomGetter;
 use crate::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 
 /**
@@ -158,12 +157,6 @@ impl AccountPrefixGetter<LegacyCosmosBootstrap> for LegacyCosmosBootstrapCompone
 impl CompatModeGetter<LegacyCosmosBootstrap> for LegacyCosmosBootstrapComponents {
     fn compat_mode(bootstrap: &LegacyCosmosBootstrap) -> Option<&CompatMode> {
         bootstrap.compat_mode.as_ref()
-    }
-}
-
-impl GasDenomGetter<LegacyCosmosBootstrap> for LegacyCosmosBootstrapComponents {
-    fn gas_denom(bootstrap: &LegacyCosmosBootstrap) -> &str {
-        &bootstrap.staking_denom
     }
 }
 

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
@@ -28,10 +28,14 @@ where
     async fn build_chain_with_node_config(
         bootstrap: &Bootstrap,
         chain_node_config: &Bootstrap::ChainNodeConfig,
+        chain_genesis_config: &Bootstrap::ChainGenesisConfig,
         relayer_wallet: &CosmosTestWallet,
     ) -> Result<CosmosChain, Bootstrap::Error> {
-        let relayer_chain_config =
-            bootstrap.build_relayer_chain_config(chain_node_config, relayer_wallet)?;
+        let relayer_chain_config = bootstrap.build_relayer_chain_config(
+            chain_node_config,
+            chain_genesis_config,
+            relayer_wallet,
+        )?;
 
         // TODO: Have a more reliable way to wait for the bootstrapped full node to
         // start up. If we don't wait, the building of the chain would fail during

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain_driver.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain_driver.rs
@@ -83,7 +83,7 @@ where
             .clone();
 
         let chain = bootstrap
-            .build_chain_with_node_config(&chain_node_config, &relayer_wallet)
+            .build_chain_with_node_config(&chain_node_config, &genesis_config, &relayer_wallet)
             .await?;
 
         let chain_command_path = bootstrap.chain_command_path().clone();

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/relayer_chain_config.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/relayer_chain_config.rs
@@ -18,7 +18,6 @@ use ibc_relayer::keyring::Store;
 use tendermint_rpc::{Error as TendermintRpcError, Url, WebSocketClientUrl};
 
 use crate::traits::bootstrap::compat_mode::HasCompatMode;
-use crate::traits::bootstrap::gas_denom::HasGasDenom;
 use crate::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilder;
 
 pub struct BuildRelayerChainConfig;
@@ -27,7 +26,6 @@ impl<Bootstrap, Chain> RelayerChainConfigBuilder<Bootstrap> for BuildRelayerChai
 where
     Bootstrap: HasAccountPrefix
         + HasCompatMode
-        + HasGasDenom
         + HasChainNodeConfigType<ChainNodeConfig = CosmosChainNodeConfig>
         + HasChainGenesisConfigType<ChainGenesisConfig = CosmosGenesisConfig>
         + HasChainType<Chain = Chain>

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/relayer_chain_config.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/relayer_chain_config.rs
@@ -4,7 +4,9 @@ use core::time::Duration;
 use cgp::core::error::CanRaiseError;
 use hermes_cosmos_test_components::bootstrap::traits::fields::account_prefix::HasAccountPrefix;
 use hermes_cosmos_test_components::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;
+use hermes_cosmos_test_components::bootstrap::traits::types::genesis_config::HasChainGenesisConfigType;
 use hermes_cosmos_test_components::bootstrap::types::chain_node_config::CosmosChainNodeConfig;
+use hermes_cosmos_test_components::bootstrap::types::genesis_config::CosmosGenesisConfig;
 use hermes_cosmos_test_components::chain::types::wallet::CosmosTestWallet;
 use hermes_test_components::chain::traits::types::wallet::HasWalletType;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
@@ -27,6 +29,7 @@ where
         + HasCompatMode
         + HasGasDenom
         + HasChainNodeConfigType<ChainNodeConfig = CosmosChainNodeConfig>
+        + HasChainGenesisConfigType<ChainGenesisConfig = CosmosGenesisConfig>
         + HasChainType<Chain = Chain>
         + CanRaiseError<TendermintRpcError>,
     Chain: HasWalletType<Wallet = CosmosTestWallet>,

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/relayer_chain_config.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/relayer_chain_config.rs
@@ -37,6 +37,7 @@ where
     fn build_relayer_chain_config(
         bootstrap: &Bootstrap,
         chain_node_config: &CosmosChainNodeConfig,
+        chain_genesis_config: &CosmosGenesisConfig,
         relayer_wallet: &CosmosTestWallet,
     ) -> Result<CosmosSdkConfig, Bootstrap::Error> {
         let relayer_chain_config = CosmosSdkConfig {
@@ -77,7 +78,7 @@ where
             client_refresh_rate: config::default::client_refresh_rate(),
             ccv_consumer_chain: false,
             trust_threshold: Default::default(),
-            gas_price: config::GasPrice::new(1.0, bootstrap.gas_denom().into()),
+            gas_price: config::GasPrice::new(1.0, chain_genesis_config.staking_denom.to_string()),
             packet_filter: Default::default(),
             address_type: AddressType::Cosmos,
             memo_prefix: Default::default(),

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/build_chain.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/build_chain.rs
@@ -1,18 +1,20 @@
 use cgp::prelude::*;
 use hermes_cosmos_test_components::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;
+use hermes_cosmos_test_components::bootstrap::traits::types::genesis_config::HasChainGenesisConfigType;
 use hermes_test_components::chain::traits::types::wallet::{HasWalletType, WalletOf};
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
 
 #[derive_component(ChainBuilderWithNodeConfigComponent, ChainBuilderWithNodeConfig<Bootstrap>)]
 #[async_trait]
 pub trait CanBuildChainWithNodeConfig:
-    HasChainType + HasChainNodeConfigType + HasChainType + HasErrorType
+    HasChainType + HasChainNodeConfigType + HasChainGenesisConfigType + HasChainType + HasErrorType
 where
     Self::Chain: HasWalletType,
 {
     async fn build_chain_with_node_config(
         &self,
         chain_node_config: &Self::ChainNodeConfig,
+        chain_genesis_config: &Self::ChainGenesisConfig,
         relayer_wallet: &WalletOf<Self::Chain>,
     ) -> Result<Self::Chain, Self::Error>;
 }

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/compat_mode.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/compat_mode.rs
@@ -5,3 +5,20 @@ use ibc_relayer::config::compat_mode::CompatMode;
 pub trait HasCompatMode: Async {
     fn compat_mode(&self) -> Option<&CompatMode>;
 }
+
+pub struct UseCompatMode34;
+pub struct UseCompatMode37;
+
+impl<Bootstrap: Async> CompatModeGetter<Bootstrap> for UseCompatMode34 {
+    fn compat_mode(_bootstrap: &Bootstrap) -> Option<&CompatMode> {
+        const COMPAT_MODE: CompatMode = CompatMode::V0_34;
+        Some(&COMPAT_MODE)
+    }
+}
+
+impl<Bootstrap: Async> CompatModeGetter<Bootstrap> for UseCompatMode37 {
+    fn compat_mode(_bootstrap: &Bootstrap) -> Option<&CompatMode> {
+        const COMPAT_MODE: CompatMode = CompatMode::V0_37;
+        Some(&COMPAT_MODE)
+    }
+}

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/compat_mode.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/compat_mode.rs
@@ -1,9 +1,21 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use ibc_relayer::config::compat_mode::CompatMode;
 
 #[derive_component(CompatModeGetterComponent, CompatModeGetter<Bootstrap>)]
 pub trait HasCompatMode: Async {
     fn compat_mode(&self) -> Option<&CompatMode>;
+}
+
+impl<Bootstrap> CompatModeGetter<Bootstrap> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("compat_mode"), Field = Option<CompatMode>>,
+{
+    fn compat_mode(bootstrap: &Bootstrap) -> Option<&CompatMode> {
+        bootstrap.get_field(PhantomData).as_ref()
+    }
 }
 
 pub struct UseCompatMode34;

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/cosmos_builder.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/cosmos_builder.rs
@@ -1,7 +1,19 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
 
 #[derive_component(CosmosBuilderGetterComponent, CosmosBuilderGetter<Bootstrap>)]
 pub trait HasCosmosBuilder: Async {
     fn cosmos_builder(&self) -> &CosmosBuilder;
+}
+
+impl<Bootstrap> CosmosBuilderGetter<Bootstrap> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("cosmos_builder"), Field: AsRef<CosmosBuilder>>,
+{
+    fn cosmos_builder(bootstrap: &Bootstrap) -> &CosmosBuilder {
+        bootstrap.get_field(PhantomData).as_ref()
+    }
 }

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/gas_denom.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/gas_denom.rs
@@ -1,6 +1,0 @@
-use cgp::prelude::*;
-
-#[derive_component(GasDenomGetterComponent, GasDenomGetter<Bootstrap>)]
-pub trait HasGasDenom: Async {
-    fn gas_denom(&self) -> &str;
-}

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/mod.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/mod.rs
@@ -1,5 +1,4 @@
 pub mod build_chain;
 pub mod compat_mode;
 pub mod cosmos_builder;
-pub mod gas_denom;
 pub mod relayer_chain_config;

--- a/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/relayer_chain_config.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/traits/bootstrap/relayer_chain_config.rs
@@ -1,5 +1,6 @@
 use cgp::prelude::*;
 use hermes_cosmos_test_components::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;
+use hermes_cosmos_test_components::bootstrap::traits::types::genesis_config::HasChainGenesisConfigType;
 use hermes_test_components::chain::traits::types::wallet::{HasWalletType, WalletOf};
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
 use ibc_relayer::chain::cosmos::config::CosmosSdkConfig;
@@ -8,13 +9,15 @@ use ibc_relayer::chain::cosmos::config::CosmosSdkConfig;
    Capability for the bootstrap context to build a Hermes v1 relayer chain config.
 */
 #[derive_component(RelayerChainConfigBuilderComponent, RelayerChainConfigBuilder<Bootstrap>)]
-pub trait CanBuildRelayerChainConfig: HasChainNodeConfigType + HasChainType + HasErrorType
+pub trait CanBuildRelayerChainConfig:
+    HasChainNodeConfigType + HasChainGenesisConfigType + HasChainType + HasErrorType
 where
     Self::Chain: HasWalletType,
 {
     fn build_relayer_chain_config(
         &self,
         chain_node_config: &Self::ChainNodeConfig,
+        chain_genesis_config: &Self::ChainGenesisConfig,
         relayer_wallet: &WalletOf<Self::Chain>,
     ) -> Result<CosmosSdkConfig, Self::Error>;
 }

--- a/crates/cosmos/cosmos-integration-tests/tests/bootstrap.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/bootstrap.rs
@@ -15,13 +15,13 @@ fn test_cosmos_bootstrap() -> Result<(), Error> {
     // TODO: load parameters from environment variables
     let bootstrap = Arc::new(CosmosBootstrap {
         runtime: runtime.clone(),
-        builder,
+        cosmos_builder: builder,
         should_randomize_identifiers: true,
         chain_store_dir: "./test-data".into(),
         chain_command_path: "gaiad".into(),
         account_prefix: "cosmos".into(),
-        staking_denom: "stake".into(),
-        transfer_denom: "coin".into(),
+        staking_denom_prefix: "stake".into(),
+        transfer_denom_prefix: "coin".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     });

--- a/crates/cosmos/cosmos-integration-tests/tests/bootstrap_legacy.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/bootstrap_legacy.rs
@@ -19,14 +19,14 @@ fn test_cosmos_legacy_bootstrap() -> Result<(), Error> {
     // TODO: load parameters from environment variables
     let bootstrap = Arc::new(LegacyCosmosBootstrap {
         runtime: runtime.clone(),
-        builder,
+        cosmos_builder: builder,
         should_randomize_identifiers: true,
         chain_store_dir: "./test-data".into(),
         chain_command_path: gaia_bin.into(),
         account_prefix: "cosmos".into(),
         compat_mode: None,
-        staking_denom: "stake".into(),
-        transfer_denom: "coin".into(),
+        staking_denom_prefix: "stake".into(),
+        transfer_denom_prefix: "coin".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     });

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -23,13 +23,13 @@ fn cosmos_integration_tests() -> Result<(), Error> {
     // TODO: load parameters from environment variables
     let bootstrap = Arc::new(CosmosBootstrap {
         runtime: runtime.clone(),
-        builder,
+        cosmos_builder: builder,
         should_randomize_identifiers: true,
         chain_store_dir: "./test-data".into(),
         chain_command_path: "gaiad".into(),
         account_prefix: "cosmos".into(),
-        staking_denom: "stake".into(),
-        transfer_denom: "coin".into(),
+        staking_denom_prefix: "stake".into(),
+        transfer_denom_prefix: "coin".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     });

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk.rs
@@ -63,6 +63,7 @@ pub use crate::bootstrap::traits::initializers::init_chain_home_dir::ChainHomeDi
 pub use crate::bootstrap::traits::initializers::init_genesis_config::ChainGenesisConfigInitializerComponent;
 pub use crate::bootstrap::traits::initializers::init_wallet::WalletInitializerComponent;
 use crate::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifier;
+use crate::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifier;
 use crate::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifier;
 pub use crate::bootstrap::traits::types::chain_node_config::{
     ChainNodeConfigTypeComponent, ProvideChainNodeConfigType,
@@ -129,6 +130,7 @@ where
         + RandomIdFlagGetter<Bootstrap>
         + CosmosGenesisConfigModifier<Bootstrap>
         + CometConfigModifier<Bootstrap>
+        + CosmosSdkConfigModifier<Bootstrap>
         + WalletConfigGenerator<Bootstrap>
         + ChainDriverBuilder<Bootstrap>
         + ProvideWalletConfigType<Bootstrap>

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk_legacy.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/components/cosmos_sdk_legacy.rs
@@ -53,6 +53,7 @@ pub use crate::bootstrap::traits::initializers::init_chain_home_dir::ChainHomeDi
 pub use crate::bootstrap::traits::initializers::init_genesis_config::ChainGenesisConfigInitializerComponent;
 pub use crate::bootstrap::traits::initializers::init_wallet::WalletInitializerComponent;
 use crate::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifier;
+use crate::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifier;
 use crate::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifier;
 pub use crate::bootstrap::traits::types::chain_node_config::{
     ChainNodeConfigTypeComponent, ProvideChainNodeConfigType,
@@ -121,6 +122,7 @@ where
         + RandomIdFlagGetter<Bootstrap>
         + CosmosGenesisConfigModifier<Bootstrap>
         + CometConfigModifier<Bootstrap>
+        + CosmosSdkConfigModifier<Bootstrap>
         + WalletConfigGenerator<Bootstrap>
         + ChainDriverBuilder<Bootstrap>
         + ProvideWalletConfigType<Bootstrap>

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/impls/initializers/update_chain_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/impls/initializers/update_chain_config.rs
@@ -14,6 +14,7 @@ use toml::Value;
 
 use crate::bootstrap::traits::initializers::init_chain_config::ChainNodeConfigInitializer;
 use crate::bootstrap::traits::modifiers::modify_comet_config::CanModifyCometConfig;
+use crate::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CanModifyCosmosSdkConfig;
 use crate::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;
 use crate::bootstrap::traits::types::genesis_config::HasChainGenesisConfigType;
 use crate::bootstrap::types::chain_node_config::CosmosChainNodeConfig;
@@ -30,6 +31,7 @@ where
         + HasChainNodeConfigType
         + HasChainGenesisConfigType<ChainGenesisConfig = CosmosGenesisConfig>
         + CanModifyCometConfig
+        + CanModifyCosmosSdkConfig
         + CanRaiseError<Runtime::Error>
         + CanRaiseError<&'static str>
         + CanRaiseError<toml::de::Error>
@@ -139,6 +141,8 @@ where
             set_grpc_port(&mut sdk_config, grpc_port).map_err(Bootstrap::raise_error)?;
             disable_grpc_web(&mut sdk_config).map_err(Bootstrap::raise_error)?;
             disable_api(&mut sdk_config).map_err(Bootstrap::raise_error)?;
+
+            bootstrap.modify_cosmos_sdk_config(&mut sdk_config)?;
 
             let sdk_config_string =
                 toml::to_string_pretty(&sdk_config).map_err(Bootstrap::raise_error)?;

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/impls/modifiers/mod.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/impls/modifiers/mod.rs
@@ -1,2 +1,3 @@
 pub mod no_modify_comet_config;
+pub mod no_modify_cosmos_sdk_config;
 pub mod no_modify_genesis_config;

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/impls/modifiers/no_modify_cosmos_sdk_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/impls/modifiers/no_modify_cosmos_sdk_config.rs
@@ -1,0 +1,18 @@
+use cgp::core::error::HasErrorType;
+use toml::Value;
+
+use crate::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifier;
+
+pub struct NoModifyCosmosSdkConfig;
+
+impl<Bootstrap> CosmosSdkConfigModifier<Bootstrap> for NoModifyCosmosSdkConfig
+where
+    Bootstrap: HasErrorType,
+{
+    fn modify_cosmos_sdk_config(
+        _bootstrap: &Bootstrap,
+        _cosmos_sdk_config: &mut Value,
+    ) -> Result<(), Bootstrap::Error> {
+        Ok(())
+    }
+}

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/account_prefix.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/account_prefix.rs
@@ -1,6 +1,18 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 
 #[derive_component(AccountPrefixGetterComponent, AccountPrefixGetter<Bootstrap>)]
 pub trait HasAccountPrefix: Async {
     fn account_prefix(&self) -> &str;
+}
+
+impl<Bootstrap> AccountPrefixGetter<Bootstrap> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("account_prefix"), Field = String>,
+{
+    fn account_prefix(bootstrap: &Bootstrap) -> &str {
+        bootstrap.get_field(PhantomData)
+    }
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_command_path.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_command_path.rs
@@ -1,11 +1,25 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use hermes_runtime_components::traits::fs::file_path::{FilePathOf, HasFilePathType};
 use hermes_runtime_components::traits::runtime::HasRuntime;
 
-#[derive_component(ChainCommandPathComponent, ChainCommandPathGetter<Bootstrap>)]
+#[derive_component(ChainCommandPathGetterComponent, ChainCommandPathGetter<Bootstrap>)]
 pub trait HasChainCommandPath: HasRuntime
 where
     Self::Runtime: HasFilePathType,
 {
     fn chain_command_path(&self) -> &FilePathOf<Self::Runtime>;
+}
+
+impl<Bootstrap, Runtime> ChainCommandPathGetter<Bootstrap> for UseContext
+where
+    Bootstrap: HasRuntime<Runtime = Runtime>
+        + HasField<symbol!("chain_command_path"), Field = Runtime::FilePath>,
+    Runtime: HasFilePathType,
+{
+    fn chain_command_path(bootstrap: &Bootstrap) -> &Runtime::FilePath {
+        bootstrap.get_field(PhantomData)
+    }
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_store_dir.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/chain_store_dir.rs
@@ -1,11 +1,22 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use hermes_runtime_components::traits::fs::file_path::{FilePathOf, HasFilePathType};
 use hermes_runtime_components::traits::runtime::HasRuntime;
 
 #[derive_component(ChainStoreDirGetterComponent, ChainStoreDirGetter<Bootstrap>)]
-pub trait HasChainStoreDir: HasRuntime
-where
-    Self::Runtime: HasFilePathType,
-{
+pub trait HasChainStoreDir: HasRuntime<Runtime: HasFilePathType> {
     fn chain_store_dir(&self) -> &FilePathOf<Self::Runtime>;
+}
+
+impl<Bootstrap, Runtime> ChainStoreDirGetter<Bootstrap> for UseContext
+where
+    Bootstrap: HasRuntime<Runtime = Runtime>
+        + HasField<symbol!("chain_store_dir"), Field = Runtime::FilePath>,
+    Runtime: HasFilePathType,
+{
+    fn chain_store_dir(bootstrap: &Bootstrap) -> &Runtime::FilePath {
+        bootstrap.get_field(PhantomData)
+    }
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/denom.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/denom.rs
@@ -1,3 +1,6 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::denom::{DenomOf, HasDenomType};
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
@@ -22,4 +25,22 @@ where
 #[derive_component(DenomPrefixGetterComponent, DenomPrefixGetter<Bootstrap>)]
 pub trait HasDenomPrefix<Label>: Async {
     fn denom_prefix(&self, label: Label) -> &str;
+}
+
+impl<Bootstrap> DenomPrefixGetter<Bootstrap, DenomForStaking> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("staking_denom_prefix"), Field = String>,
+{
+    fn denom_prefix(bootstrap: &Bootstrap, _label: DenomForStaking) -> &str {
+        bootstrap.get_field(PhantomData)
+    }
+}
+
+impl<Bootstrap> DenomPrefixGetter<Bootstrap, DenomForTransfer> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("transfer_denom_prefix"), Field = String>,
+{
+    fn denom_prefix(bootstrap: &Bootstrap, _label: DenomForTransfer) -> &str {
+        bootstrap.get_field(PhantomData)
+    }
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/random_id.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/random_id.rs
@@ -8,6 +8,17 @@ pub trait HasRandomIdFlag: Async {
     fn should_randomize_identifiers(&self) -> bool;
 }
 
+pub struct ReturnRandomIdFlag<const FLAG: bool>;
+
+impl<Bootstrap, const FLAG: bool> RandomIdFlagGetter<Bootstrap> for ReturnRandomIdFlag<FLAG>
+where
+    Bootstrap: Async,
+{
+    fn should_randomize_identifiers(_bootstrap: &Bootstrap) -> bool {
+        FLAG
+    }
+}
+
 impl<Bootstrap> RandomIdFlagGetter<Bootstrap> for UseContext
 where
     Bootstrap: Async + HasField<symbol!("should_randomize_identifiers"), Field = bool>,

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/random_id.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/fields/random_id.rs
@@ -1,6 +1,18 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 
-#[derive_component(RandomIdFlagComponent, RandomIdFlagGetter<Bootstrap>)]
+#[derive_component(RandomIdFlagGetterComponent, RandomIdFlagGetter<Bootstrap>)]
 pub trait HasRandomIdFlag: Async {
     fn should_randomize_identifiers(&self) -> bool;
+}
+
+impl<Bootstrap> RandomIdFlagGetter<Bootstrap> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("should_randomize_identifiers"), Field = bool>,
+{
+    fn should_randomize_identifiers(bootstrap: &Bootstrap) -> bool {
+        *bootstrap.get_field(PhantomData)
+    }
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/mod.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/mod.rs
@@ -1,2 +1,3 @@
 pub mod modify_comet_config;
+pub mod modify_cosmos_sdk_config;
 pub mod modify_genesis_config;

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/modify_comet_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/modify_comet_config.rs
@@ -1,3 +1,6 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use toml::Value;
 
@@ -5,4 +8,17 @@ use toml::Value;
 #[async_trait]
 pub trait CanModifyCometConfig: HasErrorType {
     fn modify_comet_config(&self, comet_config: &mut Value) -> Result<(), Self::Error>;
+}
+
+impl<Bootstrap, Modifier> CometConfigModifier<Bootstrap> for UseContext
+where
+    Bootstrap: HasErrorType + HasField<symbol!("comet_config_modifier"), Field = Modifier>,
+    Modifier: Fn(&mut Value) -> Result<(), Bootstrap::Error> + Send + Sync + 'static,
+{
+    fn modify_comet_config(
+        bootstrap: &Bootstrap,
+        comet_config: &mut Value,
+    ) -> Result<(), Bootstrap::Error> {
+        bootstrap.get_field(PhantomData)(comet_config)
+    }
 }

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/modify_cosmos_sdk_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/modify_cosmos_sdk_config.rs
@@ -1,0 +1,24 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
+use cgp::prelude::*;
+use toml::Value;
+
+#[derive_component(CosmosSdkConfigModifierComponent, CosmosSdkConfigModifier<Bootstrap>)]
+#[async_trait]
+pub trait CanModifyCosmosSdkConfig: HasErrorType {
+    fn modify_cosmos_sdk_config(&self, cosmos_sdk_config: &mut Value) -> Result<(), Self::Error>;
+}
+
+impl<Bootstrap, Modifier> CosmosSdkConfigModifier<Bootstrap> for UseContext
+where
+    Bootstrap: HasErrorType + HasField<symbol!("cosmos_sdk_config_modifier"), Field = Modifier>,
+    Modifier: Fn(&mut Value) -> Result<(), Bootstrap::Error> + Send + Sync + 'static,
+{
+    fn modify_cosmos_sdk_config(
+        bootstrap: &Bootstrap,
+        cosmos_sdk_config: &mut Value,
+    ) -> Result<(), Bootstrap::Error> {
+        bootstrap.get_field(PhantomData)(cosmos_sdk_config)
+    }
+}

--- a/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/modify_genesis_config.rs
+++ b/crates/cosmos/cosmos-test-components/src/bootstrap/traits/modifiers/modify_genesis_config.rs
@@ -1,7 +1,23 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use serde_json::Value;
 
 #[derive_component(CosmosGenesisConfigModifierComponent, CosmosGenesisConfigModifier<Bootstrap>)]
 pub trait CanModifyCosmosGenesisConfig: HasErrorType {
-    fn modify_genesis_config(&self, config: &mut Value) -> Result<(), Self::Error>;
+    fn modify_genesis_config(&self, genesis_config: &mut Value) -> Result<(), Self::Error>;
+}
+
+impl<Bootstrap, Modifier> CosmosGenesisConfigModifier<Bootstrap> for UseContext
+where
+    Bootstrap: HasErrorType + HasField<symbol!("genesis_config_modifier"), Field = Modifier>,
+    Modifier: Fn(&mut Value) -> Result<(), Bootstrap::Error> + Send + Sync + 'static,
+{
+    fn modify_genesis_config(
+        bootstrap: &Bootstrap,
+        genesis_config: &mut Value,
+    ) -> Result<(), Bootstrap::Error> {
+        bootstrap.get_field(PhantomData)(genesis_config)
+    }
 }

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_bootstrap.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_bootstrap.rs
@@ -13,7 +13,6 @@ use hermes_cosmos_integration_tests::traits::bootstrap::compat_mode::{
     CompatModeGetterComponent, UseCompatMode37,
 };
 use hermes_cosmos_integration_tests::traits::bootstrap::cosmos_builder::CosmosBuilderGetterComponent;
-use hermes_cosmos_integration_tests::traits::bootstrap::gas_denom::GasDenomGetter;
 use hermes_cosmos_integration_tests::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::*;
@@ -114,11 +113,5 @@ delegate_components! {
             ModifyWasmGenesisConfig<NoModifyGenesisConfig>,
         CometConfigModifierComponent:
             ModifyWasmNodeConfig<NoModifyCometConfig>,
-    }
-}
-
-impl GasDenomGetter<CosmosWithWasmClientBootstrap> for CosmosWithWasmClientBootstrapComponents {
-    fn gas_denom(bootstrap: &CosmosWithWasmClientBootstrap) -> &str {
-        &bootstrap.staking_denom_prefix
     }
 }

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_bootstrap.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_bootstrap.rs
@@ -1,5 +1,7 @@
 use alloc::sync::Arc;
 use cgp::core::component::UseContext;
+use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_cosmos_sdk_config::NoModifyCosmosSdkConfig;
+use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_cosmos_sdk_config::CosmosSdkConfigModifierComponent;
 use std::path::PathBuf;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
@@ -102,7 +104,10 @@ delegate_components! {
             CosmosBuilderGetterComponent,
         ]:
             UseContext,
-        CompatModeGetterComponent: UseCompatMode37,
+        CompatModeGetterComponent:
+            UseCompatMode37,
+        CosmosSdkConfigModifierComponent:
+            NoModifyCosmosSdkConfig,
         RelayerChainConfigBuilderComponent:
             BuildRelayerChainConfig,
         ChainBuilderWithNodeConfigComponent:

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_bootstrap.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_bootstrap.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use cgp::core::component::UseContext;
 use std::path::PathBuf;
 
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
@@ -8,8 +9,10 @@ use hermes_cosmos_integration_tests::impls::bootstrap::build_cosmos_chain_driver
 use hermes_cosmos_integration_tests::impls::bootstrap::relayer_chain_config::BuildRelayerChainConfig;
 use hermes_cosmos_integration_tests::impls::bootstrap::types::ProvideCosmosBootstrapChainTypes;
 use hermes_cosmos_integration_tests::traits::bootstrap::build_chain::ChainBuilderWithNodeConfigComponent;
-use hermes_cosmos_integration_tests::traits::bootstrap::compat_mode::CompatModeGetter;
-use hermes_cosmos_integration_tests::traits::bootstrap::cosmos_builder::CosmosBuilderGetter;
+use hermes_cosmos_integration_tests::traits::bootstrap::compat_mode::{
+    CompatModeGetterComponent, UseCompatMode37,
+};
+use hermes_cosmos_integration_tests::traits::bootstrap::cosmos_builder::CosmosBuilderGetterComponent;
 use hermes_cosmos_integration_tests::traits::bootstrap::gas_denom::GasDenomGetter;
 use hermes_cosmos_integration_tests::traits::bootstrap::relayer_chain_config::RelayerChainConfigBuilderComponent;
 use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
@@ -18,13 +21,11 @@ use hermes_cosmos_test_components::bootstrap::impls::generator::wallet_config::G
 use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_comet_config::NoModifyCometConfig;
 use hermes_cosmos_test_components::bootstrap::impls::modifiers::no_modify_genesis_config::NoModifyGenesisConfig;
 use hermes_cosmos_test_components::bootstrap::traits::chain::build_chain_driver::ChainDriverBuilderComponent;
-use hermes_cosmos_test_components::bootstrap::traits::fields::account_prefix::AccountPrefixGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::ChainCommandPathGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::ChainStoreDirGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::denom::{
-    DenomForStaking, DenomForTransfer, DenomPrefixGetter,
-};
-use hermes_cosmos_test_components::bootstrap::traits::fields::random_id::RandomIdFlagGetter;
+use hermes_cosmos_test_components::bootstrap::traits::fields::account_prefix::AccountPrefixGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::ChainCommandPathGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::ChainStoreDirGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::denom::DenomPrefixGetterComponent;
+use hermes_cosmos_test_components::bootstrap::traits::fields::random_id::RandomIdFlagGetterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::generator::generate_wallet_config::WalletConfigGeneratorComponent;
 use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_comet_config::CometConfigModifierComponent;
 use hermes_cosmos_test_components::bootstrap::traits::modifiers::modify_genesis_config::CosmosGenesisConfigModifierComponent;
@@ -39,9 +40,8 @@ use hermes_test_components::driver::traits::types::chain_driver::ChainDriverType
 use hermes_wasm_test_components::impls::bootstrap::build_chain_driver::BuildChainDriverAndInitWasmClient;
 use hermes_wasm_test_components::impls::bootstrap::genesis_config::ModifyWasmGenesisConfig;
 use hermes_wasm_test_components::impls::bootstrap::node_config::ModifyWasmNodeConfig;
-use hermes_wasm_test_components::traits::bootstrap::client_byte_code::WasmClientByteCodeGetter;
-use hermes_wasm_test_components::traits::bootstrap::gov_authority::GovernanceProposalAuthorityGetter;
-use ibc_relayer::config::compat_mode::CompatMode;
+use hermes_wasm_test_components::traits::bootstrap::client_byte_code::WasmClientByteCodeGetterComponent;
+use hermes_wasm_test_components::traits::bootstrap::gov_authority::GovernanceProposalAuthorityGetterComponent;
 
 /**
    A bootstrap context for bootstrapping a new Cosmos chain, and builds
@@ -50,13 +50,13 @@ use ibc_relayer::config::compat_mode::CompatMode;
 #[derive(HasField)]
 pub struct CosmosWithWasmClientBootstrap {
     pub runtime: HermesRuntime,
-    pub builder: Arc<CosmosBuilder>,
+    pub cosmos_builder: Arc<CosmosBuilder>,
     pub should_randomize_identifiers: bool,
     pub chain_store_dir: PathBuf,
     pub chain_command_path: PathBuf,
     pub account_prefix: String,
-    pub staking_denom: String,
-    pub transfer_denom: String,
+    pub staking_denom_prefix: String,
+    pub transfer_denom_prefix: String,
     pub wasm_client_byte_code: Vec<u8>,
     pub governance_proposal_authority: String,
 }
@@ -92,6 +92,18 @@ delegate_components! {
             ChainDriverTypeComponent,
         ]:
             ProvideCosmosBootstrapChainTypes,
+        [
+            ChainStoreDirGetterComponent,
+            ChainCommandPathGetterComponent,
+            AccountPrefixGetterComponent,
+            DenomPrefixGetterComponent,
+            RandomIdFlagGetterComponent,
+            WasmClientByteCodeGetterComponent,
+            GovernanceProposalAuthorityGetterComponent,
+            CosmosBuilderGetterComponent,
+        ]:
+            UseContext,
+        CompatModeGetterComponent: UseCompatMode37,
         RelayerChainConfigBuilderComponent:
             BuildRelayerChainConfig,
         ChainBuilderWithNodeConfigComponent:
@@ -105,86 +117,8 @@ delegate_components! {
     }
 }
 
-impl ChainStoreDirGetter<CosmosWithWasmClientBootstrap>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn chain_store_dir(bootstrap: &CosmosWithWasmClientBootstrap) -> &PathBuf {
-        &bootstrap.chain_store_dir
-    }
-}
-
-impl ChainCommandPathGetter<CosmosWithWasmClientBootstrap>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn chain_command_path(bootstrap: &CosmosWithWasmClientBootstrap) -> &PathBuf {
-        &bootstrap.chain_command_path
-    }
-}
-
-impl RandomIdFlagGetter<CosmosWithWasmClientBootstrap> for CosmosWithWasmClientBootstrapComponents {
-    fn should_randomize_identifiers(bootstrap: &CosmosWithWasmClientBootstrap) -> bool {
-        bootstrap.should_randomize_identifiers
-    }
-}
-
-impl DenomPrefixGetter<CosmosWithWasmClientBootstrap, DenomForStaking>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn denom_prefix(bootstrap: &CosmosWithWasmClientBootstrap, _label: DenomForStaking) -> &str {
-        &bootstrap.staking_denom
-    }
-}
-
-impl DenomPrefixGetter<CosmosWithWasmClientBootstrap, DenomForTransfer>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn denom_prefix(bootstrap: &CosmosWithWasmClientBootstrap, _label: DenomForTransfer) -> &str {
-        &bootstrap.transfer_denom
-    }
-}
-
-impl AccountPrefixGetter<CosmosWithWasmClientBootstrap>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn account_prefix(bootstrap: &CosmosWithWasmClientBootstrap) -> &str {
-        &bootstrap.account_prefix
-    }
-}
-
-impl CompatModeGetter<CosmosWithWasmClientBootstrap> for CosmosWithWasmClientBootstrapComponents {
-    fn compat_mode(_bootstrap: &CosmosWithWasmClientBootstrap) -> Option<&CompatMode> {
-        const COMPAT_MODE: CompatMode = CompatMode::V0_37;
-
-        Some(&COMPAT_MODE)
-    }
-}
-
 impl GasDenomGetter<CosmosWithWasmClientBootstrap> for CosmosWithWasmClientBootstrapComponents {
     fn gas_denom(bootstrap: &CosmosWithWasmClientBootstrap) -> &str {
-        &bootstrap.staking_denom
-    }
-}
-
-impl CosmosBuilderGetter<CosmosWithWasmClientBootstrap>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn cosmos_builder(bootstrap: &CosmosWithWasmClientBootstrap) -> &CosmosBuilder {
-        &bootstrap.builder
-    }
-}
-
-impl WasmClientByteCodeGetter<CosmosWithWasmClientBootstrap>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn wasm_client_byte_code(bootstrap: &CosmosWithWasmClientBootstrap) -> &Vec<u8> {
-        &bootstrap.wasm_client_byte_code
-    }
-}
-
-impl GovernanceProposalAuthorityGetter<CosmosWithWasmClientBootstrap>
-    for CosmosWithWasmClientBootstrapComponents
-{
-    fn governance_proposal_authority(bootstrap: &CosmosWithWasmClientBootstrap) -> &String {
-        &bootstrap.governance_proposal_authority
+        &bootstrap.staking_denom_prefix
     }
 }

--- a/crates/cosmos/cosmos-wasm-relayer/tests/both_wasm_cosmos.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/tests/both_wasm_cosmos.rs
@@ -53,13 +53,13 @@ fn test_both_wasm_cosmos() -> Result<(), Error> {
 
         let bootstrap = Arc::new(CosmosWithWasmClientBootstrap {
             runtime: runtime.clone(),
-            builder: builder.clone(),
+            cosmos_builder: builder.clone(),
             should_randomize_identifiers: true,
             chain_store_dir: store_dir.join("chains"),
             chain_command_path: "simd".into(),
             account_prefix: "cosmos".into(),
-            staking_denom: "stake".into(),
-            transfer_denom: "coin".into(),
+            staking_denom_prefix: "stake".into(),
+            transfer_denom_prefix: "coin".into(),
             wasm_client_byte_code,
             governance_proposal_authority: "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn".into(), // TODO: don't hard code this
         });

--- a/crates/cosmos/cosmos-wasm-relayer/tests/cosmos_to_wasm_cosmos.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/tests/cosmos_to_wasm_cosmos.rs
@@ -45,13 +45,13 @@ fn test_cosmos_to_wasm_cosmos() -> Result<(), Error> {
 
     let gaia_bootstrap = Arc::new(CosmosBootstrap {
         runtime: runtime.clone(),
-        builder: builder.clone(),
+        cosmos_builder: builder.clone(),
         should_randomize_identifiers: true,
         chain_store_dir: store_dir.join("chains"),
         chain_command_path: "simd".into(),
         account_prefix: "cosmos".into(),
-        staking_denom: "stake".into(),
-        transfer_denom: "coin".into(),
+        staking_denom_prefix: "stake".into(),
+        transfer_denom_prefix: "coin".into(),
         genesis_config_modifier: Box::new(|_| Ok(())),
         comet_config_modifier: Box::new(|_| Ok(())),
     });

--- a/crates/cosmos/cosmos-wasm-relayer/tests/cosmos_to_wasm_cosmos.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/tests/cosmos_to_wasm_cosmos.rs
@@ -67,13 +67,13 @@ fn test_cosmos_to_wasm_cosmos() -> Result<(), Error> {
 
         let simd_bootstrap = Arc::new(CosmosWithWasmClientBootstrap {
             runtime: runtime.clone(),
-            builder: builder.clone(),
+            cosmos_builder: builder.clone(),
             should_randomize_identifiers: true,
             chain_store_dir: store_dir.join("chains"),
             chain_command_path: "simd".into(),
             account_prefix: "cosmos".into(),
-            staking_denom: "stake".into(),
-            transfer_denom: "coin".into(),
+            staking_denom_prefix: "stake".into(),
+            transfer_denom_prefix: "coin".into(),
             wasm_client_byte_code,
             governance_proposal_authority: "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn".into(), // TODO: don't hard code this
         });

--- a/crates/wasm/wasm-test-components/src/traits/bootstrap/client_byte_code.rs
+++ b/crates/wasm/wasm-test-components/src/traits/bootstrap/client_byte_code.rs
@@ -1,6 +1,18 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 
 #[derive_component(WasmClientByteCodeGetterComponent, WasmClientByteCodeGetter<Bootstrap>)]
 pub trait HasWasmClientByteCode {
     fn wasm_client_byte_code(&self) -> &Vec<u8>;
+}
+
+impl<Bootstrap> WasmClientByteCodeGetter<Bootstrap> for UseContext
+where
+    Bootstrap: Async + HasField<symbol!("wasm_client_byte_code"), Field = Vec<u8>>,
+{
+    fn wasm_client_byte_code(bootstrap: &Bootstrap) -> &Vec<u8> {
+        bootstrap.get_field(PhantomData)
+    }
 }

--- a/crates/wasm/wasm-test-components/src/traits/bootstrap/gov_authority.rs
+++ b/crates/wasm/wasm-test-components/src/traits/bootstrap/gov_authority.rs
@@ -1,3 +1,6 @@
+use core::marker::PhantomData;
+
+use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::address::{AddressOf, HasAddressType};
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
@@ -5,4 +8,15 @@ use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
 #[derive_component(GovernanceProposalAuthorityGetterComponent, GovernanceProposalAuthorityGetter<Bootstrap>)]
 pub trait HasGovernanceProposalAuthority: HasChainType<Chain: HasAddressType> {
     fn governance_proposal_authority(&self) -> &AddressOf<Self::Chain>;
+}
+
+impl<Bootstrap, Chain> GovernanceProposalAuthorityGetter<Bootstrap> for UseContext
+where
+    Bootstrap: HasChainType<Chain = Chain>
+        + HasField<symbol!("governance_proposal_authority"), Field = Chain::Address>,
+    Chain: HasAddressType,
+{
+    fn governance_proposal_authority(bootstrap: &Bootstrap) -> &Chain::Address {
+        bootstrap.get_field(PhantomData)
+    }
 }


### PR DESCRIPTION
- Introduce `CosmosSdkConfigModifier` trait, which Cosmos bootstrap contexts now required to implement.
- Implement `UseContext` for various accessor traits for the bootstrap context.
- Pass `Bootstrap::ChainGenesisConfig` to `build_chain_with_node_config` and `build_relayer_chain_config`.
- Rename fields in Cosmos bootstrap contexts.