### PR TITLE
Use `#[cgp_context]` to simplify delegation of providers to Cosmos context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cgp"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "cgp-async"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -462,12 +462,12 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 
 [[package]]
 name = "cgp-component-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-component-macro-lib",
  "syn 2.0.96",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "itertools 0.14.0",
  "prettyplease",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "cgp-core"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "cgp-error"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-core",
 ]
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-error-extra",
  "cgp-inner",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "cgp-field"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "cgp-inner"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "cgp-runtime"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-core",
 ]
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "cgp-sync"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-async-macro",
 ]
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "cgp-type"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#7f969635b24c1aa7fb518bbdd2a46624c0fa751c"
+source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cgp"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "cgp-async"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -462,12 +462,12 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 
 [[package]]
 name = "cgp-component-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-component-macro-lib",
  "syn 2.0.96",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "itertools 0.14.0",
  "prettyplease",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "cgp-core"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "cgp-error"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-core",
 ]
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-error-extra",
  "cgp-inner",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "cgp-field"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "cgp-inner"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "cgp-runtime"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-core",
 ]
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "cgp-sync"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-async-macro",
 ]
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "cgp-type"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git?branch=cgp-context#bd59056b44a8ef8acbd7e486de7137c5aeb351c5"
+source = "git+https://github.com/contextgeneric/cgp.git#0493db7328fafbad9c693e554aba7fd1594c9a5b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,24 +177,24 @@ hermes-ibc-token-transfer-components    = { version = "0.1.0" }
 hermes-ibc-mock-chain                   = { version = "0.1.0" }
 
 [patch.crates-io]
