### PR TITLE
Allow packet clearing to be done through event relayer

### DIFF
--- a/crates/chain/chain-components/src/impls/queries/block_events.rs
+++ b/crates/chain/chain-components/src/impls/queries/block_events.rs
@@ -1,0 +1,71 @@
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::time::Duration;
+
+use cgp::prelude::*;
+use hermes_chain_type_components::traits::types::event::HasEventType;
+use hermes_chain_type_components::traits::types::height::HasHeightType;
+use hermes_runtime_components::traits::runtime::HasRuntime;
+use hermes_runtime_components::traits::sleep::CanSleep;
+
+use crate::traits::queries::block_events::{BlockEventsQuerier, BlockEventsQuerierComponent};
+use crate::traits::queries::chain_status::CanQueryChainHeight;
+
+pub struct WaitBlockHeightAndQueryEvents<InQuerier>(pub PhantomData<InQuerier>);
+
+#[cgp_provider(BlockEventsQuerierComponent)]
+impl<Chain, InQuerier> BlockEventsQuerier<Chain> for WaitBlockHeightAndQueryEvents<InQuerier>
+where
+    Chain: HasRuntime + HasEventType + CanQueryChainHeight,
+    InQuerier: BlockEventsQuerier<Chain>,
+    Chain::Runtime: CanSleep,
+{
+    async fn query_block_events(
+        chain: &Chain,
+        height: &Chain::Height,
+    ) -> Result<Vec<Chain::Event>, Chain::Error> {
+        let runtime = chain.runtime();
+
+        loop {
+            let current_height = chain.query_chain_height().await?;
+            if &current_height >= height {
+                break;
+            } else {
+                runtime.sleep(Duration::from_millis(200)).await;
+            }
+        }
+
+        InQuerier::query_block_events(chain, height).await
+    }
+}
+
+pub struct RetryQueryBlockEvents<const MAX_RETRIES: usize, InQuerier>(pub PhantomData<InQuerier>);
+
+#[cgp_provider(BlockEventsQuerierComponent)]
+impl<Chain, InQuerier, const MAX_RETRIES: usize> BlockEventsQuerier<Chain>
+    for RetryQueryBlockEvents<MAX_RETRIES, InQuerier>
+where
+    Chain: HasRuntime + HasHeightType + HasEventType + HasAsyncErrorType,
+    InQuerier: BlockEventsQuerier<Chain>,
+    Chain::Runtime: CanSleep,
+{
+    async fn query_block_events(
+        chain: &Chain,
+        height: &Chain::Height,
+    ) -> Result<Vec<Chain::Event>, Chain::Error> {
+        let runtime = chain.runtime();
+        let mut sleep_time = Duration::from_millis(500);
+
+        for _ in 0..MAX_RETRIES {
+            let res = InQuerier::query_block_events(chain, height).await;
+            if let Ok(events) = res {
+                return Ok(events);
+            }
+
+            runtime.sleep(sleep_time).await;
+            sleep_time *= 2;
+        }
+
+        InQuerier::query_block_events(chain, height).await
+    }
+}

--- a/crates/chain/chain-components/src/impls/queries/mod.rs
+++ b/crates/chain/chain-components/src/impls/queries/mod.rs
@@ -1,3 +1,4 @@
+pub mod block_events;
 pub mod consensus_state_height;
 pub mod consensus_state_heights;
 pub mod query_and_convert_client_state;

--- a/crates/chain/chain-components/src/traits/queries/ack_packets.rs
+++ b/crates/chain/chain-components/src/traits/queries/ack_packets.rs
@@ -36,10 +36,6 @@ where
         counterparty_channel_id: &Self::ChannelId,
         counterparty_port_id: &Self::PortId,
         sequences: &[Counterparty::Sequence],
-        // The height is given to query the packets from a specific height.
-        // This height should be the same as the query height from the
-        // `CanQueryPacketAcknowledgements` made on the same chain.
-        height: &Self::Height,
     ) -> Result<
         Vec<(
             Counterparty::OutgoingPacket,
@@ -75,7 +71,6 @@ where
         counterparty_channel_id: &Self::ChannelId,
         counterparty_port_id: &Self::PortId,
         sequence: &Counterparty::Sequence,
-        height: &Self::Height,
     ) -> Result<
         (
             Counterparty::OutgoingPacket,

--- a/crates/chain/chain-components/src/traits/queries/block_events.rs
+++ b/crates/chain/chain-components/src/traits/queries/block_events.rs
@@ -1,0 +1,17 @@
+use alloc::vec::Vec;
+
+use cgp::prelude::*;
+use hermes_chain_type_components::traits::types::event::HasEventType;
+use hermes_chain_type_components::traits::types::height::HasHeightType;
+
+#[cgp_component {
+    provider: BlockEventsQuerier,
+    context: Chain,
+}]
+#[async_trait]
+pub trait CanQueryBlockEvents: HasHeightType + HasEventType + HasAsyncErrorType {
+    async fn query_block_events(
+        &self,
+        height: &Self::Height,
+    ) -> Result<Vec<Self::Event>, Self::Error>;
+}

--- a/crates/chain/chain-components/src/traits/queries/mod.rs
+++ b/crates/chain/chain-components/src/traits/queries/mod.rs
@@ -1,5 +1,6 @@
 pub mod ack_packets;
 pub mod block;
+pub mod block_events;
 pub mod chain_status;
 pub mod channel_end;
 pub mod client_state;

--- a/crates/chain/chain-components/src/traits/queries/packet_acknowledgements.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_acknowledgements.rs
@@ -25,5 +25,5 @@ where
         channel_id: &Self::ChannelId,
         port_id: &Self::PortId,
         sequences: &[Counterparty::Sequence],
-    ) -> Result<Option<(Vec<Counterparty::Sequence>, Self::Height)>, Self::Error>;
+    ) -> Result<Option<Vec<Counterparty::Sequence>>, Self::Error>;
 }

--- a/crates/chain/chain-components/src/traits/queries/packet_acknowledgements.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_acknowledgements.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 
 use cgp::prelude::*;
-use hermes_chain_type_components::traits::types::height::HasHeightType;
 use hermes_chain_type_components::traits::types::ibc::channel_id::HasChannelIdType;
 use hermes_chain_type_components::traits::types::ibc::port_id::HasPortIdType;
 use hermes_chain_type_components::traits::types::ibc::sequence::HasSequenceType;
@@ -12,7 +11,7 @@ use hermes_chain_type_components::traits::types::ibc::sequence::HasSequenceType;
 }]
 #[async_trait]
 pub trait CanQueryPacketAcknowledgements<Counterparty>:
-    HasHeightType + HasChannelIdType<Counterparty> + HasPortIdType<Counterparty> + HasAsyncErrorType
+    HasChannelIdType<Counterparty> + HasPortIdType<Counterparty> + HasAsyncErrorType
 where
     Counterparty: HasSequenceType<Self>,
 {

--- a/crates/chain/chain-components/src/traits/queries/packet_commitments.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_commitments.rs
@@ -26,5 +26,5 @@ pub trait CanQueryPacketCommitments<Counterparty>:
         &self,
         channel_id: &Self::ChannelId,
         port_id: &Self::PortId,
-    ) -> Result<(Vec<Self::Sequence>, Self::Height), Self::Error>;
+    ) -> Result<Vec<Self::Sequence>, Self::Error>;
 }

--- a/crates/chain/chain-components/src/traits/queries/packet_commitments.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_commitments.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 
 use cgp::prelude::*;
-use hermes_chain_type_components::traits::types::height::HasHeightType;
 use hermes_chain_type_components::traits::types::ibc::channel_id::HasChannelIdType;
 use hermes_chain_type_components::traits::types::ibc::port_id::HasPortIdType;
 use hermes_chain_type_components::traits::types::ibc::sequence::HasSequenceType;
@@ -12,8 +11,7 @@ use hermes_chain_type_components::traits::types::ibc::sequence::HasSequenceType;
 }]
 #[async_trait]
 pub trait CanQueryPacketCommitments<Counterparty>:
-    HasHeightType
-    + HasChannelIdType<Counterparty>
+    HasChannelIdType<Counterparty>
     + HasPortIdType<Counterparty>
     + HasSequenceType<Counterparty>
     + HasAsyncErrorType

--- a/crates/chain/chain-components/src/traits/queries/send_packets.rs
+++ b/crates/chain/chain-components/src/traits/queries/send_packets.rs
@@ -33,10 +33,6 @@ pub trait CanQuerySendPackets<Counterparty>:
         counterparty_channel_id: &ChannelIdOf<Counterparty, Self>,
         counterparty_port_id: &PortIdOf<Counterparty, Self>,
         sequences: &[Self::Sequence],
-        // The height is given to query the packets from a specific height.
-        // This height should be the same as the query height from the
-        // `CanQueryPacketCommitments` made on the same chain.
-        height: &Self::Height,
     ) -> Result<Vec<Self::OutgoingPacket>, Self::Error>;
 }
 
@@ -63,6 +59,5 @@ pub trait CanQuerySendPacket<Counterparty>:
         counterparty_channel_id: &ChannelIdOf<Counterparty, Self>,
         counterparty_port_id: &PortIdOf<Counterparty, Self>,
         sequence: &Self::Sequence,
-        height: &Self::Height,
     ) -> Result<Self::OutgoingPacket, Self::Error>;
 }

