### PR TITLE
Fix relay context selector

### DIFF
--- a/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
@@ -143,9 +143,9 @@ delegate_components! {
             UseField<symbol!("chain_a")>,
         ChainGetterAtComponent<Index<1>>:
             UseField<symbol!("chain_b")>,
-        ClientIdAtGetterComponent<Src, Dst>:
+        ClientIdAtGetterComponent<Index<0>, Index<1>>:
             UseField<symbol!("client_id_a")>,
-        ClientIdAtGetterComponent<Dst, Src>:
+        ClientIdAtGetterComponent<Index<1>, Index<0>>:
             UseField<symbol!("client_id_b")>,
         PacketMutexGetterComponent:
             UseField<symbol!("packet_lock_mutex")>,
@@ -158,6 +158,8 @@ delegate_components! {
             ChainTypeAtComponent<Dst>,
             ChainGetterAtComponent<Src>,
             ChainGetterAtComponent<Dst>,
+            ClientIdAtGetterComponent<Src, Dst>,
+            ClientIdAtGetterComponent<Dst, Src>,
             MessageBatchSenderGetterComponent<Src>,
             MessageBatchSenderGetterComponent<Dst>,
         ]:

--- a/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
@@ -11,10 +11,7 @@ use hermes_logger::ProvideHermesLogger;
 use hermes_logging_components::traits::has_logger::{
     GlobalLoggerGetterComponent, LoggerGetterComponent, LoggerTypeComponent,
 };
-use hermes_relayer_components::error::impls::retry::ReturnMaxRetry;
-use hermes_relayer_components::error::traits::retry::{
-    MaxErrorRetryGetterComponent, RetryableErrorComponent,
-};
+use hermes_relayer_components::error::traits::retry::RetryableErrorComponent;
 use hermes_relayer_components::multi::traits::chain_at::{
     ChainAt, ChainGetterAtComponent, ChainTypeAtComponent,
 };
@@ -23,13 +20,12 @@ use hermes_relayer_components::multi::traits::relay_at::ClientIdAt;
 use hermes_relayer_components::multi::types::index::Index;
 use hermes_relayer_components::multi::types::tags::{Dst, Src};
 use hermes_relayer_components::relay::impls::packet_lock::{
-    PacketMutexGetterComponent, PacketMutexOf, ProvidePacketLockWithMutex,
+    PacketMutexGetterComponent, PacketMutexOf,
 };
 use hermes_relayer_components::relay::impls::selector::SelectRelayAToB;
 use hermes_relayer_components::relay::traits::auto_relayer::CanAutoRelay;
 use hermes_relayer_components::relay::traits::chains::HasRelayClientIds;
 use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
-use hermes_relayer_components::relay::traits::packet_lock::PacketLockComponent;
 use hermes_relayer_components::relay::traits::target::{
     DestinationTarget, HasDestinationTargetChainTypes, HasSourceTargetChainTypes, SourceTarget,
 };
@@ -135,10 +131,6 @@ delegate_components! {
             GlobalLoggerGetterComponent,
         ]:
             ProvideHermesLogger,
-        MaxErrorRetryGetterComponent:
-            ReturnMaxRetry<3>,
-        PacketLockComponent:
-            ProvidePacketLockWithMutex,
         ChainGetterAtComponent<Index<0>>:
             UseField<symbol!("chain_a")>,
         ChainGetterAtComponent<Index<1>>:

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_to_wasm_cosmos_relay.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/cosmos_to_wasm_cosmos_relay.rs
@@ -18,7 +18,6 @@ use hermes_logging_components::traits::logger::CanLog;
 use hermes_relayer_components::chain::traits::types::channel::HasInitChannelOptionsType;
 use hermes_relayer_components::chain::traits::types::connection::HasInitConnectionOptionsType;
 use hermes_relayer_components::components::default::relay::*;
-use hermes_relayer_components::error::impls::retry::ReturnMaxRetry;
 use hermes_relayer_components::error::traits::retry::{
     MaxErrorRetryGetterComponent, RetryableErrorComponent,
 };
@@ -29,9 +28,7 @@ use hermes_relayer_components::multi::traits::client_id_at::ClientIdAtGetterComp
 use hermes_relayer_components::multi::types::tags::{Dst, Src};
 use hermes_relayer_components::relay::impls::channel::bootstrap::CanBootstrapChannel;
 use hermes_relayer_components::relay::impls::connection::bootstrap::CanBootstrapConnection;
-use hermes_relayer_components::relay::impls::packet_lock::{
-    PacketMutexGetterComponent, ProvidePacketLockWithMutex,
-};
+use hermes_relayer_components::relay::impls::packet_lock::PacketMutexGetterComponent;
 use hermes_relayer_components::relay::impls::packet_relayers::general::lock::LogSkipRelayLockedPacket;
 use hermes_relayer_components::relay::traits::packet_filter::RelayPacketFilterComponent;
 use hermes_relayer_components::relay::traits::packet_lock::PacketLockComponent;
@@ -109,10 +106,6 @@ delegate_components! {
             UseField<symbol!("dst_client_id")>,
         PacketMutexGetterComponent:
             UseField<symbol!("packet_lock_mutex")>,
-        MaxErrorRetryGetterComponent:
-            ReturnMaxRetry<3>,
-        PacketLockComponent:
-            ProvidePacketLockWithMutex,
     }
 }
 

