### PR TITLE
Make `query_packet_receipt` return `Option` to work with timeout packet proofs

### DIFF
--- a/crates/chain/chain-components/src/impls/payload_builders/packet.rs
+++ b/crates/chain/chain-components/src/impls/payload_builders/packet.rs
@@ -182,7 +182,7 @@ where
     pub packet: &'a Counterparty::OutgoingPacket,
 }
 
-impl<'a, Chain, Counterparty> Debug for InvalidTimeoutReceipt<'a, Chain, Counterparty>
+impl<Chain, Counterparty> Debug for InvalidTimeoutReceipt<'_, Chain, Counterparty>
 where
     Chain: HasHeightType,
     Counterparty: HasOutgoingPacketType<Chain>

--- a/crates/chain/chain-components/src/traits/queries/packet_receipt.rs
+++ b/crates/chain/chain-components/src/traits/queries/packet_receipt.rs
@@ -29,5 +29,5 @@ pub trait CanQueryPacketReceipt<Counterparty>:
         port_id: &Self::PortId,
         sequence: &SequenceOf<Counterparty, Self>,
         height: &Self::Height,
-    ) -> Result<(Self::PacketReceipt, Self::CommitmentProof), Self::Error>;
+    ) -> Result<(Option<Self::PacketReceipt>, Self::CommitmentProof), Self::Error>;
 }

--- a/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_receipt.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/queries/packet_receipt.rs
@@ -27,17 +27,13 @@ where
         port_id: &Chain::PortId,
         sequence: &Counterparty::Sequence,
         height: &Chain::Height,
-    ) -> Result<(Chain::PacketReceipt, Chain::CommitmentProof), Chain::Error> {
+    ) -> Result<(Option<Chain::PacketReceipt>, Chain::CommitmentProof), Chain::Error> {
         let receipt_path =
             format!("receipts/ports/{port_id}/channels/{channel_id}/sequences/{sequence}");
 
         let (receipt, proof) = chain
             .query_abci_with_proofs(IBC_QUERY_PATH, receipt_path.as_bytes(), height)
             .await?;
-
-        let receipt = receipt.ok_or_else(|| {
-            Chain::raise_error(format!("packet receipt not found at: {receipt_path}"))
-        })?;
 
         // TODO: Use a more precise `PacketReceipt` type, i.e. `bool`
 

--- a/crates/cosmos/cosmos-relayer/src/impls/error.rs
+++ b/crates/cosmos/cosmos-relayer/src/impls/error.rs
@@ -28,12 +28,14 @@ use hermes_protobuf_encoding_components::impls::encode_mut::chunk::{
     InvalidWireType, UnsupportedWireType,
 };
 use hermes_protobuf_encoding_components::impls::encode_mut::proto_field::decode_required::RequiredFieldTagNotFound;
+use hermes_relayer_components::chain::impls::payload_builders::packet::InvalidTimeoutReceipt;
 use hermes_relayer_components::chain::impls::queries::consensus_state_height::NoConsensusStateAtLessThanHeight;
 use hermes_relayer_components::chain::traits::queries::connection_end::ConnectionNotFoundError;
 use hermes_relayer_components::chain::traits::send_message::EmptyMessageResponse;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainIdType;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
 use hermes_relayer_components::error::impls::error::{
     MaxRetryExceededError, UnwrapMaxRetryExceededError,
 };
@@ -166,6 +168,8 @@ delegate_components! {
                 MissingCreateClientEventError<'a, Chain, Counterparty>,
             <'a, Chain: HasIbcChainTypes<Counterparty>, Counterparty>
                 ConnectionNotFoundError<'a, Chain, Counterparty>,
+            <'a, Chain: HasHeightType, Counterparty: HasOutgoingPacketType<Chain>>
+                InvalidTimeoutReceipt<'a, Chain, Counterparty>,
             <'a, Chain>
                 ProposalFailed<'a, Chain>,
             <'a, Relay>


### PR DESCRIPTION
Fixes: https://github.com/informalsystems/ibc-starknet/pull/325