### PR TITLE
fix: Fix infinite recursion in `Debug::fmt` method

### DIFF
--- a/crates/error/src/types.rs
+++ b/crates/error/src/types.rs
@@ -68,7 +68,7 @@ impl Debug for Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Debug::fmt(self, f)
+        self.detail.fmt(f)
     }
 }
 


### PR DESCRIPTION
## Description

I noticed an issue where the `Debug::fmt` method was calling itself, causing infinite recursion. To resolve this, I replaced the recursive call with one that properly formats the error details. Now, instead of calling `Debug::fmt(self, f)`, it correctly calls `self.detail.fmt(f)` to print the error details.

This should prevent any stack overflow issues and ensure that errors are printed correctly.
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
