### PR TITLE
Increase wait timeout to allow Osmosis to start up

### DIFF
--- a/crates/test/test-components/src/chain_driver/impls/wait.rs
+++ b/crates/test/test-components/src/chain_driver/impls/wait.rs
@@ -21,7 +21,7 @@ where
         let runtime = chain_driver.runtime();
         let chain = chain_driver.chain();
 
-        for _ in 0..10 {
+        for _ in 0..30 {
             if let Ok(height) = chain.query_chain_height().await {
                 if Chain::revision_height(&height) >= H {
                     return Ok(());
@@ -32,7 +32,7 @@ where
         }
 
         Err(ChainDriver::raise_error(
-            "chain did not progress to target height within 5 seconds",
+            "chain did not progress to target height within 15 seconds",
         ))
     }
 }


### PR DESCRIPTION
It turns out that Osmosis can take anywhere between 5~10 seconds to fully start up a chain full node, even in a fresh local environment.