### PR TITLE
Return `Option` in ABCI query

### DIFF
--- a/crates/cli/cli/src/commands/query/channel/ends.rs
+++ b/crates/cli/cli/src/commands/query/channel/ends.rs
@@ -99,7 +99,10 @@ impl CommandRunner<HermesApp> for QueryChannelEnds {
 
         let channel_end_bytes: Vec<u8> = chain
             .query_abci(IBC_QUERY_PATH, channel_end_path.as_bytes(), &query_height)
-            .await?;
+            .await?
+            .ok_or_else(|| {
+                HermesApp::raise_error(format!("channel not found: {channel_id}/{port_id}"))
+            })?;
 
         let channel_end = ChannelEnd::decode_vec(&channel_end_bytes)?;
 
@@ -134,7 +137,10 @@ impl CommandRunner<HermesApp> for QueryChannelEnds {
 
         let client_state_bytes = chain
             .query_abci(IBC_QUERY_PATH, client_state_path.as_bytes(), &query_height)
-            .await?;
+            .await?
+            .ok_or_else(|| {
+                HermesApp::raise_error(format!("client state not found: {client_id}"))
+            })?;
 
         let any_client_state = Any {
             type_url: TENDERMINT_CLIENT_STATE_TYPE_URL.to_owned(),

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/abci.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/abci.rs
@@ -48,7 +48,7 @@ where
         path: &str,
         data: &[u8],
         height: &Height,
-    ) -> Result<Vec<u8>, Chain::Error> {
+    ) -> Result<Option<Vec<u8>>, Chain::Error> {
         let tm_height =
             TendermintHeight::try_from(height.revision_height()).map_err(Chain::raise_error)?;
         let response = chain
@@ -61,7 +61,11 @@ where
             return Err(Chain::raise_error(AbciQueryError { response }));
         }
 
-        Ok(response.value)
+        if response.value.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(response.value))
+        }
     }
 
     async fn query_abci_with_proofs(
@@ -69,7 +73,7 @@ where
         path: &str,
         data: &[u8],
         query_height: &Height,
-    ) -> Result<(Vec<u8>, Chain::CommitmentProof), Chain::Error> {
+    ) -> Result<(Option<Vec<u8>>, Chain::CommitmentProof), Chain::Error> {
         let tm_height = TendermintHeight::try_from(query_height.revision_height())
             .map_err(Chain::raise_error)?;
         let response = chain
@@ -102,7 +106,11 @@ where
             proof_height,
         };
 
-        Ok((response.value, commitment_proof))
+        if response.value.is_empty() {
+            Ok((None, commitment_proof))
+        } else {
+            Ok((Some(response.value), commitment_proof))
+        }
     }
 }
 

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/chain_id.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/chain_id.rs
@@ -50,7 +50,10 @@ where
 
         let channel_end_bytes = chain
             .query_abci(IBC_QUERY_PATH, channel_end_path.as_bytes(), &latest_height)
-            .await?;
+            .await?
+            .ok_or_else(|| {
+                Chain::raise_error(format!("channel not found: {channel_id}/{port_id}"))
+            })?;
 
         let channel_end = ChannelEnd::decode_vec(&channel_end_bytes).map_err(Chain::raise_error)?;
 
@@ -73,7 +76,8 @@ where
 
         let connnection_end_bytes = chain
             .query_abci(IBC_QUERY_PATH, connection_path.as_bytes(), &latest_height)
-            .await?;
+            .await?
+            .ok_or_else(|| Chain::raise_error(format!("connection not found: {connection_id}")))?;
 
         let connection_end =
             ConnectionEnd::decode_vec(&connnection_end_bytes).map_err(Chain::raise_error)?;

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/consensus_state.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/consensus_state.rs
@@ -24,6 +24,7 @@ where
     Chain: HasIbcChainTypes<Counterparty, ClientId = ClientId, Height = Height>
         + HasRawConsensusStateType<RawConsensusState = Any>
         + CanQueryAbci