--- a/crates/cli/cli/src/commands/query/packet/commitments.rs
+++ b/crates/cli/cli/src/commands/query/packet/commitments.rs
@@ -2,12 +2,11 @@ use cgp::prelude::*;
 use hermes_cli_components::traits::build::CanLoadBuilder;
 use hermes_cli_components::traits::command::CommandRunnerComponent;
 use hermes_cli_framework::command::CommandRunner;
-use hermes_cli_framework::output::{json, Output};
+use hermes_cli_framework::output::Output;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_relayer_components::chain::traits::queries::packet_commitments::CanQueryPacketCommitments;
 use ibc::core::host::types::identifiers::{ChainId, ChannelId, PortId};
 
-use crate::commands::query::packet::util::PacketSequences;
 use crate::contexts::app::HermesApp;
 use crate::Result;
 
@@ -48,7 +47,7 @@ impl CommandRunner<HermesApp> for QueryPacketCommitments {
 
         let chain = builder.build_chain(&self.chain_id).await?;
 
-        let (sequences, height) =
+        let sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &chain,
                 &self.channel_id,
@@ -56,12 +55,6 @@ impl CommandRunner<HermesApp> for QueryPacketCommitments {
             )
             .await?;
 
-        let packet_sequences = PacketSequences::new(height, sequences);
-
-        if json() {
-            Ok(Output::success(packet_sequences))
-        } else {
-            Ok(Output::success(packet_sequences.collated()))
-        }
+        Ok(Output::success(sequences))
     }
 }

