### PR TITLE
Use new check_components! macro to check for implementation of Cosmos…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cgp"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "cgp-async"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -462,12 +462,12 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 
 [[package]]
 name = "cgp-component-macro"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-component-macro-lib",
  "syn 2.0.98",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro-lib"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "cgp-core"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "cgp-error"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-extra"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-core",
 ]
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-error-extra",
  "cgp-inner",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "cgp-field"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro-lib"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "cgp-inner"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "cgp-runtime"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-core",
 ]
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "cgp-sync"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-async-macro",
 ]
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "cgp-type"
 version = "0.4.0"
-source = "git+https://github.com/contextgeneric/cgp.git#1cae8d8d86620c975113495e22fe7ed59ad83245"
+source = "git+https://github.com/contextgeneric/cgp.git#a58b043ffd15dda3a5c84b3b4709292591d38e79"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -9,14 +9,13 @@ use cgp::prelude::*;
 use futures::lock::Mutex;
 use hermes_any_counterparty::contexts::any_counterparty::AnyCounterparty;
 use hermes_chain_type_components::traits::fields::chain_id::ChainIdGetterComponent;
-use hermes_chain_type_components::traits::fields::message_response_events::HasMessageResponseEvents;
+use hermes_chain_type_components::traits::fields::message_response_events::MessageResponseEventsGetterComponent;
 use hermes_chain_type_components::traits::types::event::HasEventType;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
 use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
 use hermes_cosmos_chain_components::components::delegate::DelegateCosmosChainComponents;
 use hermes_cosmos_chain_components::impls::types::config::CosmosChainConfig;
-use hermes_cosmos_chain_components::traits::convert_gas_to_fee::CanConvertGasToFee;
-use hermes_cosmos_chain_components::traits::eip::eip_query::CanQueryEipBaseFee;
+use hermes_cosmos_chain_components::traits::eip::eip_query::EipQuerierComponent;
 use hermes_cosmos_chain_components::traits::gas_config::{
     GasConfigGetter, GasConfigGetterComponent,
 };
