### PR TITLE
Update `query_packet_receipt` to return `Option<Chain::PacketReceipt>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ version = "0.1.0"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
+ "hermes-logging-components",
  "hermes-relayer-components",
  "hermes-relayer-components-extra",
  "hermes-runtime-components",

--- a/crates/chain/chain-components/src/impls/payload_builders/packet.rs
+++ b/crates/chain/chain-components/src/impls/payload_builders/packet.rs
@@ -1,5 +1,9 @@
+use core::fmt::Debug;
+
 use cgp::prelude::*;
 use hermes_chain_type_components::traits::fields::height::CanIncrementHeight;
+use hermes_chain_type_components::traits::types::height::HasHeightType;
+use hermes_chain_type_components::traits::types::ibc::packet::HasOutgoingPacketType;
 
 use crate::traits::packet::fields::{
     HasPacketDstChannelId, HasPacketDstPortId, HasPacketSequence, HasPacketSrcChannelId,
@@ -129,7 +133,7 @@ where
         + CanQueryPacketReceipt<Counterparty>
         + HasCommitmentProofHeight
         + HasCommitmentProofType
-        + HasAsyncErrorType,
+        + for<'a> CanRaiseAsyncError<InvalidTimeoutReceipt<'a, Chain, Counterparty>>,
     Counterparty:
         HasPacketDstChannelId<Chain> + HasPacketDstPortId<Chain> + HasPacketSequence<Chain>,
 {
@@ -139,7 +143,7 @@ where
         height: &Chain::Height,
         packet: &Counterparty::OutgoingPacket,
     ) -> Result<TimeoutUnorderedPacketPayload<Chain>, Chain::Error> {
-        let (_, proof_unreceived) = chain
+        let (receipt, proof_unreceived) = chain
             .query_packet_receipt(
                 &Counterparty::packet_dst_channel_id(packet),
                 &Counterparty::packet_dst_port_id(packet),
@@ -148,7 +152,13 @@ where
             )
             .await?;
 
-        // TODO: validate packet receipt
+        if receipt.is_some() {
+            return Err(Chain::raise_error(InvalidTimeoutReceipt {
+                chain,
+                height,
+                packet,
+            }));
+        }
 
         // TODO: check that all commitment proof heights are the same
         let update_height = Chain::commitment_proof_height(&proof_unreceived).clone();
@@ -159,5 +169,34 @@ where
         };
 
         Ok(payload)
+    }
+}
+
+pub struct InvalidTimeoutReceipt<'a, Chain, Counterparty>
+where
+    Chain: HasHeightType,
+    Counterparty: HasOutgoingPacketType<Chain>,
+{
+    pub chain: &'a Chain,
+    pub height: &'a Chain::Height,
+    pub packet: &'a Counterparty::OutgoingPacket,
+}
+
+impl<Chain, Counterparty> Debug for InvalidTimeoutReceipt<'_, Chain, Counterparty>
+where
+    Chain: HasHeightType,
+    Counterparty: HasOutgoingPacketType<Chain>
+        + HasPacketDstChannelId<Chain>
+        + HasPacketDstPortId<Chain>
+        + HasPacketSequence<Chain>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f,
+            "cannot construct a timeout packet payload as a packet receipt exists at height {} for packet {}/{}/{}",
+            self.height,
+            Counterparty::packet_dst_channel_id(self.packet),
+            Counterparty::packet_dst_port_id(self.packet),
+            Counterparty::packet_sequence(self.packet),
+        )
     }
 }

--- a/crates/chain/chain-components/src/traits/queries/packet_receipt.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_receipt.rs
@@ -29,5 +29,5 @@ pub trait CanQueryPacketReceipt<Counterparty>:
         port_id: &Self::PortId,
         sequence: &SequenceOf<Counterparty, Self>,
         height: &Self::Height,
-    ) -> Result<(Self::PacketReceipt, Self::CommitmentProof), Self::Error>;
+    ) -> Result<(Option<Self::PacketReceipt>, Self::CommitmentProof), Self::Error>;
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_receipt.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_receipt.rs
@@ -27,17 +27,13 @@ where
         port_id: &Chain::PortId,
         sequence: &Counterparty::Sequence,
         height: &Chain::Height,
-    ) -> Result<(Chain::PacketReceipt, Chain::CommitmentProof), Chain::Error> {
+    ) -> Result<(Option<Chain::PacketReceipt>, Chain::CommitmentProof), Chain::Error> {
         let receipt_path =
             format!("receipts/ports/{port_id}/channels/{channel_id}/sequences/{sequence}");
 
         let (receipt, proof) = chain
             .query_abci_with_proofs(IBC_QUERY_PATH, receipt_path.as_bytes(), height)
             .await?;
-
-        let receipt = receipt.ok_or_else(|| {
-            Chain::raise_error(format!("packet receipt not found at: {receipt_path}"))
-        })?;
 
         // TODO: Use a more precise `PacketReceipt` type, i.e. `bool`
 

--- a/crates/cosmos/cosmos-relayer/src/impls/error.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/error.rs
@@ -28,12 +28,14 @@ use hermes_protobuf_encoding_components::impls::encode_mut::chunk::{
     InvalidWireType, UnsupportedWireType,
 };
 use hermes_protobuf_encoding_components::impls::encode_mut::proto_field::decode_required::RequiredFieldTagNotFound;
+use hermes_relayer_components::chain::impls::payload_builders::packet::InvalidTimeoutReceipt;
 use hermes_relayer_components::chain::impls::queries::consensus_state_height::NoConsensusStateAtLessThanHeight;
 use hermes_relayer_components::chain::traits::queries::connection_end::ConnectionNotFoundError;
 use hermes_relayer_components::chain::traits::send_message::EmptyMessageResponse;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
 use hermes_relayer_components::error::impls::error::{
     MaxRetryExceededError, UnwrapMaxRetryExceededError,
 };
@@ -166,6 +168,8 @@ delegate_components! {
                 MissingCreateClientEventError<'a, Chain, Counterparty>,
             <'a, Chain: HasIbcChainTypes<Counterparty>, Counterparty>
                 ConnectionNotFoundError<'a, Chain, Counterparty>,
+            <'a, Chain: HasHeightType, Counterparty: HasOutgoingPacketType<Chain>>
+                InvalidTimeoutReceipt<'a, Chain, Counterparty>,
             <'a, Chain>
                 ProposalFailed<'a, Chain>,
             <'a, Relay>

--- a/crates/relayer/relayer-components/src/relay/impls/auto_relayers/poll_event.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/auto_relayers/poll_event.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::format;
 use core::marker::PhantomData;
 
 use cgp::core::error::ErrorOf;
@@ -7,6 +8,9 @@ use hermes_chain_components::traits::queries::block_events::CanQueryBlockEvents;
 use hermes_chain_components::traits::types::event::HasEventType;
 use hermes_chain_components::traits::types::height::CanIncrementHeight;
 use hermes_chain_components::types::aliases::{EventOf, HeightOf};
+use hermes_logging_components::traits::has_logger::HasLogger;
+use hermes_logging_components::traits::logger::CanLog;
+use hermes_logging_components::types::level::{LevelInfo, LevelTrace};
 use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_runtime_components::traits::task::{CanRunConcurrentTasks, Task};
 
@@ -22,11 +26,13 @@ where
     Relay: Clone
         + HasRuntime
         + HasTargetChains<Target>
+        + HasLogger
         + CanRelayEvent<Target>
         + CanRaiseAsyncError<ErrorOf<Relay::TargetChain>>,
     Target: RelayTarget,
     Relay::TargetChain: CanIncrementHeight + CanQueryBlockEvents,
     Relay::Runtime: CanRunConcurrentTasks,
+    Relay::Logger: CanLog<LevelInfo> + CanLog<LevelTrace>,
 {
     async fn auto_relay_with_heights(
         relay: &Relay,
@@ -39,11 +45,27 @@ where
 
         let mut height = start_height.clone();
 
+        relay
+            .logger()
+            .log(
+                &format!("Will start relaying at height `{height}`"),
+                &LevelInfo,
+            )
+            .await;
+
         loop {
             let events = chain
                 .query_block_events(&height)
                 .await
                 .map_err(Relay::raise_error)?;
+
+            relay
+                .logger()
+                .log(
+                    &format!("Queried {} events at height `{height}`", events.len()),
+                    &LevelTrace,
+                )
+                .await;
 
             let tasks = events
                 .into_iter()
@@ -62,6 +84,13 @@ where
 
             if let Some(end_height) = end_height {
                 if &height > end_height {
+                    relay
+                        .logger()
+                        .log(
+                            &format!("Done clearing packets at height `{height}`"),
+                            &LevelInfo,
+                        )
+                        .await;
                     return Ok(());
                 }
             }

--- a/crates/test/test-components/Cargo.toml
+++ b/crates/test/test-components/Cargo.toml
@@ -17,3 +17,4 @@ hermes-runtime-components           = { workspace = true }
 hermes-chain-type-components        = { workspace = true }
 hermes-relayer-components           = { workspace = true }
 hermes-relayer-components-extra     = { workspace = true }
+hermes-logging-components           = { workspace = true }

--- a/crates/test/test-components/src/chain/impls/assert/poll_assert_eventual_amount.rs
+++ b/crates/test/test-components/src/chain/impls/assert/poll_assert_eventual_amount.rs
@@ -1,7 +1,11 @@
+use alloc::format;
 use core::fmt::Debug;
 use core::time::Duration;
 
 use cgp::prelude::*;
+use hermes_logging_components::traits::has_logger::HasLogger;
+use hermes_logging_components::traits::logger::CanLog;
+use hermes_logging_components::types::level::LevelError;
 use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_runtime_components::traits::sleep::CanSleep;
 
@@ -21,8 +25,10 @@ where
     Chain: HasRuntime
         + HasPollAssertDuration
         + CanQueryBalance
+        + HasLogger
         + for<'a> CanRaiseAsyncError<EventualAmountTimeoutError<'a, Chain>>,
     Chain::Runtime: CanSleep,
+    Chain::Logger: CanLog<LevelError>,
 {
     async fn assert_eventual_amount(
         chain: &Chain,
@@ -47,6 +53,16 @@ where
                 }
             };
         }
+
+        let final_balance = chain.query_balance(address, denom).await?;
+
+        chain
+            .logger()
+            .log(
+                &format!("Expected balance `{amount}`, found `{final_balance}`"),
+                &LevelError,
+            )
+            .await;
 
         Err(Chain::raise_error(EventualAmountTimeoutError {
             chain,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

Following https://github.com/informalsystems/hermes-sdk/pull/544 this PR changes `query_packet_receipt` to return `Option<Chain::PacketReceipt>`.

This PR also adds logs for:
* Auto relaying
* Eventual balance assertion failure

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