--- a/crates/cosmos/cosmos-wasm-relayer/src/context/wasm_cosmos_relay.rs
+++ b/crates/cosmos/cosmos-wasm-relayer/src/context/wasm_cosmos_relay.rs
@@ -17,7 +17,6 @@ use hermes_logging_components::traits::logger::CanLog;
 use hermes_relayer_components::chain::traits::types::channel::HasInitChannelOptionsType;
 use hermes_relayer_components::chain::traits::types::connection::HasInitConnectionOptionsType;
 use hermes_relayer_components::components::default::relay::*;
-use hermes_relayer_components::error::impls::retry::ReturnMaxRetry;
 use hermes_relayer_components::error::traits::retry::{
     MaxErrorRetryGetterComponent, RetryableErrorComponent,
 };
@@ -28,9 +27,7 @@ use hermes_relayer_components::multi::traits::client_id_at::ClientIdAtGetterComp
 use hermes_relayer_components::multi::types::tags::{Dst, Src};
 use hermes_relayer_components::relay::impls::channel::bootstrap::CanBootstrapChannel;
 use hermes_relayer_components::relay::impls::connection::bootstrap::CanBootstrapConnection;
-use hermes_relayer_components::relay::impls::packet_lock::{
-    PacketMutexGetterComponent, ProvidePacketLockWithMutex,
-};
+use hermes_relayer_components::relay::impls::packet_lock::PacketMutexGetterComponent;
 use hermes_relayer_components::relay::impls::packet_relayers::general::lock::LogSkipRelayLockedPacket;
 use hermes_relayer_components::relay::traits::packet_filter::RelayPacketFilterComponent;
 use hermes_relayer_components::relay::traits::packet_lock::PacketLockComponent;
@@ -108,10 +105,6 @@ delegate_components! {
             UseField<symbol!("dst_client_id")>,
         PacketMutexGetterComponent:
             UseField<symbol!("packet_lock_mutex")>,
-        MaxErrorRetryGetterComponent:
-            ReturnMaxRetry<3>,
-        PacketLockComponent:
-            ProvidePacketLockWithMutex,
     }
 }
 

--- a/crates/relayer/relayer-components/src/components/default/relay.rs
+++ b/crates/relayer/relayer-components/src/components/default/relay.rs
@@ -1,6 +1,8 @@
 pub use cgp::extra::run::RunnerComponent;
 use cgp::prelude::*;
 
+use crate::error::impls::retry::ReturnMaxRetry;
+pub use crate::error::traits::retry::MaxErrorRetryGetterComponent;
 use crate::relay::impls::auto_relayers::both_targets::RelayBothTargets;
 use crate::relay::impls::auto_relayers::event::RelayEvents;
 use crate::relay::impls::channel::open_ack::RelayChannelOpenAck;
@@ -19,6 +21,7 @@ use crate::relay::impls::message_senders::chain_sender::SendIbcMessagesToChain;
 use crate::relay::impls::message_senders::update_client::SendIbcMessagesWithUpdateClient;
 use crate::relay::impls::packet_clearers::packets::ClearAllPackets;
 use crate::relay::impls::packet_filters::chain::FilterRelayPacketWithChains;
