### PR TITLE
refactor: allow to return `None` if packet commitment not found

### DIFF
--- a/crates/chain/chain-components/src/traits/queries/packet_commitment.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_commitment.rs
@@ -27,5 +27,5 @@ pub trait CanQueryPacketCommitment<Counterparty>:
         port_id: &Self::PortId,
         sequence: &Self::Sequence,
         height: &Self::Height,
-    ) -> Result<(Self::PacketCommitment, Self::CommitmentProof), Self::Error>;
+    ) -> Result<(Option<Self::PacketCommitment>, Self::CommitmentProof), Self::Error>;
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_commitment.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_commitment.rs
@@ -30,7 +30,7 @@ where
         port_id: &Chain::PortId,
         sequence: &Chain::Sequence,
         height: &Chain::Height,
-    ) -> Result<(Chain::PacketCommitment, Chain::CommitmentProof), Chain::Error> {
+    ) -> Result<(Option<Chain::PacketCommitment>, Chain::CommitmentProof), Chain::Error> {
         let commitment_path =
             format!("commitments/ports/{port_id}/channels/{channel_id}/sequences/{sequence}");
 
@@ -38,6 +38,6 @@ where
             .query_abci_with_proofs(IBC_QUERY_PATH, commitment_path.as_bytes(), height)
             .await?;
 
-        Ok((commitment, proof))
+        Ok((Some(commitment), proof))
     }
 }


### PR DESCRIPTION
Needed for https://github.com/informalsystems/ibc-starknet/pull/297

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