+        + CanRaiseAsyncError<String>
         + CanRaiseAsyncError<DecodeError>,
     Counterparty: HasHeightFields,
 {
@@ -45,7 +46,8 @@ where
                 consensus_state_path.as_bytes(),
                 query_height,
             )
-            .await?;
+            .await?
+            .ok_or_else(|| Chain::raise_error(format!("consensus state not found: {client_id}")))?;
 
         let consensus_state_any =
             Message::decode(consensus_state_bytes.as_ref()).map_err(Chain::raise_error)?;
@@ -62,6 +64,7 @@ where
         + HasRawConsensusStateType<RawConsensusState = Any>
         + HasCommitmentProofType
         + CanQueryAbci
+        + CanRaiseAsyncError<String>
         + CanRaiseAsyncError<DecodeError>,
     Counterparty: HasHeightFields,
 {
@@ -84,6 +87,9 @@ where
                 query_height,
             )
             .await?;
+
+        let consensus_state_bytes = consensus_state_bytes
+            .ok_or_else(|| Chain::raise_error(format!("consensus state not found: {client_id}")))?;
 
         let consensus_state_any =
             Message::decode(consensus_state_bytes.as_ref()).map_err(Chain::raise_error)?;

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_acknowledgement.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_acknowledgement.rs
@@ -21,7 +21,7 @@ where
         + HasAcknowledgementType<Counterparty, Acknowledgement = Vec<u8>>
         + HasCommitmentProofType
         + CanQueryAbci
-        + HasAsyncErrorType,
+        + CanRaiseAsyncError<String>,
     Counterparty: HasIbcChainTypes<Chain>,
     Chain::ChannelId: Display,
 {
@@ -37,6 +37,8 @@ where
         let (ack, proof) = chain
             .query_abci_with_proofs(IBC_QUERY_PATH, ack_path.as_bytes(), height)
             .await?;
+
+        let ack = ack.ok_or_else(|| Chain::raise_error(format!("ack not found at: {ack_path}")))?;
 
         Ok((ack, proof))
     }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_commitment.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_commitment.rs
@@ -38,6 +38,6 @@ where
             .query_abci_with_proofs(IBC_QUERY_PATH, commitment_path.as_bytes(), height)
             .await?;
 
-        Ok((Some(commitment), proof))
+        Ok((commitment, proof))
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/received_ack.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/received_ack.rs
@@ -42,6 +42,6 @@ where
 
         // Once a packet has been cleared, the chain would have removed its packet commitment
 
-        Ok(commitment.is_empty())
+        Ok(commitment.is_none())
     }
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/unbonding_period.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/unbonding_period.rs
@@ -31,7 +31,8 @@ where
                 &"".to_owned().into_bytes(),
                 &latest_height,
             )
-            .await?;
+            .await?
+            .ok_or_else(|| Chain::raise_error("failed to query for staking params"))?;
 
         let query_staking_params: QueryParamsResponse =
             QueryParamsResponse::decode(query_staking_params_bytes.as_ref())

--- a/crates/cosmos/cosmos-chain-components/src/traits/abci_query.rs
+++ b/crates/cosmos/cosmos-chain-components/src/traits/abci_query.rs
@@ -13,12 +13,12 @@ pub trait CanQueryAbci: HasHeightType + HasCommitmentProofType + HasAsyncErrorTy
         path: &str,
         data: &[u8],
         height: &Self::Height,
-    ) -> Result<Vec<u8>, Self::Error>;
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
 
     async fn query_abci_with_proofs(
         &self,
         path: &str,
         data: &[u8],
         height: &Self::Height,
-    ) -> Result<(Vec<u8>, Self::CommitmentProof), Self::Error>;
+    ) -> Result<(Option<Vec<u8>>, Self::CommitmentProof), Self::Error>;
 }


### PR DESCRIPTION
Due to the quirks of Golang, the ABCI query actually returns empty bytes when a given path is not found in the Merkle store of a Cosmos chain. Currently, when an entry like client state is not found, the relayer would just fail with a confusing error message of failing to decode the empty bytes.

This PR fixes the issue by making the ABCI querier return an `Option<Vec<u8>>`, with `None` returned if empty bytes are returned from the full node.