-cgp                         = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-core                    = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-extra                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-async                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-async-macro             = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-component               = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-component-macro         = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-component-macro-lib     = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-type                    = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-field                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-field-macro             = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-field-macro-lib         = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-error                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-error-extra             = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-run                     = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-runtime                 = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-sync                    = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
-cgp-inner                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp                         = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-core                    = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-extra                   = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-async                   = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-async-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-component               = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-component-macro         = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-component-macro-lib     = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-type                    = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-field                   = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-field-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-field-macro-lib         = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-error                   = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-error-extra             = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-run                     = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-runtime                 = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-sync                    = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp-inner                   = { git = "https://github.com/contextgeneric/cgp.git" }
 
 hermes-chain-components             = { path = "./crates/chain/chain-components" }
 hermes-chain-type-components        = { path = "./crates/chain/chain-type-components" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,24 +177,24 @@ hermes-ibc-token-transfer-components    = { version = "0.1.0" }
 hermes-ibc-mock-chain                   = { version = "0.1.0" }
 
 [patch.crates-io]
-cgp                         = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-core                    = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-extra                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-async                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-async-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-component               = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-component-macro         = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-component-macro-lib     = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-type                    = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-field                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-field-macro             = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-field-macro-lib         = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-error                   = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-error-extra             = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-run                     = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-runtime                 = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-sync                    = { git = "https://github.com/contextgeneric/cgp.git" }
-cgp-inner                   = { git = "https://github.com/contextgeneric/cgp.git" }
+cgp                         = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-core                    = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-extra                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-async                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-async-macro             = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-component               = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-component-macro         = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-component-macro-lib     = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-type                    = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-field                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-field-macro             = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-field-macro-lib         = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-error                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-error-extra             = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-run                     = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-runtime                 = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-sync                    = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
+cgp-inner                   = { git = "https://github.com/contextgeneric/cgp.git", branch = "cgp-context" }
 
 hermes-chain-components             = { path = "./crates/chain/chain-components" }
 hermes-chain-type-components        = { path = "./crates/chain/chain-type-components" }

--- a/crates/cosmos/cosmos-relayer/src/contexts/birelay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/birelay.rs
@@ -18,31 +18,12 @@ use crate::contexts::chain::CosmosChain;
 use crate::contexts::relay::CosmosRelay;
 use crate::impls::error::HandleCosmosError;
 
+#[cgp_context(CosmosBiRelayComponents: DefaultBiRelayComponents)]
 #[derive(HasField, Clone)]
 pub struct CosmosBiRelay {
     pub runtime: HermesRuntime,
     pub relay_a_to_b: CosmosRelay,
     pub relay_b_to_a: CosmosRelay,
-}
-
-pub struct CosmosBiRelayComponents;
-
-impl HasComponents for CosmosBiRelay {
-    type Components = CosmosBiRelayComponents;
-}
-
-impl<Component> DelegateComponent<Component> for CosmosBiRelayComponents
-where
-    Self: IsDefaultBiRelayComponents<Component>,
-{
-    type Delegate = DefaultBiRelayComponents;
-}
-
-impl<Name, Context, Params> IsProviderFor<Name, Context, Params> for CosmosBiRelayComponents
-where
-    Self: IsDefaultBiRelayComponents<Name>,
-    DefaultBiRelayComponents: IsProviderFor<Name, Context, Params>,
-{
 }
 
 delegate_components! {

--- a/crates/cosmos/cosmos-relayer/src/contexts/build.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/build.rs
@@ -37,7 +37,9 @@ use hermes_relayer_components_extra::build::traits::cache::{
 use hermes_relayer_components_extra::build::traits::relay_with_batch_builder::{
     RelayWithBatchBuilder, RelayWithBatchBuilderComponent,
 };
-use hermes_relayer_components_extra::components::extra::build::*;
+use hermes_relayer_components_extra::components::extra::build::{
+    ChainBuilderComponent, ExtraBuildComponents, IsExtraBuildComponents,
+};
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{RuntimeGetterComponent, RuntimeTypeComponent};
 use ibc::core::host::types::identifiers::{ChainId, ClientId};
@@ -50,6 +52,10 @@ use crate::contexts::relay::CosmosRelay;
 use crate::impls::error::HandleCosmosError;
 use crate::types::telemetry::CosmosTelemetry;
 
+#[cgp_context(
+    CosmosBuildComponents:
+        ExtraBuildComponents<CosmosBaseBuildComponents>
+)]
 #[derive(Clone)]
 pub struct CosmosBuilder {
     pub fields: Arc<dyn HasCosmosBuilderFields>,
@@ -86,31 +92,7 @@ impl HasCosmosBuilderFields for CosmosBuilderFields {
     }
 }
 
-pub struct CosmosBuildComponents;
-
 pub struct CosmosBaseBuildComponents;
-
-impl HasComponents for CosmosBuilder {
-    type Components = CosmosBuildComponents;
-}
-
-impl HasComponents for CosmosBuildComponents {
-    type Components = CosmosBaseBuildComponents;
-}
-
-impl<Name> DelegateComponent<Name> for CosmosBuildComponents
-where
-    Self: IsExtraBuildComponents<Name>,
-{
-    type Delegate = ExtraBuildComponents<CosmosBaseBuildComponents>;
-}
-
-impl<Name, Context, Params> IsProviderFor<Name, Context, Params> for CosmosBuildComponents
-where
-    Self: IsExtraBuildComponents<Name>,
-    ExtraBuildComponents<CosmosBaseBuildComponents>: IsProviderFor<Name, Context, Params>,
-{
-}
 
 delegate_components! {
     CosmosBuildComponents {

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -14,6 +14,7 @@ use hermes_chain_type_components::traits::fields::chain_id::ChainIdGetterCompone
 use hermes_chain_type_components::traits::fields::message_response_events::HasMessageResponseEvents;
 use hermes_chain_type_components::traits::types::event::HasEventType;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
+use hermes_cosmos_chain_components::components::client::ChainStatusQuerierComponent;
 use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
 use hermes_cosmos_chain_components::components::delegate::DelegateCosmosChainComponents;
 use hermes_cosmos_chain_components::impls::types::config::{CosmosChainConfig, EventSourceMode};
@@ -138,9 +139,10 @@ use tendermint_rpc::{HttpClient, Url, WebSocketClientUrl};
 use crate::contexts::encoding::ProvideCosmosEncoding;
 use crate::impls::error::HandleCosmosError;
 use crate::impls::subscription::CanCreateAbciEventSubscription;
-use crate::presets::chain::*;
+use crate::presets::chain::{CosmosChainFullPreset, IsCosmosChainFullPreset};
 use crate::types::telemetry::CosmosTelemetry;
 
+#[cgp_context(CosmosChainContextComponents: CosmosChainFullPreset)]
 #[derive(Clone)]
 pub struct CosmosChain {
     pub base_chain: Arc<BaseCosmosChain>,
@@ -167,12 +169,6 @@ impl Deref for CosmosChain {
     fn deref(&self) -> &BaseCosmosChain {
         &self.base_chain
     }
-}
-
-pub struct CosmosChainContextComponents;
-
-impl HasComponents for CosmosChain {
-    type Components = CosmosChainContextComponents;
 }
 
 delegate_components! {
@@ -203,20 +199,6 @@ delegate_components! {
         ]:
             WasmChainComponents,
     }
-}
-
-impl<Name> DelegateComponent<Name> for CosmosChainContextComponents
-where
-    Self: IsCosmosChainFullPreset<Name>,
-{
-    type Delegate = CosmosChainFullPreset;
-}
-
-impl<Name, Context, Params> IsProviderFor<Name, Context, Params> for CosmosChainContextComponents
-where
-    Self: IsCosmosChainFullPreset<Name>,
-    CosmosChainFullPreset: IsProviderFor<Name, Context, Params>,
-{
 }
 
 delegate_components! {

--- a/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/encoding.rs
@@ -1,6 +1,8 @@
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
 use cgp::prelude::*;
-use hermes_cosmos_chain_components::encoding::components::*;
+use hermes_cosmos_chain_components::encoding::components::{
+    CosmosClientEncodingComponents, IsCosmosClientEncodingComponents,
+};
 use hermes_cosmos_chain_components::types::tendermint::{
     TendermintClientState, TendermintConsensusState,
 };
@@ -27,23 +29,8 @@ use prost_types::Any;
 
 use crate::impls::error::HandleCosmosError;
 
+#[cgp_context(CosmosEncodingContextComponents: CosmosClientEncodingComponents)]
 pub struct CosmosEncoding;
-
-pub struct CosmosEncodingContextComponents;
-
-impl HasComponents for CosmosEncoding {
-    type Components = CosmosEncodingContextComponents;
-}
-
-with_cosmos_client_encoding_components! {
-    | Components | {
-        delegate_components! {
-            CosmosEncodingContextComponents {
-                Components: CosmosClientEncodingComponents,
-            }
-        }
-    }
-}
 
 delegate_components! {
     CosmosEncodingContextComponents {

--- a/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/relay.rs
@@ -44,6 +44,7 @@ use ibc::core::host::types::identifiers::ClientId;
 use crate::contexts::chain::CosmosChain;
 use crate::impls::error::HandleCosmosError;
 
+#[cgp_context(CosmosRelayComponents: ExtraRelayPreset)]
 #[derive(Clone)]
 pub struct CosmosRelay {
     pub fields: Arc<dyn HasCosmosRelayFields>,
@@ -106,8 +107,6 @@ impl CosmosRelay {
     }
 }
 
-pub struct CosmosRelayComponents;
-
 delegate_components! {
     CosmosRelayComponents {
         [
@@ -155,24 +154,6 @@ delegate_components! {
         ]:
             SelectRelayAToB,
     }
-}
-
-impl<Name> DelegateComponent<Name> for CosmosRelayComponents
-where
-    Self: IsExtraRelayPreset<Name>,
-{
-    type Delegate = ExtraRelayPreset;
-}
-
-impl<Name, Context, Params> IsProviderFor<Name, Context, Params> for CosmosRelayComponents
-where
-    Self: IsExtraRelayPreset<Name>,
-    ExtraRelayPreset: IsProviderFor<Name, Context, Params>,
-{
-}
-
-impl HasComponents for CosmosRelay {
-    type Components = CosmosRelayComponents;
 }
 
 pub trait CanUseCosmosRelay:


### PR DESCRIPTION
This is a short PR to simplify the definition of Cosmos contexts using the `#[cgp_context]` macro introduced in https://github.com/contextgeneric/cgp/pull/66.