--- a/crates/cli/cli/src/commands/query/packet/pending.rs
+++ b/crates/cli/cli/src/commands/query/packet/pending.rs
@@ -182,7 +182,7 @@ impl QueryPendingPackets {
         let counterparty_chain = builder.build_chain(&counterparty_chain_id.clone()).await?;
 
         // Retrieve source Chain summary
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &chain,
                 &channel_id,
@@ -230,7 +230,7 @@ impl QueryPendingPackets {
         };
 
         // Retrieve destination chain summary
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &counterparty_chain,
                 counterparty_channel_id,

--- a/crates/cli/cli/src/commands/query/packet/pending.rs
+++ b/crates/cli/cli/src/commands/query/packet/pending.rs
@@ -210,7 +210,7 @@ impl QueryPendingPackets {
         )
         .await?;
 
-        let unreceived_acknowledgement_sequences = if let Some((acks_on_counterparty, _)) =
+        let unreceived_acknowledgement_sequences = if let Some(acks_on_counterparty) =
             acks_and_height_on_counterparty
         {
             <CosmosChain as CanQueryUnreceivedAcksSequences<CosmosChain>>::query_unreceived_acknowledgments_sequences(
@@ -255,7 +255,7 @@ impl QueryPendingPackets {
         )
         .await?;
 
-        let unreceived_acknowledgement_sequences = if let Some((acks_on_counterparty, _)) =
+        let unreceived_acknowledgement_sequences = if let Some(acks_on_counterparty) =
             acks_and_height_on_counterparty
         {
             <CosmosChain as CanQueryUnreceivedAcksSequences<CosmosChain>>::query_unreceived_acknowledgments_sequences(

--- a/crates/cli/cli/src/commands/query/packet/pending_acks.rs
+++ b/crates/cli/cli/src/commands/query/packet/pending_acks.rs
@@ -124,7 +124,7 @@ impl QueryPendingAcks {
         let counterparty_chain_id = client_state.chain_id();
         let counterparty_chain = builder.build_chain(&counterparty_chain_id.clone()).await?;
 
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &chain,
                 &channel_id,

--- a/crates/cli/cli/src/commands/query/packet/pending_acks.rs
+++ b/crates/cli/cli/src/commands/query/packet/pending_acks.rs
@@ -5,7 +5,7 @@ use hermes_chain_components::traits::queries::unreceived_acks_sequences::CanQuer
 use hermes_cli_components::traits::build::CanLoadBuilder;
 use hermes_cli_components::traits::command::CommandRunnerComponent;
 use hermes_cli_framework::command::CommandRunner;
-use hermes_cli_framework::output::{json, Output};
+use hermes_cli_framework::output::Output;
 use hermes_cosmos_chain_components::traits::abci_query::CanQueryAbci;
 use hermes_cosmos_chain_components::types::tendermint::TendermintClientState;
 use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
@@ -16,14 +16,12 @@ use hermes_protobuf_encoding_components::types::any::Any;
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainHeight;
 use ibc::clients::tendermint::types::TENDERMINT_CLIENT_STATE_TYPE_URL;
 use ibc::core::channel::types::channel::{ChannelEnd, State};
-use ibc::core::client::types::Height;
 use ibc::core::connection::types::ConnectionEnd;
 use ibc::core::host::types::identifiers::{ChainId, ChannelId, PortId, Sequence};
 use ibc::cosmos_host::IBC_QUERY_PATH;
 use ibc::primitives::proto::Protobuf;
 use oneline_eyre::eyre::eyre;
 
-use crate::commands::query::packet::util::PacketSequences;
 use crate::contexts::app::HermesApp;
 use crate::Result;
 
@@ -58,7 +56,7 @@ pub struct QueryPendingAcks {
 }
 
 impl QueryPendingAcks {
-    async fn execute(&self, builder: &CosmosBuilder) -> Result<Option<(Vec<Sequence>, Height)>> {
+    async fn execute(&self, builder: &CosmosBuilder) -> Result<Option<Vec<Sequence>>> {
         let port_id = self.port_id.clone();
         let channel_id = self.channel_id.clone();
         let chain = builder.build_chain(&self.chain_id).await?;
@@ -142,19 +140,16 @@ impl QueryPendingAcks {
         )
         .await?;
 
-        let unreceived_acknowledgement_sequences_and_height = if let Some((
-            acks_on_counterparty,
-            height,
-        )) =
+        let unreceived_acknowledgement_sequences_and_height = if let Some(acks_on_counterparty) =
             acks_and_height_on_counterparty
         {
-            Some((<CosmosChain as CanQueryUnreceivedAcksSequences<CosmosChain>>::query_unreceived_acknowledgments_sequences(
+            Some(<CosmosChain as CanQueryUnreceivedAcksSequences<CosmosChain>>::query_unreceived_acknowledgments_sequences(
                         &chain,
                         &channel_id,
                         &port_id,
                         &acks_on_counterparty,
                     )
-                    .await?, height))
+                    .await?)
         } else {
             None
         };
@@ -171,15 +166,7 @@ impl CommandRunner<HermesApp> for QueryPendingAcks {
         match self.execute(&builder).await {
             Err(e) => Ok(Output::error(e)),
             Ok(None) => Ok(Output::success_msg("No unreceived acknowledgements")),
-            Ok(Some((sequences, height))) => {
-                let packet_sequences = PacketSequences::new(height, sequences);
-
-                if json() {
-                    Ok(Output::success(packet_sequences))
-                } else {
-                    Ok(Output::success(packet_sequences.collated()))
-                }
-            }
+            Ok(Some(sequences)) => Ok(Output::success(sequences)),
         }
     }
 }

--- a/crates/cli/cli/src/commands/query/packet/util/mod.rs
+++ b/crates/cli/cli/src/commands/query/packet/util/mod.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-use ibc::core::client::types::Height;
 use ibc::core::host::types::identifiers::Sequence;
 use serde::Serialize;
 
@@ -49,42 +48,5 @@ impl CollatedPendingPackets {
                 .collated()
                 .collect(),
         }
-    }
-}
-
-#[derive(Serialize, Debug)]
-pub struct PacketSequences {
-    pub height: Height,
-    pub sequences: Vec<u64>,
-}
-
-impl PacketSequences {
-    pub fn new(height: Height, sequences: Vec<Sequence>) -> Self {
-        Self {
-            height,
-            sequences: sequences.into_iter().map(u64::from).collect(),
-        }
-    }
-
-    pub fn collated(self) -> CollatedPacketSequences {
-        CollatedPacketSequences {
-            height: self.height,
-            sequences: self.sequences.into_iter().collated().collect(),
-        }
-    }
-}
-
-#[derive(Serialize)]
-pub struct CollatedPacketSequences {
-    pub height: Height,
-    pub sequences: Vec<Collated<u64>>,
-}
-
-impl fmt::Debug for CollatedPacketSequences {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PacketSequences")
-            .field("height", &self.height)
-            .field("sequences", &self.sequences)
-            .finish()
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/components/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/client.rs
@@ -6,6 +6,9 @@ pub use hermes_chain_type_components::traits::types::message_response::MessageRe
 use hermes_relayer_components::chain::impls::payload_builders::channel::BuildChannelHandshakePayload;
 use hermes_relayer_components::chain::impls::payload_builders::connection::BuildConnectionHandshakePayload;
 use hermes_relayer_components::chain::impls::payload_builders::packet::BuildPacketPayloads;
+use hermes_relayer_components::chain::impls::queries::block_events::{
+    RetryQueryBlockEvents, WaitBlockHeightAndQueryEvents,
+};
 use hermes_relayer_components::chain::impls::queries::consensus_state_height::QueryConsensusStateHeightsAndFindHeightBefore;
 pub use hermes_relayer_components::chain::traits::commitment_prefix::CommitmentPrefixTypeComponent;
 pub use hermes_relayer_components::chain::traits::extract_data::{
@@ -331,7 +334,11 @@ cgp_preset! {
         BlockQuerierComponent:
             QueryCometBlock,
         BlockEventsQuerierComponent:
-            QueryCosmosBlockEvents,
+            RetryQueryBlockEvents<
+                5,
+                WaitBlockHeightAndQueryEvents<
+                    QueryCosmosBlockEvents
+                >>,
         AbciQuerierComponent:
             QueryAbci,
         UnbondingPeriodQuerierComponent:

--- a/crates/cosmos/cosmos-chain-components/src/components/client.rs
+++ b/crates/cosmos/cosmos-chain-components/src/components/client.rs
@@ -52,6 +52,7 @@ pub use hermes_relayer_components::chain::traits::queries::ack_packets::{
     AckPacketQuerierComponent, AckPacketsQuerierComponent,
 };
 pub use hermes_relayer_components::chain::traits::queries::block::BlockQuerierComponent;
+pub use hermes_relayer_components::chain::traits::queries::block_events::BlockEventsQuerierComponent;
 pub use hermes_relayer_components::chain::traits::queries::chain_status::ChainStatusQuerierComponent;
 pub use hermes_relayer_components::chain::traits::queries::channel_end::{
     ChannelEndQuerierComponent, ChannelEndWithProofsQuerierComponent,
@@ -156,6 +157,7 @@ use crate::impls::queries::abci::QueryAbci;
 use crate::impls::queries::ack_packet::QueryCosmosAckPacket;
 use crate::impls::queries::ack_packets::QueryAckPacketsConcurrently;
 use crate::impls::queries::block::QueryCometBlock;
+use crate::impls::queries::block_events::QueryCosmosBlockEvents;
 use crate::impls::queries::chain_id::QueryChainIdFromAbci;
 use crate::impls::queries::chain_status::QueryCosmosChainStatus;
 use crate::impls::queries::channel_end::QueryCosmosChannelEndFromAbci;
@@ -328,6 +330,8 @@ cgp_preset! {
             ProvideCosmosInitChannelOptionsType,
         BlockQuerierComponent:
             QueryCometBlock,
+        BlockEventsQuerierComponent:
+            QueryCosmosBlockEvents,
         AbciQuerierComponent:
             QueryAbci,
         UnbondingPeriodQuerierComponent:

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/ack_packet.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/ack_packet.rs
@@ -46,7 +46,6 @@ where
         counterparty_channel_id: &ChannelId,
         counterparty_port_id: &PortId,
         sequence: &Sequence,
-        _height: &Height,
     ) -> Result<(Packet, WriteAckEvent), Chain::Error> {
         // The ack packet are queried from the destination chain, so the destination
         // channel id and port id are the counterparty channel id and counterparty port id.

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/ack_packets.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/ack_packets.rs
@@ -23,7 +23,6 @@ where
         counterparty_channel_id: &Chain::ChannelId,
         counterparty_port_id: &Chain::PortId,
         sequences: &[Counterparty::Sequence],
-        height: &Chain::Height,
     ) -> Result<
         Vec<(
             Counterparty::OutgoingPacket,
@@ -40,7 +39,6 @@ where
                     counterparty_channel_id,
                     counterparty_port_id,
                     sequence,
-                    height,
                 )
             })
             .try_collect::<Vec<_>>()

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/block_events.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/block_events.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use cgp::prelude::*;
+use hermes_chain_type_components::traits::types::event::HasEventType;
+use hermes_chain_type_components::traits::types::height::HasHeightType;
+use hermes_relayer_components::chain::traits::queries::block_events::{
+    BlockEventsQuerier, BlockEventsQuerierComponent,
+};
+use ibc::core::client::types::Height;
+use tendermint::abci::Code;
+use tendermint::block::Height as TmHeight;
+use tendermint::Error as TmError;
+use tendermint_rpc::{Client, Error as RpcError};
+
+use crate::traits::rpc_client::HasRpcClient;
+use crate::types::event::CosmosEvent;
+
+pub struct QueryCosmosBlockEvents;
+
+#[cgp_provider(BlockEventsQuerierComponent)]
+impl<Chain> BlockEventsQuerier<Chain> for QueryCosmosBlockEvents
+where
+    Chain: HasHeightType<Height = Height>
+        + HasEventType<Event = CosmosEvent>
+        + HasRpcClient
+        + CanRaiseAsyncError<TmError>
+        + CanRaiseAsyncError<RpcError>,
+{
+    async fn query_block_events(
+        chain: &Chain,
+        height: &Chain::Height,
+    ) -> Result<Vec<Chain::Event>, Chain::Error> {
+        let tendermint_height =
+            TmHeight::try_from(height.revision_height()).map_err(Chain::raise_error)?;
+
+        let response = chain
+            .rpc_client()
+            .block_results(tendermint_height)
+            .await
+            .map_err(Chain::raise_error)?;
+
+        let mut events = Vec::new();
+
+        if let Some(begin_block_events) = response.begin_block_events {
+            events.extend(begin_block_events.into_iter().map(Arc::new));
+        }
+
+        if let Some(txs_results) = response.txs_results {
+            for tx_result in txs_results {
+                if tx_result.code == Code::Ok {
+                    events.extend(tx_result.events.into_iter().map(Arc::new));
+                }
+            }
+        }
+
+        if let Some(end_block_events) = response.end_block_events {
+            events.extend(end_block_events.into_iter().map(Arc::new));
+        }
+
+        Ok(events)
+    }
+}

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/mod.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/mod.rs
@@ -2,6 +2,7 @@ pub mod abci;
 pub mod ack_packet;
 pub mod ack_packets;
 pub mod block;
+pub mod block_events;
 pub mod chain_id;
 pub mod chain_status;
 pub mod channel_end;

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_acknowledgements.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_acknowledgements.rs
@@ -5,7 +5,7 @@ use eyre::eyre;
 use hermes_relayer_components::chain::traits::queries::packet_acknowledgements::{
     PacketAcknowledgementsQuerier, PacketAcknowledgementsQuerierComponent,
 };
-use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use hermes_relayer_components::chain::traits::types::ibc::{HasIbcChainTypes, HasSequenceType};
 use http::uri::InvalidUri;
 use http::Uri;
 use ibc::core::client::types::Height;
@@ -37,7 +37,7 @@ where
         + CanRaiseAsyncError<DecodingError>
         + CanRaiseAsyncError<Status>
         + CanRaiseAsyncError<eyre::Report>,
-    Counterparty: HasIbcChainTypes<Chain, Sequence = Sequence, Height = Height>,
+    Counterparty: HasSequenceType<Chain, Sequence = Sequence>,
 {
     async fn query_packet_acknowlegements(
         chain: &Chain,

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_acknowledgements.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_acknowledgements.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use cgp::prelude::*;
-use eyre::eyre;
 use hermes_relayer_components::chain::traits::queries::packet_acknowledgements::{
     PacketAcknowledgementsQuerier, PacketAcknowledgementsQuerierComponent,
 };
@@ -44,7 +43,7 @@ where
         channel_id: &Chain::ChannelId,
         port_id: &Chain::PortId,
         sequences: &[Counterparty::Sequence],
-    ) -> Result<Option<(Vec<Counterparty::Sequence>, Chain::Height)>, Chain::Error> {
+    ) -> Result<Option<Vec<Counterparty::Sequence>>, Chain::Error> {
         let mut client = ChannelQueryClient::connect(
             Uri::try_from(&chain.grpc_address().to_string()).map_err(Chain::raise_error)?,
         )
@@ -83,12 +82,6 @@ where
         response_acks.retain(|s| commit_set.contains(s));
         response_acks.sort_unstable();
 
-        let raw_height = response
-            .height
-            .ok_or_else(|| Chain::raise_error(eyre!("missing height in response")))?;
-
-        let height = Height::try_from(raw_height).map_err(Chain::raise_error)?;
-
-        Ok(Some((response_acks, height)))
+        Ok(Some(response_acks))
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_commitments.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_commitments.rs
@@ -1,5 +1,4 @@
 use cgp::prelude::*;
-use eyre::eyre;
 use hermes_relayer_components::chain::traits::queries::packet_commitments::{
     PacketCommitmentsQuerier, PacketCommitmentsQuerierComponent,
 };
@@ -40,7 +39,7 @@ where
         chain: &Chain,
         channel_id: &Chain::ChannelId,
         port_id: &Chain::PortId,
-    ) -> Result<(Vec<Chain::Sequence>, Chain::Height), Chain::Error> {
+    ) -> Result<Vec<Chain::Sequence>, Chain::Error> {
         let mut client = ChannelQueryClient::connect(
             Uri::try_from(&chain.grpc_address().to_string()).map_err(Chain::raise_error)?,
         )
@@ -70,12 +69,6 @@ where
             .map(|packet_state| packet_state.sequence.into())
             .collect();
 
-        let raw_height = response
-            .height
-            .ok_or_else(|| Chain::raise_error(eyre!("missing height in response")))?;
-
-        let height = Height::try_from(raw_height).map_err(Chain::raise_error)?;
-
-        Ok((commitment_sequences, height))
+        Ok(commitment_sequences)
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/send_packet.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/send_packet.rs
@@ -46,7 +46,6 @@ where
         counterparty_channel_id: &ChannelId,
         counterparty_port_id: &PortId,
         sequence: &Sequence,
-        _height: &Height,
     ) -> Result<Packet, Chain::Error> {
         // The unreceived packet are queried from the source chain, so the destination
         // channel id and port id are the counterparty channel id and counterparty port id.

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/send_packets.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/send_packets.rs
@@ -20,7 +20,6 @@ where
         counterparty_channel_id: &Counterparty::ChannelId,
         counterparty_port_id: &Counterparty::PortId,
         sequences: &[Chain::Sequence],
-        height: &Chain::Height,
     ) -> Result<Vec<Chain::OutgoingPacket>, Chain::Error> {
         let send_packets = stream::iter(sequences)
             // TODO: use `flat_map_unordered`
@@ -31,7 +30,6 @@ where
                     counterparty_channel_id,
                     counterparty_port_id,
                     sequence,
-                    height,
                 )
             })
             .try_collect::<Vec<_>>()

--- a/crates/cosmos/cosmos-chain-components/src/types/event.rs
+++ b/crates/cosmos/cosmos-chain-components/src/types/event.rs
@@ -1,1 +1,5 @@
+use std::sync::Arc;
+
 pub use tendermint::abci::Event as AbciEvent;
+
+pub type CosmosEvent = Arc<AbciEvent>;

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/relay_driver.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/relay_driver.rs
@@ -1,5 +1,6 @@
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
-use cgp::core::field::Index;
+use cgp::core::field::{Index, WithField};
+use cgp::core::types::WithType;
 use cgp::extra::run::CanRun;
 use cgp::prelude::*;
 use hermes_async_runtime_components::task::types::future_task::FutureTask;
@@ -10,19 +11,16 @@ use hermes_error::handlers::debug::DebugError;
 use hermes_error::impls::ProvideHermesError;
 use hermes_error::types::Error;
 use hermes_relayer_components::multi::traits::birelay_at::{
-    BiRelayTypeAtComponent, ProvideBiRelayTypeAt,
+    BiRelayGetterAtComponent, BiRelayTypeAtComponent,
 };
-use hermes_relayer_components::multi::traits::chain_at::{
-    ChainTypeAtComponent, ProvideChainTypeAt,
-};
-use hermes_relayer_components::multi::traits::relay_at::{
-    ProvideRelayTypeAt, RelayTypeAtComponent,
-};
+use hermes_relayer_components::multi::traits::chain_at::ChainTypeAtComponent;
+use hermes_relayer_components::multi::traits::relay_at::RelayTypeAtComponent;
 use hermes_runtime_components::traits::spawn::CanSpawnTask;
 use hermes_test_components::relay_driver::run::{
     RelayerBackgroundRunner, RelayerBackgroundRunnerComponent,
 };
 
+#[derive(HasField)]
 pub struct CosmosRelayDriver {
     pub birelay: CosmosBiRelay,
 }
@@ -37,6 +35,19 @@ delegate_components! {
     CosmosRelayDriverComponents {
         ErrorTypeComponent: ProvideHermesError,
         ErrorRaiserComponent: DebugError,
+        [
+            ChainTypeAtComponent<Index<0>>,
+            ChainTypeAtComponent<Index<1>>,
+        ]:
+            WithType<CosmosChain>,
+        [
+            RelayTypeAtComponent<Index<0>, Index<1>>,
+            RelayTypeAtComponent<Index<1>, Index<0>>,
+        ]: WithType<CosmosRelay>,
+        BiRelayTypeAtComponent<Index<0>, Index<1>>:
+            WithType<CosmosBiRelay>,
+        BiRelayGetterAtComponent<Index<0>, Index<1>>:
+            WithField<symbol!("birelay")>,
     }
 }
 
@@ -56,27 +67,10 @@ impl RelayerBackgroundRunner<CosmosRelayDriver> for CosmosRelayDriverComponents 
     }
 }
 
-#[cgp_provider(ChainTypeAtComponent<Index<0>>)]
-impl ProvideChainTypeAt<CosmosRelayDriver, Index<0>> for CosmosRelayDriverComponents {
-    type Chain = CosmosChain;
+pub trait CanUseCosmosRelayDriver:
+    CanUseComponent<BiRelayTypeAtComponent<Index<0>, Index<1>>, (Index<0>, Index<1>)>
+    + CanUseComponent<BiRelayGetterAtComponent<Index<0>, Index<1>>, (Index<0>, Index<1>)>
+{
 }
 
-#[cgp_provider(ChainTypeAtComponent<Index<1>>)]
-impl ProvideChainTypeAt<CosmosRelayDriver, Index<1>> for CosmosRelayDriverComponents {
-    type Chain = CosmosChain;
-}
-
-#[cgp_provider(RelayTypeAtComponent<Index<0>, Index<1>>)]
-impl ProvideRelayTypeAt<CosmosRelayDriver, Index<0>, Index<1>> for CosmosRelayDriverComponents {
-    type Relay = CosmosRelay;
-}
-
-#[cgp_provider(RelayTypeAtComponent<Index<1>, Index<0>>)]
-impl ProvideRelayTypeAt<CosmosRelayDriver, Index<1>, Index<0>> for CosmosRelayDriverComponents {
-    type Relay = CosmosRelay;
-}
-
-#[cgp_provider(BiRelayTypeAtComponent<Index<0>, Index<1>>)]
-impl ProvideBiRelayTypeAt<CosmosRelayDriver, Index<0>, Index<1>> for CosmosRelayDriverComponents {
-    type BiRelay = CosmosBiRelay;
-}
+impl CanUseCosmosRelayDriver for CosmosRelayDriver {}

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -4,6 +4,7 @@ use hermes_cosmos_integration_tests::contexts::binary_channel::test_driver::Cosm
 use hermes_cosmos_integration_tests::init::{init_preset_bootstraps, init_test_runtime};
 use hermes_error::types::Error;
 use hermes_ibc_test_suite::tests::clearing::TestPacketClearing;
+use hermes_ibc_test_suite::tests::transfer::TestIbcTransfer;
 use hermes_test_components::test_case::traits::test_case::TestCase;
 
 #[test]
@@ -15,7 +16,7 @@ fn cosmos_integration_tests() -> Result<(), Error> {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
-        // TestIbcTransfer.run_test(&setup).await?;
+        TestIbcTransfer.run_test(&setup).await?;
 
         TestPacketClearing.run_test(&setup).await?;
 

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -16,7 +16,7 @@ fn cosmos_integration_tests() -> Result<(), Error> {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
-        TestIbcTransfer.run_test(&setup).await?;
+        // TestIbcTransfer.run_test(&setup).await?;
 
         TestPacketClearing.run_test(&setup).await?;
 

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -3,6 +3,7 @@
 use hermes_cosmos_integration_tests::contexts::binary_channel::test_driver::CosmosBinaryChannelTestDriver;
 use hermes_cosmos_integration_tests::init::{init_preset_bootstraps, init_test_runtime};
 use hermes_error::types::Error;
+use hermes_ibc_test_suite::tests::clearing::TestPacketClearing;
 use hermes_ibc_test_suite::tests::transfer::TestIbcTransfer;
 use hermes_test_components::test_case::traits::test_case::TestCase;
 
@@ -14,7 +15,10 @@ fn cosmos_integration_tests() -> Result<(), Error> {
     runtime.runtime.clone().block_on(async move {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
-        TestIbcTransfer::run_test(&TestIbcTransfer, &setup).await?;
+
+        TestIbcTransfer.run_test(&setup).await?;
+
+        TestPacketClearing.run_test(&setup).await?;
 
         <Result<(), Error>>::Ok(())
     })?;

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -16,7 +16,7 @@ fn cosmos_integration_tests() -> Result<(), Error> {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
-        // TestIbcTransfer.run_test(&setup).await?;
+        TestIbcTransfer.run_test(&setup).await?;
 
         TestPacketClearing.run_test(&setup).await?;
 

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -4,7 +4,6 @@ use hermes_cosmos_integration_tests::contexts::binary_channel::test_driver::Cosm
 use hermes_cosmos_integration_tests::init::{init_preset_bootstraps, init_test_runtime};
 use hermes_error::types::Error;
 use hermes_ibc_test_suite::tests::clearing::TestPacketClearing;
-use hermes_ibc_test_suite::tests::transfer::TestIbcTransfer;
 use hermes_test_components::test_case::traits::test_case::TestCase;
 
 #[test]
@@ -16,7 +15,7 @@ fn cosmos_integration_tests() -> Result<(), Error> {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
-        TestIbcTransfer.run_test(&setup).await?;
+        // TestIbcTransfer.run_test(&setup).await?;
 
         TestPacketClearing.run_test(&setup).await?;
 

--- a/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/cosmos_integration_tests.rs
@@ -8,15 +8,28 @@ use hermes_ibc_test_suite::tests::transfer::TestIbcTransfer;
 use hermes_test_components::test_case::traits::test_case::TestCase;
 
 #[test]
-fn cosmos_integration_tests() -> Result<(), Error> {
+fn test_ibc_transfer() -> Result<(), Error> {
     let runtime = init_test_runtime();
 
-    // TODO: Use a test suite entry point for running multiple tests
     runtime.runtime.clone().block_on(async move {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
         TestIbcTransfer.run_test(&setup).await?;
+
+        <Result<(), Error>>::Ok(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn test_packet_clearing() -> Result<(), Error> {
+    let runtime = init_test_runtime();
+
+    runtime.runtime.clone().block_on(async move {
+        let setup: CosmosBinaryChannelTestDriver =
+            init_preset_bootstraps(&runtime, Default::default()).await?;
 
         TestPacketClearing.run_test(&setup).await?;
 

--- a/crates/cosmos/cosmos-integration-tests/tests/filter.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/filter.rs
@@ -77,7 +77,7 @@ fn packet_filter_test() -> Result<(), Error> {
         // Wait for a bit
         tokio::time::sleep(core::time::Duration::from_secs(5)).await;
 
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &setup.chain_driver_a.chain,
                 &setup.channel_id_a,
@@ -168,7 +168,7 @@ fn no_packet_filter_test() -> Result<(), Error> {
             .assert_eventual_amount(&setup.chain_driver_b.user_wallet_b.address, &balance_b)
             .await?;
 
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &setup.chain_driver_a.chain,
                 &setup.channel_id_a,

--- a/crates/cosmos/cosmos-integration-tests/tests/filter.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/filter.rs
@@ -51,7 +51,7 @@ fn packet_filter_test() -> Result<(), Error> {
             balance_a.denom.clone(),
         );
 
-        setup.relay_driver.run_relayer_in_background().await?;
+        let _relayer = setup.relay_driver.run_relayer_in_background().await?;
 
         <CosmosChain as CanIbcTransferToken<CosmosChain>>::ibc_transfer_token(
             &setup.chain_driver_a.chain,
@@ -115,7 +115,7 @@ fn no_packet_filter_test() -> Result<(), Error> {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
-        setup.relay_driver.run_relayer_in_background().await?;
+        let _relayer = setup.relay_driver.run_relayer_in_background().await?;
 
         let balance_a = setup
             .chain_driver_a

--- a/crates/cosmos/cosmos-integration-tests/tests/packet_ack.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/packet_ack.rs
@@ -124,7 +124,7 @@ fn packet_ack_test() -> Result<(), Error> {
         .await?;
 
         assert!(acks_and_height_on_counterparty.is_some());
-        assert!(acks_and_height_on_counterparty.unwrap().0.is_empty());
+        assert!(acks_and_height_on_counterparty.unwrap().is_empty());
 
         <Result<(), Error>>::Ok(())
     })?;

--- a/crates/cosmos/cosmos-integration-tests/tests/packet_ack.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/packet_ack.rs
@@ -82,7 +82,7 @@ fn packet_ack_test() -> Result<(), Error> {
             .assert_eventual_amount(&setup.chain_driver_b.user_wallet_b.address, &balance_b)
             .await?;
 
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &setup.chain_driver_a.chain,
                 &setup.channel_id_a,
@@ -105,7 +105,7 @@ fn packet_ack_test() -> Result<(), Error> {
         // Wait for acknowledgments to be relayed
         tokio::time::sleep(core::time::Duration::from_secs(15)).await;
 
-        let (commitment_sequences, _) =
+        let commitment_sequences =
             <CosmosChain as CanQueryPacketCommitments<CosmosChain>>::query_packet_commitments(
                 &setup.chain_driver_a.chain,
                 &setup.channel_id_a,

--- a/crates/cosmos/cosmos-integration-tests/tests/packet_ack.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/packet_ack.rs
@@ -29,7 +29,7 @@ fn packet_ack_test() -> Result<(), Error> {
         let setup: CosmosBinaryChannelTestDriver =
             init_preset_bootstraps(&runtime, Default::default()).await?;
 
-        setup.relay_driver.run_relayer_in_background().await?;
+        let _relayer = setup.relay_driver.run_relayer_in_background().await?;
 
         let balance_a = setup
             .chain_driver_a

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -432,6 +432,7 @@ pub trait CanUseCosmosChain:
     + CanExtractFromEvent<CosmosCreateClientEvent>
     + CanExtractFromMessageResponse<CosmosCreateClientEvent>
     + CanUseComponent<ChainStatusQuerierComponent>
+    + CanUseComponent<BlockEventsQuerierComponent>
 {
 }
 

--- a/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
@@ -11,6 +11,7 @@ use hermes_logger::ProvideHermesLogger;
 use hermes_logging_components::traits::has_logger::{
     GlobalLoggerGetterComponent, LoggerGetterComponent, LoggerTypeComponent,
 };
+use hermes_relayer_components::components::default::relay::AutoRelayerComponent;
 use hermes_relayer_components::error::traits::retry::RetryableErrorComponent;
 use hermes_relayer_components::multi::traits::chain_at::{
     ChainAt, ChainGetterAtComponent, ChainTypeAtComponent,
@@ -22,7 +23,6 @@ use hermes_relayer_components::relay::impls::packet_lock::{
     PacketMutexGetterComponent, PacketMutexOf,
 };
 use hermes_relayer_components::relay::impls::selector::SelectRelayAToB;
-use hermes_relayer_components::relay::traits::auto_relayer::CanAutoRelay;
 use hermes_relayer_components::relay::traits::chains::HasRelayClientIds;
 use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
 use hermes_relayer_components::relay::traits::target::{
@@ -37,7 +37,7 @@ use hermes_relayer_components_extra::components::extra::relay::{
 };
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{
-    RuntimeGetterComponent, RuntimeOf, RuntimeTypeComponent,
+    HasRuntime, RuntimeGetterComponent, RuntimeOf, RuntimeTypeComponent,
 };
 use ibc::core::host::types::identifiers::ClientId;
 
@@ -177,8 +177,9 @@ impl HasComponents for CosmosRelay {
 
 pub trait CanUseCosmosRelay:
     HasRelayClientIds
-    + CanAutoRelay<SourceTarget>
-    + CanAutoRelay<DestinationTarget>
+    + HasRuntime
+    + CanUseComponent<AutoRelayerComponent, SourceTarget>
+    + CanUseComponent<AutoRelayerComponent, DestinationTarget>
     + HasSourceTargetChainTypes
     + HasDestinationTargetChainTypes
     + CanCreateClient<SourceTarget>

--- a/crates/relayer/relayer-components/src/components/default/relay.rs
+++ b/crates/relayer/relayer-components/src/components/default/relay.rs
@@ -4,7 +4,7 @@ use cgp::prelude::*;
 use crate::error::impls::retry::ReturnMaxRetry;
 pub use crate::error::traits::retry::MaxErrorRetryGetterComponent;
 use crate::relay::impls::auto_relayers::both_targets::RelayBothTargets;
-use crate::relay::impls::auto_relayers::event_subscription::RelayWithEventSubscription;
+use crate::relay::impls::auto_relayers::poll_event::RelayWithPolledEvents;
 use crate::relay::impls::channel::open_ack::RelayChannelOpenAck;
 use crate::relay::impls::channel::open_confirm::RelayChannelOpenConfirm;
 use crate::relay::impls::channel::open_handshake::RelayChannelOpenHandshake;
@@ -61,7 +61,7 @@ cgp_preset! {
         TimeoutUnorderedPacketRelayerComponent: BaseTimeoutUnorderedPacketRelayer,
         EventRelayerComponent: PacketEventRelayer,
         RunnerComponent: RelayBothTargets,
-        AutoRelayerComponent: RelayWithEventSubscription,
+        AutoRelayerComponent: RelayWithPolledEvents,
         ClientCreatorComponent: CreateClientWithChains,
         PacketClearerComponent: ClearAllPackets,
         ChannelInitializerComponent: InitializeChannel,

--- a/crates/relayer/relayer-components/src/components/default/relay.rs
+++ b/crates/relayer/relayer-components/src/components/default/relay.rs
@@ -5,6 +5,7 @@ use crate::error::impls::retry::ReturnMaxRetry;
 pub use crate::error::traits::retry::MaxErrorRetryGetterComponent;
 use crate::relay::impls::auto_relayers::both_targets::RelayBothTargets;
 use crate::relay::impls::auto_relayers::poll_event::RelayWithPolledEvents;
+use crate::relay::impls::auto_relayers::starting_current_height::AutoRelayStartingCurrentHeight;
 use crate::relay::impls::channel::open_ack::RelayChannelOpenAck;
 use crate::relay::impls::channel::open_confirm::RelayChannelOpenConfirm;
 use crate::relay::impls::channel::open_handshake::RelayChannelOpenHandshake;
@@ -28,7 +29,9 @@ use crate::relay::impls::packet_relayers::receive::base_receive_packet::BaseRece
 use crate::relay::impls::packet_relayers::receive::skip_received_packet::SkipReceivedPacketRelayer;
 use crate::relay::impls::packet_relayers::timeout_unordered::timeout_unordered_packet::BaseTimeoutUnorderedPacketRelayer;
 use crate::relay::impls::update_client::default::DefaultTargetUpdateClientMessageBuilder;
-pub use crate::relay::traits::auto_relayer::AutoRelayerComponent;
+pub use crate::relay::traits::auto_relayer::{
+    AutoRelayerComponent, AutoRelayerWithHeightsComponent,
+};
 pub use crate::relay::traits::channel::open_ack::ChannelOpenAckRelayerComponent;
 pub use crate::relay::traits::channel::open_confirm::ChannelOpenConfirmRelayerComponent;
 pub use crate::relay::traits::channel::open_handshake::ChannelOpenHandshakeRelayerComponent;
@@ -61,7 +64,8 @@ cgp_preset! {
         TimeoutUnorderedPacketRelayerComponent: BaseTimeoutUnorderedPacketRelayer,
         EventRelayerComponent: PacketEventRelayer,
         RunnerComponent: RelayBothTargets,
-        AutoRelayerComponent: RelayWithPolledEvents,
+        AutoRelayerComponent: AutoRelayStartingCurrentHeight,
+        AutoRelayerWithHeightsComponent: RelayWithPolledEvents,
         ClientCreatorComponent: CreateClientWithChains,
         PacketClearerComponent: ClearAllPackets,
         ChannelInitializerComponent: InitializeChannel,

--- a/crates/relayer/relayer-components/src/components/default/relay.rs
+++ b/crates/relayer/relayer-components/src/components/default/relay.rs
@@ -4,7 +4,7 @@ use cgp::prelude::*;
 use crate::error::impls::retry::ReturnMaxRetry;
 pub use crate::error::traits::retry::MaxErrorRetryGetterComponent;
 use crate::relay::impls::auto_relayers::both_targets::RelayBothTargets;
-use crate::relay::impls::auto_relayers::event::RelayEvents;
+use crate::relay::impls::auto_relayers::event_subscription::RelayWithEventSubscription;
 use crate::relay::impls::channel::open_ack::RelayChannelOpenAck;
 use crate::relay::impls::channel::open_confirm::RelayChannelOpenConfirm;
 use crate::relay::impls::channel::open_handshake::RelayChannelOpenHandshake;
@@ -61,7 +61,7 @@ cgp_preset! {
         TimeoutUnorderedPacketRelayerComponent: BaseTimeoutUnorderedPacketRelayer,
         EventRelayerComponent: PacketEventRelayer,
         RunnerComponent: RelayBothTargets,
-        AutoRelayerComponent: RelayEvents,
+        AutoRelayerComponent: RelayWithEventSubscription,
         ClientCreatorComponent: CreateClientWithChains,
         PacketClearerComponent: ClearAllPackets,
         ChannelInitializerComponent: InitializeChannel,

--- a/crates/relayer/relayer-components/src/multi/traits/birelay_at.rs
+++ b/crates/relayer/relayer-components/src/multi/traits/birelay_at.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use cgp::core::component::WithProvider;
 use cgp::core::types::ProvideType;
 use cgp::prelude::*;
@@ -11,6 +13,14 @@ pub trait HasBiRelayTypeAt<TagA, TagB>: Async {
     type BiRelay: Async;
 }
 
+#[cgp_component {
+    name: BiRelayGetterAtComponent<TagA, TagB>,
+    provider: BiRelayGetterAt,
+}]
+pub trait HasBiRelayAt<TagA, TagB>: HasBiRelayTypeAt<TagA, TagB> {
+    fn birelay_at(&self, _tag: PhantomData<(TagA, TagB)>) -> &Self::BiRelay;
+}
+
 pub type BiRelayAt<Context, TagA, TagB> = <Context as HasBiRelayTypeAt<TagA, TagB>>::BiRelay;
 
 #[cgp_provider(BiRelayTypeAtComponent<TagA, TagB>)]
@@ -22,4 +32,15 @@ where
     BiRelay: Async,
 {
     type BiRelay = BiRelay;
+}
+
+#[cgp_provider(BiRelayGetterAtComponent<TagA, TagB>)]
+impl<Context, TagA, TagB, Provider> BiRelayGetterAt<Context, TagA, TagB> for WithProvider<Provider>
+where
+    Context: HasBiRelayTypeAt<TagA, TagB>,
+    Provider: FieldGetter<Context, BiRelayGetterAtComponent<TagA, TagB>, Value = Context::BiRelay>,
+{
+    fn birelay_at(context: &Context, _tag: PhantomData<(TagA, TagB)>) -> &Context::BiRelay {
+        Provider::get_field(context, PhantomData)
+    }
 }

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/event.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/event.rs
@@ -37,10 +37,7 @@ where
     Relay: CanRelayEvent<Target>,
 {
     async fn run(self) {
-        let _ = self
-            .relay
-            .relay_chain_event(&self.height, &self.event)
-            .await;
+        let _ = self.relay.relay_chain_event(&self.event).await;
     }
 }
 

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/mod.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/mod.rs
@@ -2,3 +2,4 @@ pub mod both_targets;
 pub mod both_ways;
 pub mod event_subscription;
 pub mod poll_event;
+pub mod starting_current_height;

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/mod.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/mod.rs
@@ -1,3 +1,4 @@
 pub mod both_targets;
 pub mod both_ways;
-pub mod event;
+pub mod event_subscription;
+pub mod poll_event;

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/poll_event.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/poll_event.rs
@@ -2,13 +2,13 @@ use alloc::boxed::Box;
 use core::marker::PhantomData;
 
 use cgp::core::error::ErrorOf;
-use cgp::extra::runtime::HasRuntime;
 use cgp::prelude::*;
 use hermes_chain_components::traits::queries::block_events::CanQueryBlockEvents;
 use hermes_chain_components::traits::queries::chain_status::CanQueryChainHeight;
 use hermes_chain_components::traits::types::event::HasEventType;
 use hermes_chain_components::traits::types::height::CanIncrementHeight;
 use hermes_chain_components::types::aliases::EventOf;
+use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_runtime_components::traits::task::{CanRunConcurrentTasks, Task};
 
 use crate::components::default::relay::AutoRelayerComponent;

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/poll_event.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/poll_event.rs
@@ -1,0 +1,84 @@
+use alloc::boxed::Box;
+use core::marker::PhantomData;
+
+use cgp::core::error::ErrorOf;
+use cgp::extra::runtime::HasRuntime;
+use cgp::prelude::*;
+use hermes_chain_components::traits::queries::block_events::CanQueryBlockEvents;
+use hermes_chain_components::traits::queries::chain_status::CanQueryChainHeight;
+use hermes_chain_components::traits::types::event::HasEventType;
+use hermes_chain_components::traits::types::height::CanIncrementHeight;
+use hermes_chain_components::types::aliases::EventOf;
+use hermes_runtime_components::traits::task::{CanRunConcurrentTasks, Task};
+
+use crate::components::default::relay::AutoRelayerComponent;
+use crate::relay::traits::auto_relayer::AutoRelayer;
+use crate::relay::traits::event_relayer::CanRelayEvent;
+use crate::relay::traits::target::{HasTargetChainTypes, HasTargetChains, RelayTarget};
+
+pub struct RelayWithPolledEvents;
+
+#[cgp_provider(AutoRelayerComponent)]
+impl<Relay, Target> AutoRelayer<Relay, Target> for RelayWithPolledEvents
+where
+    Relay: Clone
+        + HasRuntime
+        + HasTargetChains<Target>
+        + CanRelayEvent<Target>
+        + CanRaiseAsyncError<ErrorOf<Relay::TargetChain>>,
+    Target: RelayTarget,
+    Relay::TargetChain: CanQueryChainHeight + CanIncrementHeight + CanQueryBlockEvents,
+    Relay::Runtime: CanRunConcurrentTasks,
+{
+    async fn auto_relay(relay: &Relay, _target: Target) -> Result<(), Relay::Error> {
+        let chain = relay.target_chain();
+        let runtime = relay.runtime();
+
+        let mut height = chain
+            .query_chain_height()
+            .await
+            .map_err(Relay::raise_error)?;
+
+        loop {
+            let events = chain
+                .query_block_events(&height)
+                .await
+                .map_err(Relay::raise_error)?;
+
+            let tasks = events
+                .into_iter()
+                .map(|event| {
+                    Box::new(EventRelayerTask {
+                        relay: relay.clone(),
+                        event,
+                        phantom: PhantomData,
+                    })
+                })
+                .collect();
+
+            runtime.run_concurrent_tasks(tasks).await;
+
+            height = Relay::TargetChain::increment_height(&height).map_err(Relay::raise_error)?;
+        }
+    }
+}
+
+pub struct EventRelayerTask<Relay, Target>
+where
+    Target: RelayTarget,
+    Relay: HasTargetChainTypes<Target, TargetChain: HasEventType>,
+{
+    pub relay: Relay,
+    pub event: EventOf<Relay::TargetChain>,
+    pub phantom: PhantomData<Target>,
+}
+
+impl<Relay, Target> Task for EventRelayerTask<Relay, Target>
+where
+    Target: RelayTarget,
+    Relay: CanRelayEvent<Target>,
+{
+    async fn run(self) {
+        let _ = self.relay.relay_chain_event(&self.event).await;
+    }
+}

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/starting_current_height.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/starting_current_height.rs
@@ -1,0 +1,31 @@
+use cgp::core::error::ErrorOf;
+use cgp::prelude::*;
+use hermes_chain_components::traits::queries::chain_status::CanQueryChainHeight;
+
+use crate::components::default::relay::AutoRelayerComponent;
+use crate::relay::traits::auto_relayer::{AutoRelayer, CanAutoRelayWithHeights};
+use crate::relay::traits::target::{HasTargetChains, RelayTarget};
+
+pub struct AutoRelayStartingCurrentHeight;
+
+#[cgp_provider(AutoRelayerComponent)]
+impl<Relay, Target> AutoRelayer<Relay, Target> for AutoRelayStartingCurrentHeight
+where
+    Relay: HasTargetChains<Target>
+        + CanAutoRelayWithHeights<Target>
+        + CanRaiseAsyncError<ErrorOf<Relay::TargetChain>>,
+    Target: RelayTarget,
+    Relay::TargetChain: CanQueryChainHeight,
+{
+    async fn auto_relay(relay: &Relay, target: Target) -> Result<(), Relay::Error> {
+        let start_height = relay
+            .target_chain()
+            .query_chain_height()
+            .await
+            .map_err(Relay::raise_error)?;
+
+        relay
+            .auto_relay_with_heights(target, &start_height, None)
+            .await
+    }
+}

--- a/crates/relayer/relayer-components/src/relay/impls/packet_clearers/ack.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/packet_clearers/ack.rs
@@ -91,7 +91,7 @@ where
         let dst_chain = relay.dst_chain();
         let src_chain = relay.src_chain();
 
-        let (commitment_sequences, _) = src_chain
+        let commitment_sequences = src_chain
             .query_packet_commitments(src_channel_id, src_port_id)
             .await
             .map_err(Relay::raise_error)?;

--- a/crates/relayer/relayer-components/src/relay/impls/packet_clearers/ack.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/packet_clearers/ack.rs
@@ -3,6 +3,7 @@ use alloc::boxed::Box;
 use cgp::core::error::ErrorOf;
 use cgp::prelude::*;
 use hermes_chain_components::traits::packet::from_write_ack::CanBuildPacketFromWriteAck;
+use hermes_chain_components::traits::queries::chain_status::CanQueryChainHeight;
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLog;
 use hermes_runtime_components::traits::runtime::HasRuntime;
@@ -74,8 +75,9 @@ where
 impl<Relay> PacketClearer<Relay> for ClearAckPackets
 where
     Relay: Clone + HasRuntime + HasRelayChains + CanRaiseRelayChainErrors + HasLogger,
-    Relay::DstChain:
-        CanQueryAckPackets<Relay::SrcChain> + CanQueryPacketAcknowledgements<Relay::SrcChain>,
+    Relay::DstChain: CanQueryChainHeight
+        + CanQueryAckPackets<Relay::SrcChain>
+        + CanQueryPacketAcknowledgements<Relay::SrcChain>,
     Relay::SrcChain: CanQueryPacketCommitments<Relay::DstChain>
         + CanQueryUnreceivedAcksSequences<Relay::DstChain>,
     Relay::Runtime: CanRunConcurrentTasks,
@@ -101,7 +103,7 @@ where
             .await
             .map_err(Relay::raise_error)?;
 
-        if let Some((acks_on_counterparty, height)) = acks_and_height_on_counterparty {
+        if let Some(acks_on_counterparty) = acks_and_height_on_counterparty {
             let unreceived_ack_sequences = src_chain
                 .query_unreceived_acknowledgments_sequences(
                     src_channel_id,
@@ -118,8 +120,12 @@ where
                     dst_channel_id,
                     dst_port_id,
                     &unreceived_ack_sequences,
-                    &height,
                 )
+                .await
+                .map_err(Relay::raise_error)?;
+
+            let height = dst_chain
+                .query_chain_height()
                 .await
                 .map_err(Relay::raise_error)?;
 

--- a/crates/relayer/relayer-components/src/relay/impls/packet_clearers/receive_packet.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/packet_clearers/receive_packet.rs
@@ -88,11 +88,6 @@ where
         let dst_chain = relay.dst_chain();
         let src_chain = relay.src_chain();
 
-        let height = src_chain
-            .query_chain_height()
-            .await
-            .map_err(Relay::raise_error)?;
-
         let commitment_sequences = src_chain
             .query_packet_commitments(src_channel_id, src_port_id)
             .await
@@ -110,7 +105,6 @@ where
                 dst_channel_id,
                 dst_port_id,
                 &unreceived_sequences,
-                &height,
             )
             .await
             .map_err(Relay::raise_error)?;

--- a/crates/relayer/relayer-components/src/relay/traits/auto_relayer.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/auto_relayer.rs
@@ -5,6 +5,6 @@ use cgp::prelude::*;
   context: Relay,
 }]
 #[async_trait]
-pub trait CanAutoRelay<Target: Async>: Async + HasAsyncErrorType {
+pub trait CanAutoRelay<Target: Async>: HasAsyncErrorType {
     async fn auto_relay(&self, target: Target) -> Result<(), Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/auto_relayer.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/auto_relayer.rs
@@ -1,10 +1,32 @@
 use cgp::prelude::*;
+use hermes_chain_components::traits::types::height::HasHeightType;
+use hermes_chain_components::types::aliases::HeightOf;
+
+use crate::relay::traits::target::{HasTargetChainTypes, RelayTarget};
 
 #[cgp_component {
-  provider: AutoRelayer,
-  context: Relay,
+    provider: AutoRelayer,
+    context: Relay,
 }]
 #[async_trait]
 pub trait CanAutoRelay<Target: Async>: HasAsyncErrorType {
     async fn auto_relay(&self, target: Target) -> Result<(), Self::Error>;
+}
+
+#[cgp_component {
+    provider: AutoRelayerWithHeights,
+    context: Relay,
+}]
+#[async_trait]
+pub trait CanAutoRelayWithHeights<Target>:
+    HasTargetChainTypes<Target, TargetChain: HasHeightType> + HasAsyncErrorType
+where
+    Target: RelayTarget,
+{
+    async fn auto_relay_with_heights(
+        &self,
+        target: Target,
+        start_height: &HeightOf<Self::TargetChain>,
+        end_height: Option<&HeightOf<Self::TargetChain>>,
+    ) -> Result<(), Self::Error>;
 }

--- a/crates/relayer/relayer-components/src/relay/traits/event_relayer.rs
+++ b/crates/relayer/relayer-components/src/relay/traits/event_relayer.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 use hermes_chain_components::traits::types::height::HasHeightType;
 
 use crate::chain::traits::types::event::HasEventType;
-use crate::chain::types::aliases::{EventOf, HeightOf};
+use crate::chain::types::aliases::EventOf;
 use crate::relay::traits::target::{HasTargetChainTypes, RelayTarget};
 
 /**
@@ -31,7 +31,6 @@ pub trait CanRelayEvent<Target: RelayTarget>:
     */
     async fn relay_chain_event(
         &self,
-        height: &HeightOf<Self::TargetChain>,
         event: &EventOf<Self::TargetChain>,
     ) -> Result<(), Self::Error>;
 }

--- a/crates/test/test-suite/src/tests/clearing.rs
+++ b/crates/test/test-suite/src/tests/clearing.rs
@@ -16,9 +16,7 @@ use hermes_relayer_components::multi::traits::chain_at::HasChainTypeAt;
 use hermes_relayer_components::multi::traits::relay_at::RelayAt;
 use hermes_relayer_components::relay::traits::auto_relayer::CanAutoRelayWithHeights;
 use hermes_relayer_components::relay::traits::chains::HasRelayChainTypes;
-use hermes_relayer_components::relay::traits::target::{
-    DestinationTarget, HasDestinationTargetChainTypes, HasSourceTargetChainTypes, SourceTarget,
-};
+use hermes_relayer_components::relay::traits::target::{HasSourceTargetChainTypes, SourceTarget};
 use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
 use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
 use hermes_test_components::chain::traits::transfer::amount::CanConvertIbcTransferredAmount;
@@ -79,14 +77,10 @@ where
     BiRelay: HasTwoWayRelay,
     RelayAt<BiRelay, Index<0>, Index<1>>: HasRelayChainTypes<SrcChain = ChainA, DstChain = ChainB>
         + HasSourceTargetChainTypes
-        + HasDestinationTargetChainTypes
-        + CanAutoRelayWithHeights<SourceTarget>
-        + CanAutoRelayWithHeights<DestinationTarget>,
+        + CanAutoRelayWithHeights<SourceTarget>,
     RelayAt<BiRelay, Index<1>, Index<0>>: HasRelayChainTypes<SrcChain = ChainB, DstChain = ChainA>
         + HasSourceTargetChainTypes
-        + HasDestinationTargetChainTypes
-        + CanAutoRelayWithHeights<SourceTarget>
-        + CanAutoRelayWithHeights<DestinationTarget>,
+        + CanAutoRelayWithHeights<SourceTarget>,
     Logger: CanLogMessage,
     Driver::Error: From<ChainA::Error>
         + From<ChainB::Error>

--- a/crates/test/test-suite/src/tests/clearing.rs
+++ b/crates/test/test-suite/src/tests/clearing.rs
@@ -1,0 +1,197 @@
+use alloc::format;
+use core::marker::PhantomData;
+
+use cgp::core::field::Index;
+use cgp::prelude::*;
+use hermes_logging_components::traits::has_logger::HasLogger;
+use hermes_logging_components::traits::logger::CanLogMessage;
+use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
+use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
+use hermes_relayer_components::multi::traits::chain_at::HasChainTypeAt;
+use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
+use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
+use hermes_test_components::chain::traits::transfer::amount::CanConvertIbcTransferredAmount;
+use hermes_test_components::chain::traits::transfer::ibc_transfer::CanIbcTransferToken;
+use hermes_test_components::chain::traits::types::amount::HasAmountMethods;
+use hermes_test_components::chain::traits::types::memo::HasDefaultMemo;
+use hermes_test_components::chain_driver::traits::fields::amount::CanGenerateRandomAmount;
+use hermes_test_components::chain_driver::traits::fields::denom_at::{HasDenomAt, TransferDenom};
+use hermes_test_components::chain_driver::traits::fields::wallet::{HasWalletAt, UserWallet};
+use hermes_test_components::chain_driver::traits::types::chain::HasChain;
+use hermes_test_components::driver::traits::channel_at::HasChannelAt;
+use hermes_test_components::driver::traits::types::chain_driver_at::HasChainDriverAt;
+use hermes_test_components::driver::traits::types::relay_driver_at::HasRelayDriverAt;
+use hermes_test_components::test_case::traits::test_case::TestCase;
+
+pub struct TestPacketClearing;
+
+impl<Driver, ChainA, ChainB, ChainDriverA, ChainDriverB, RelayDriver, Logger> TestCase<Driver>
+    for TestPacketClearing
+where
+    Driver: HasAsyncErrorType
+        + HasLogger<Logger = Logger>
+        + HasChainTypeAt<Index<0>, Chain = ChainA>
+        + HasChainTypeAt<Index<1>, Chain = ChainB>
+        + HasChainDriverAt<Index<0>, ChainDriver = ChainDriverA>
+        + HasChainDriverAt<Index<1>, ChainDriver = ChainDriverB>
+        + HasRelayDriverAt<Index<0>, Index<1>, RelayDriver = RelayDriver>
+        + HasChannelAt<Index<0>, Index<1>>
+        + HasChannelAt<Index<1>, Index<0>>,
+    ChainDriverA: HasChain<Chain = ChainA>
+        + HasDenomAt<TransferDenom, Index<0>>
+        + HasWalletAt<UserWallet, Index<0>>
+        + HasWalletAt<UserWallet, Index<1>>
+        + CanGenerateRandomAmount,
+    ChainDriverB:
+        HasChain<Chain = ChainB> + HasWalletAt<UserWallet, Index<0>> + CanGenerateRandomAmount,
+    ChainA: HasIbcChainTypes<ChainB>
+        + HasChainId
+        + HasOutgoingPacketType<ChainB>
+        + CanQueryBalance
+        + HasAmountMethods
+        + CanConvertIbcTransferredAmount<ChainB>
+        + CanIbcTransferToken<ChainB>
+        + CanAssertEventualAmount
+        + HasDefaultMemo,
+    ChainB: HasIbcChainTypes<ChainA>
+        + HasChainId
+        + HasOutgoingPacketType<ChainA>
+        + HasAmountMethods
+        + CanQueryBalance
+        + CanIbcTransferToken<ChainA>
+        + CanConvertIbcTransferredAmount<ChainA>
+        + CanAssertEventualAmount
+        + HasDefaultMemo,
+    Logger: CanLogMessage,
+    Driver::Error: From<ChainA::Error> + From<ChainB::Error>,
+{
+    async fn run_test(&self, driver: &Driver) -> Result<(), Driver::Error> {
+        let logger = driver.logger();
+
+        let chain_driver_a = driver.chain_driver_at(PhantomData::<Index<0>>);
+
+        let chain_driver_b = driver.chain_driver_at(PhantomData::<Index<1>>);
+
+        let relay_driver = driver.relay_driver_at(PhantomData::<(Index<0>, Index<1>)>);
+
+        let chain_a = chain_driver_a.chain();
+
+        let chain_id_a = chain_a.chain_id();
+
+        let chain_b = chain_driver_b.chain();
+
+        let chain_id_b = chain_b.chain_id();
+
+        let wallet_a1 = chain_driver_a.wallet_at(UserWallet, PhantomData::<Index<0>>);
+
+        let address_a1 = ChainA::wallet_address(wallet_a1);
+
+        let wallet_b = chain_driver_b.wallet_at(UserWallet, PhantomData::<Index<0>>);
+
+        let address_b = ChainB::wallet_address(wallet_b);
+
+        let denom_a = chain_driver_a.denom_at(TransferDenom, PhantomData::<Index<0>>);
+
+        let balance_a1 = chain_a.query_balance(address_a1, denom_a).await?;
+
+        let a_to_b_amount = chain_driver_a.random_amount(1000, &balance_a1).await;
+
+        let channel_id_a = driver.channel_id_at(PhantomData::<(Index<0>, Index<1>)>);
+
+        let port_id_a = driver.port_id_at(PhantomData::<(Index<0>, Index<1>)>);
+
+        let channel_id_b = driver.channel_id_at(PhantomData::<(Index<1>, Index<0>)>);
+
+        let port_id_b = driver.port_id_at(PhantomData::<(Index<1>, Index<0>)>);
+
+        logger
+            .log_message(&format!(
+                "Sending IBC transfer from chain {} to chain {} with amount of {} {}",
+                chain_id_a, chain_id_b, a_to_b_amount, denom_a
+            ))
+            .await;
+
+        chain_a
+            .ibc_transfer_token(
+                channel_id_a,
+                port_id_a,
+                wallet_a1,
+                address_b,
+                &a_to_b_amount,
+                &chain_a.default_memo(),
+            )
+            .await?;
+
+        let balance_a2 = ChainA::subtract_amount(&balance_a1, &a_to_b_amount)?;
+
+        let balance_a3 = chain_a.query_balance(address_a1, denom_a).await?;
+
+        assert_eq!(balance_a2, balance_a3);
+
+        let balance_b1 = ChainB::ibc_transfer_amount_from(&a_to_b_amount, channel_id_b, port_id_b)?;
+
+        logger
+            .log_message(&format!(
+                "Waiting for user on chain B to receive IBC transferred amount of {}",
+                balance_b1
+            ))
+            .await;
+
+        chain_b
+            .assert_eventual_amount(address_b, &balance_b1)
+            .await?;
+
+        let wallet_a2 = chain_driver_a.wallet_at(UserWallet, PhantomData::<Index<1>>);
+
+        let address_a2 = ChainA::wallet_address(wallet_a2);
+
+        let b_to_a_amount = chain_driver_b.random_amount(500, &balance_b1).await;
+
+        logger
+            .log_message(&format!(
+                "Sending IBC transfer from chain {} to chain {} with amount of {}",
+                chain_id_b, chain_id_a, b_to_a_amount,
+            ))
+            .await;
+
+        chain_b
+            .ibc_transfer_token(
+                channel_id_b,
+                port_id_b,
+                wallet_b,
+                address_a2,
+                &b_to_a_amount,
+                &chain_b.default_memo(),
+            )
+            .await?;
+
+        let balance_b2 = ChainB::subtract_amount(&balance_b1, &b_to_a_amount)?;
+
+        let denom_b = ChainB::amount_denom(&balance_b1);
+
+        let balance_b3 = chain_b.query_balance(address_b, denom_b).await?;
+
+        assert_eq!(balance_b2, balance_b3);
+
+        let balance_a4 = chain_a.query_balance(address_a2, denom_a).await?;
+
+        let balance_a5 = ChainA::add_amount(
+            &balance_a4,
+            &ChainA::transmute_counterparty_amount(&b_to_a_amount, denom_a),
+        )?;
+
+        chain_a
+            .assert_eventual_amount(address_a2, &balance_a5)
+            .await?;
+
+        logger
+            .log_message(&format!(
+                "successfully performed reverse IBC transfer from chain {} back to chain {}",
+                chain_id_b, chain_id_a,
+            ))
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/test/test-suite/src/tests/mod.rs
+++ b/crates/test/test-suite/src/tests/mod.rs
@@ -1,1 +1,2 @@
+pub mod clearing;
 pub mod transfer;


### PR DESCRIPTION
This PR introduces a new and simplified way of clearing packets and perform event-based relaying, by unifying them behind a poll-based event relaying interface.

## Block Height Querier

A new `CanQueryBlockEvents` interface is defined to allow polling events from a chain based on specific height:

```rust
pub trait CanQueryBlockEvents: HasHeightType + HasEventType + HasAsyncErrorType {
    async fn query_block_events(
        &self,
        height: &Self::Height,
    ) -> Result<Vec<Self::Event>, Self::Error>;
}
```

## Auto Relayer with Height Range

A new `CanAutoRelayWithHeights` interface is introduced to allow auto relaying based on specific height range:

```rust
pub trait CanAutoRelayWithHeights<Target>:
    HasTargetChainTypes<Target, TargetChain: HasHeightType> + HasAsyncErrorType
where
    Target: RelayTarget,
{
    async fn auto_relay_with_heights(
        &self,
        target: Target,
        start_height: &HeightOf<Self::TargetChain>,
        end_height: Option<&HeightOf<Self::TargetChain>>,
    ) -> Result<(), Self::Error>;
}
```

If the `end_height` is `None`, then the relayer would go on indefinitely for future block events.

## Default Relay Preset

The default relay preset now uses the poll-based event relayer instead of the push-based relayer that uses `Subscription`.

## Removal of Packet Clearing and Push-based Event Relayer

All pushed-based event relayer code and packet clearing code will be removed in subsequent PR, once we migrate to use the poll-based Event relayer on ibc-starknet.

We will also have a separate PR to add CLI commands for event-based relaying with height range, so that relayer operators can clear packets by providing specific range of heights to relay.