+use crate::relay::impls::packet_lock::ProvidePacketLockWithMutex;
 use crate::relay::impls::packet_relayers::ack::base_ack_packet::BaseAckPacketRelayer;
 use crate::relay::impls::packet_relayers::general::default::DefaultPacketRelayer;
 use crate::relay::impls::packet_relayers::receive::base_receive_packet::BaseReceivePacketRelayer;
@@ -41,6 +44,7 @@ pub use crate::relay::traits::event_relayer::EventRelayerComponent;
 pub use crate::relay::traits::ibc_message_sender::{IbcMessageSenderComponent, MainSink};
 pub use crate::relay::traits::packet_clearer::PacketClearerComponent;
 pub use crate::relay::traits::packet_filter::RelayPacketFilterComponent;
+pub use crate::relay::traits::packet_lock::PacketLockComponent;
 pub use crate::relay::traits::packet_relayer::PacketRelayerComponent;
 pub use crate::relay::traits::packet_relayers::ack_packet::AckPacketRelayerComponent;
 pub use crate::relay::traits::packet_relayers::receive_packet::ReceivePacketRelayerComponent;
@@ -71,5 +75,7 @@ cgp_preset! {
         ConnectionOpenTryRelayerComponent: RelayConnectionOpenTry,
         ConnectionOpenHandshakeRelayerComponent: RelayConnectionOpenHandshake,
         RelayPacketFilterComponent: FilterRelayPacketWithChains,
+        MaxErrorRetryGetterComponent: ReturnMaxRetry<3>,
+        PacketLockComponent: ProvidePacketLockWithMutex,
     }
 }

--- a/crates/relayer/relayer-components/src/relay/impls/selector.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/selector.rs
@@ -3,6 +3,8 @@ use core::marker::PhantomData;
 use crate::multi::traits::chain_at::{
     ChainGetterAt, HasChainAt, HasChainTypeAt, ProvideChainTypeAt,
 };
+use crate::multi::traits::client_id_at::{ClientIdAtGetter, HasClientIdAt};
+use crate::multi::traits::relay_at::ClientIdAt;
 use crate::multi::types::index::Index;
 use crate::multi::types::tags::{Dst, Src};
 
@@ -39,6 +41,35 @@ where
         relay.chain_at(PhantomData::<DstTag>)
     }
 }
+
+impl<Relay, SrcTag, DstTag, SrcChain, DstChain> ClientIdAtGetter<Relay, Src, Dst>
+    for SelectRelayChains<SrcTag, DstTag>
+where
+    Relay: HasChainAt<SrcTag, Chain = SrcChain>
+        + HasChainTypeAt<Src, Chain = SrcChain>
+        + HasChainAt<DstTag, Chain = DstChain>
+        + HasChainTypeAt<Dst, Chain = DstChain>
+        + HasClientIdAt<SrcTag, DstTag>,
+{
+    fn client_id_at(relay: &Relay, _tag: PhantomData<(Src, Dst)>) -> &ClientIdAt<Relay, Src, Dst> {
+        relay.client_id_at(PhantomData::<(SrcTag, DstTag)>)
+    }
+}
+
+impl<Relay, SrcTag, DstTag, SrcChain, DstChain> ClientIdAtGetter<Relay, Dst, Src>
+    for SelectRelayChains<SrcTag, DstTag>
+where
+    Relay: HasChainAt<SrcTag, Chain = SrcChain>
+        + HasChainTypeAt<Src, Chain = SrcChain>
+        + HasChainAt<DstTag, Chain = DstChain>
+        + HasChainTypeAt<Dst, Chain = DstChain>
+        + HasClientIdAt<DstTag, SrcTag>,
+{
+    fn client_id_at(relay: &Relay, _tag: PhantomData<(Dst, Src)>) -> &ClientIdAt<Relay, Dst, Src> {
+        relay.client_id_at(PhantomData::<(DstTag, SrcTag)>)
+    }
+}
+
 pub type SelectRelayAToB = SelectRelayChains<Index<0>, Index<1>>;
 
 pub type SelectRelayBToA = SelectRelayChains<Index<1>, Index<0>>;


### PR DESCRIPTION
- Implement `ClientIdAtGetter` for `SelectRelayChains`, as missed in #498.
- Add `MaxErrorRetryGetterComponent` and `PacketLockComponent` to DefaultRelayPreset