@@ -29,10 +28,16 @@ use hermes_cosmos_chain_components::traits::rpc_client::{
 use hermes_cosmos_chain_components::traits::tx_extension_options::{
     TxExtensionOptionsGetter, TxExtensionOptionsGetterComponent,
 };
-use hermes_cosmos_chain_components::traits::unbonding_period::CanQueryUnbondingPeriod;
+use hermes_cosmos_chain_components::traits::unbonding_period::UnbondingPeriodQuerierComponent;
 use hermes_cosmos_chain_components::types::commitment_proof::CosmosCommitmentProof;
 use hermes_cosmos_chain_components::types::config::gas::gas_config::GasConfig;
+use hermes_cosmos_chain_components::types::events::channel::{
+    CosmosChannelOpenInitEvent, CosmosChannelOpenTryEvent,
+};
 use hermes_cosmos_chain_components::types::events::client::CosmosCreateClientEvent;
+use hermes_cosmos_chain_components::types::events::connection::{
+    CosmosConnectionOpenInitEvent, CosmosConnectionOpenTryEvent,
+};
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_cosmos_chain_components::types::messages::packet::packet_filter::PacketFilterConfig;
 use hermes_cosmos_chain_components::types::payloads::client::{
@@ -46,41 +51,40 @@ use hermes_logger::{HermesLogger, UseHermesLogger};
 use hermes_logging_components::traits::has_logger::{
     GlobalLoggerGetterComponent, LoggerGetterComponent, LoggerTypeProviderComponent,
 };
-use hermes_logging_components::traits::logger::CanLog;
+use hermes_logging_components::traits::logger::LoggerComponent;
 use hermes_relayer_components::chain::traits::commitment_prefix::{
-    HasCommitmentPrefixType, HasIbcCommitmentPrefix, IbcCommitmentPrefixGetter,
-    IbcCommitmentPrefixGetterComponent,
+    HasCommitmentPrefixType, IbcCommitmentPrefixGetter, IbcCommitmentPrefixGetterComponent,
 };
 use hermes_relayer_components::chain::traits::extract_data::{
-    CanExtractFromEvent, CanExtractFromMessageResponse,
+    CanExtractFromMessageResponse, EventExtractorComponent, MessageResponseExtractorComponent,
 };
-use hermes_relayer_components::chain::traits::message_builders::update_client::CanBuildUpdateClientMessage;
-use hermes_relayer_components::chain::traits::packet::fields::HasPacketSrcChannelId;
+use hermes_relayer_components::chain::traits::message_builders::create_client::CreateClientMessageBuilderComponent;
+use hermes_relayer_components::chain::traits::message_builders::update_client::UpdateClientMessageBuilderComponent;
 use hermes_relayer_components::chain::traits::packet::filter::{
-    CanFilterIncomingPacket, CanFilterOutgoingPacket,
+    IncomingPacketFilterComponent, OutgoingPacketFilterComponent,
 };
-use hermes_relayer_components::chain::traits::payload_builders::create_client::CanBuildCreateClientPayload;
+use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilderComponent;
+use hermes_relayer_components::chain::traits::payload_builders::update_client::UpdateClientPayloadBuilderComponent;
 use hermes_relayer_components::chain::traits::queries::block_events::BlockEventsQuerierComponent;
-use hermes_relayer_components::chain::traits::queries::block_time::{
-    BlockTimeQuerierComponent, CanQueryBlockTime,
-};
+use hermes_relayer_components::chain::traits::queries::block_time::BlockTimeQuerierComponent;
 use hermes_relayer_components::chain::traits::queries::chain_status::ChainStatusQuerierComponent;
 use hermes_relayer_components::chain::traits::queries::channel_end::{
-    CanQueryChannelEnd, CanQueryChannelEndWithProofs,
+    ChannelEndQuerierComponent, ChannelEndWithProofsQuerierComponent,
 };
 use hermes_relayer_components::chain::traits::queries::client_state::{
-    CanQueryAllClientStates, CanQueryClientState, CanQueryClientStateWithProofs,
+    AllClientStatesQuerierComponent, ClientStateQuerierComponent,
+    ClientStateWithProofsQuerierComponent, RawClientStateQuerierComponent,
 };
 use hermes_relayer_components::chain::traits::queries::connection_end::{
-    CanQueryConnectionEnd, CanQueryConnectionEndWithProofs,
+    ConnectionEndQuerierComponent, ConnectionEndWithProofsQuerierComponent,
 };
 use hermes_relayer_components::chain::traits::queries::consensus_state::{
-    CanQueryConsensusState, CanQueryConsensusStateWithProofs, CanQueryRawConsensusState,
+    ConsensusStateQuerierComponent, ConsensusStateWithProofsQuerierComponent,
 };
-use hermes_relayer_components::chain::traits::queries::packet_acknowledgement::CanQueryPacketAcknowledgement;
-use hermes_relayer_components::chain::traits::queries::packet_commitment::CanQueryPacketCommitment;
+use hermes_relayer_components::chain::traits::queries::packet_acknowledgement::PacketAcknowledgementQuerierComponent;
+use hermes_relayer_components::chain::traits::queries::packet_commitment::PacketCommitmentQuerierComponent;
 use hermes_relayer_components::chain::traits::queries::packet_is_cleared::PacketIsClearedQuerierComponent;
-use hermes_relayer_components::chain::traits::queries::packet_receipt::CanQueryPacketReceipt;
+use hermes_relayer_components::chain::traits::queries::packet_receipt::PacketReceiptQuerierComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::ChainIdGetter;
 use hermes_relayer_components::chain::traits::types::channel::HasChannelEndType;
 use hermes_relayer_components::chain::traits::types::client_state::{
@@ -90,7 +94,7 @@ use hermes_relayer_components::chain::traits::types::create_client::{
     HasCreateClientMessageOptionsType, HasCreateClientPayloadOptionsType,
     HasCreateClientPayloadType,
 };
-use hermes_relayer_components::chain::traits::types::ibc_events::send_packet::HasSendPacketEvent;
+use hermes_relayer_components::chain::traits::types::ibc_events::send_packet::SendPacketEventComponent;
 use hermes_relayer_components::chain::traits::types::proof::HasCommitmentProofType;
 use hermes_relayer_components::chain::traits::types::update_client::HasUpdateClientPayloadType;
 use hermes_relayer_components::error::traits::RetryableErrorComponent;
@@ -101,29 +105,27 @@ use hermes_relayer_components::transaction::traits::default_signer::{
     DefaultSignerGetter, DefaultSignerGetterComponent,
 };
 use hermes_relayer_components::transaction::traits::nonce::nonce_mutex::NonceAllocationMutexGetterComponent;
-use hermes_relayer_components::transaction::traits::poll_tx_response::CanPollTxResponse;
-use hermes_relayer_components::transaction::traits::query_tx_response::CanQueryTxResponse;
+use hermes_relayer_components::transaction::traits::poll_tx_response::TxResponsePollerComponent;
+use hermes_relayer_components::transaction::traits::query_tx_response::TxResponseQuerierComponent;
 use hermes_relayer_components::transaction::traits::simulation_fee::{
     FeeForSimulationGetter, FeeForSimulationGetterComponent,
 };
-use hermes_relayer_components::transaction::traits::submit_tx::CanSubmitTx;
+use hermes_relayer_components::transaction::traits::submit_tx::TxSubmitterComponent;
 use hermes_relayer_components_extra::telemetry::traits::telemetry::HasTelemetry;
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::{
     RuntimeGetterComponent, RuntimeTypeProviderComponent,
 };
-use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
-use hermes_test_components::chain::traits::messages::ibc_transfer::CanBuildIbcTokenTransferMessage;
-use hermes_test_components::chain::traits::proposal::messages::deposit::CanBuildDepositProposalMessage;
-use hermes_test_components::chain::traits::proposal::messages::vote::CanBuildVoteProposalMessage;
-use hermes_test_components::chain::traits::proposal::query_status::CanQueryProposalStatus;
-use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
-use hermes_test_components::chain::traits::transfer::ibc_transfer::CanIbcTransferToken;
+use hermes_test_components::chain::traits::assert::eventual_amount::EventualAmountAsserterComponent;
+use hermes_test_components::chain::traits::messages::ibc_transfer::{
+    CanBuildIbcTokenTransferMessage, IbcTokenTransferMessageBuilderComponent,
+};
+use hermes_test_components::chain::traits::proposal::query_status::ProposalStatusQuerierComponent;
+use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
+use hermes_test_components::chain::traits::transfer::ibc_transfer::TokenIbcTransferrerComponent;
 use hermes_wasm_test_components::components::WasmChainComponents;
 use hermes_wasm_test_components::traits::chain::messages::store_code::StoreCodeMessageBuilderComponent;
-use hermes_wasm_test_components::traits::chain::upload_client_code::{
-    CanUploadWasmClientCode, WasmClientCodeUploaderComponent,
-};
+use hermes_wasm_test_components::traits::chain::upload_client_code::WasmClientCodeUploaderComponent;
 use ibc::core::channel::types::channel::ChannelEnd;
 use ibc::core::host::types::identifiers::ChainId;
 use ibc_proto::cosmos::tx::v1beta1::Fee;
@@ -324,68 +326,100 @@ pub trait CanUseCosmosChain:
     + HasCreateClientPayloadOptionsType<
         CosmosChain,
         CreateClientPayloadOptions = CosmosCreateClientOptions,
-    > + CanQueryBalance
-    + HasCommitmentPrefixType<CommitmentPrefix = Vec<u8>>
-    + CanIbcTransferToken<CosmosChain>
-    + CanConvertGasToFee
-    + CanQueryEipBaseFee
-    + CanQueryUnbondingPeriod
+    > + HasCommitmentPrefixType<CommitmentPrefix = Vec<u8>>
     + CanBuildIbcTokenTransferMessage<CosmosChain>
-    + CanQueryClientState<CosmosChain>
-    + CanQueryClientStateWithProofs<CosmosChain>
-    + CanQueryConsensusState<CosmosChain>
-    + CanQueryConsensusStateWithProofs<CosmosChain>
-    + CanQueryRawConsensusState<CosmosChain>
-    + CanQueryAllClientStates<CosmosChain>
-    + CanQueryClientState<AnyCounterparty>
-    + CanQueryConsensusState<AnyCounterparty>
-    + CanQueryAllClientStates<AnyCounterparty>
-    + CanBuildUpdateClientMessage<CosmosChain>
-    + CanQueryConnectionEnd<CosmosChain>
-    + CanQueryChannelEnd<CosmosChain>
-    + CanQueryChannelEndWithProofs<CosmosChain>
-    + CanQueryConnectionEndWithProofs<CosmosChain>
-    + CanQueryPacketCommitment<CosmosChain>
-    + CanQueryPacketAcknowledgement<CosmosChain>
-    + CanQueryPacketReceipt<CosmosChain>
     + HasRawClientStateType<RawClientState = Any>
-    + CanSubmitTx
-    + CanPollTxResponse
-    + CanQueryTxResponse
-    + CanQueryBlockTime
-    + CanAssertEventualAmount
-    + CanUploadWasmClientCode
-    + CanQueryProposalStatus
-    + CanBuildDepositProposalMessage
-    + CanBuildVoteProposalMessage
-    + HasMessageResponseEvents
-    + HasIbcCommitmentPrefix
-    + HasSendPacketEvent<CosmosChain>
-    + CanBuildCreateClientPayload<CosmosChain>
-    + CanFilterIncomingPacket<CosmosChain>
-    + CanFilterOutgoingPacket<CosmosChain>
-    + HasPacketSrcChannelId<CosmosChain>
-    + CanExtractFromEvent<CosmosCreateClientEvent>
     + CanExtractFromMessageResponse<CosmosCreateClientEvent>
-    + CanUseComponent<ChainStatusQuerierComponent>
-    + CanUseComponent<BlockEventsQuerierComponent>
-    + CanUseComponent<PacketIsClearedQuerierComponent, CosmosChain>
 {
 }
 
 impl CanUseCosmosChain for CosmosChain {}
 
-pub trait CanUseCosmosChainComponents:
-    Async + CanUseComponent<ChainStatusQuerierComponent> // + CanQueryChainStatus
-{
+check_components! {
+    CanUseCosmosChainComponents for CosmosChain {
+        TxSubmitterComponent,
+        TxResponsePollerComponent,
+        TxResponseQuerierComponent,
+        ChainStatusQuerierComponent,
+        BlockEventsQuerierComponent,
+        BlockTimeQuerierComponent,
+        BalanceQuerierComponent,
+        ProposalStatusQuerierComponent,
+        EipQuerierComponent,
+        UnbondingPeriodQuerierComponent,
+
+        IbcCommitmentPrefixGetterComponent,
+        MessageResponseEventsGetterComponent,
+
+        WasmClientCodeUploaderComponent,
+        EventualAmountAsserterComponent,
+
+        [
+            EventExtractorComponent,
+            MessageResponseExtractorComponent,
+        ]: [
+            CosmosCreateClientEvent,
+            CosmosConnectionOpenInitEvent,
+            CosmosConnectionOpenTryEvent,
+            CosmosChannelOpenInitEvent,
+            CosmosChannelOpenTryEvent,
+        ],
+
+        [
+            ClientStateWithProofsQuerierComponent,
+            ConsensusStateWithProofsQuerierComponent,
+            ConnectionEndQuerierComponent,
+            ConnectionEndWithProofsQuerierComponent,
+            ChannelEndQuerierComponent,
+            ChannelEndWithProofsQuerierComponent,
+            PacketCommitmentQuerierComponent,
+            PacketAcknowledgementQuerierComponent,
+            PacketReceiptQuerierComponent,
+
+            CreateClientPayloadBuilderComponent,
+            CreateClientMessageBuilderComponent,
+            UpdateClientMessageBuilderComponent,
+            UpdateClientPayloadBuilderComponent,
+            IbcTokenTransferMessageBuilderComponent,
+
+            IncomingPacketFilterComponent,
+            OutgoingPacketFilterComponent,
+
+            TokenIbcTransferrerComponent,
+        ]:
+            CosmosChain,
+        [
+            ClientStateQuerierComponent,
+            AllClientStatesQuerierComponent,
+            ConsensusStateQuerierComponent,
+        ]: [
+            CosmosChain,
+            AnyCounterparty,
+        ]
+    }
 }
 
-impl CanUseCosmosChainComponents for CosmosChain {}
+check_components! {
+    <Counterparty>
+    CanUseCosmosChainWithAnyCounterparty for CosmosChain
+    {
+        [
+            PacketIsClearedQuerierComponent,
+            RawClientStateQuerierComponent,
+            ChannelEndQuerierComponent,
 
-pub trait CanUseLoggerWithCosmosChain:
-    for<'a> CanLog<LogSendMessagesWithSignerAndNonce<'a, CosmosChain>>
-    + for<'a> CanLog<TxNoResponseError<'a, CosmosChain>>
-{
+            SendPacketEventComponent,
+        ]: Counterparty,
+    }
 }
 
-impl CanUseLoggerWithCosmosChain for HermesLogger {}
+check_components! {
+    <'a>
+    CanLogWithCosmosChain for HermesLogger
+    {
+        LoggerComponent: [
+            LogSendMessagesWithSignerAndNonce<'a, CosmosChain>,
+            TxNoResponseError<'a, CosmosChain>,
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

This PR uses the new `check_components!` macro introduced in https://github.com/contextgeneric/cgp/pull/78 to check for the implementation and wiring of `CosmosChain`. 

This serves as a proof of concept for future refactoring, so that we can more easily check for whether a given component is implemented for a context.