### PR TITLE
Wait for chain to progress one height when a tx response just becomes available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,7 @@ dependencies = [
  "hermes-protobuf-encoding-components",
  "hermes-relayer-components",
  "hermes-relayer-components-extra",
+ "hermes-runtime-components",
  "http 1.2.0",
  "ibc",
  "ibc-client-tendermint",

--- a/crates/cosmos/cosmos-chain-components/Cargo.toml
+++ b/crates/cosmos/cosmos-chain-components/Cargo.toml
@@ -17,6 +17,7 @@ hermes-error                            = { workspace = true }
 hermes-relayer-components               = { workspace = true }
 hermes-relayer-components-extra         = { workspace = true }
 hermes-chain-type-components            = { workspace = true }
+hermes-runtime-components               = { workspace = true }
 hermes-encoding-components              = { workspace = true }
 hermes-protobuf-encoding-components     = { workspace = true }
 hermes-cosmos-encoding-components       = { workspace = true }

--- a/crates/cosmos/cosmos-chain-components/src/impls/transaction/query_tx_response.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/transaction/query_tx_response.rs
@@ -1,9 +1,8 @@
-use core::time::Duration;
-
 use cgp::extra::runtime::HasRuntime;
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainHeight;
 use hermes_relayer_components::chain::traits::types::height::HasHeightFields;
+use hermes_relayer_components::chain::traits::types::poll_interval::HasPollInterval;
 use hermes_relayer_components::transaction::traits::query_tx_response::{
     TxResponseQuerier, TxResponseQuerierComponent,
 };
@@ -26,6 +25,7 @@ where
         + HasRpcClient
         + CanQueryChainHeight
         + HasHeightFields
+        + HasPollInterval
         + CanRaiseAsyncError<TendermintRpcError>,
     Chain::Runtime: CanSleep,
 {
@@ -75,7 +75,7 @@ where
                     if Chain::revision_height(&chain_height) > response_height {
                         break;
                     } else {
-                        chain.runtime().sleep(Duration::from_millis(500)).await;
+                        chain.runtime().sleep(chain.poll_interval()).await;
                     }
                 }
 

--- a/crates/cosmos/cosmos-chain-components/src/impls/transaction/query_tx_response.rs
+++ b/crates/cosmos/cosmos-chain-components/src/impls/transaction/query_tx_response.rs
@@ -1,9 +1,15 @@
+use core::time::Duration;
+
+use cgp::extra::runtime::HasRuntime;
 use cgp::prelude::*;
+use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainHeight;
+use hermes_relayer_components::chain::traits::types::height::HasHeightFields;
 use hermes_relayer_components::transaction::traits::query_tx_response::{
     TxResponseQuerier, TxResponseQuerierComponent,
 };
 use hermes_relayer_components::transaction::traits::types::tx_hash::HasTransactionHashType;
 use hermes_relayer_components::transaction::traits::types::tx_response::HasTxResponseType;
+use hermes_runtime_components::traits::sleep::CanSleep;
 use tendermint::Hash as TxHash;
 use tendermint_rpc::endpoint::tx::Response as TxResponse;
 use tendermint_rpc::query::Query;
@@ -11,15 +17,17 @@ use tendermint_rpc::{Client, Error as TendermintRpcError, Order};
 
 use crate::traits::rpc_client::HasRpcClient;
 
-pub struct QueryCosmosTxResponse;
-
-#[cgp_provider(TxResponseQuerierComponent)]
+#[cgp_new_provider(TxResponseQuerierComponent)]
 impl<Chain> TxResponseQuerier<Chain> for QueryCosmosTxResponse
 where
-    Chain: HasTransactionHashType<TxHash = TxHash>
+    Chain: HasRuntime
+        + HasTransactionHashType<TxHash = TxHash>
         + HasTxResponseType<TxResponse = TxResponse>
         + HasRpcClient
+        + CanQueryChainHeight
+        + HasHeightFields
         + CanRaiseAsyncError<TendermintRpcError>,
+    Chain::Runtime: CanSleep,
 {
     async fn query_tx_response(
         chain: &Chain,
@@ -27,7 +35,7 @@ where
     ) -> Result<Option<TxResponse>, Chain::Error> {
         let query = Query::eq("tx.hash", tx_hash.to_string());
 
-        let response = chain
+        let responses = chain
             .rpc_client()
             .tx_search(
                 query,
@@ -39,6 +47,41 @@ where
             .await
             .map_err(Chain::raise_error)?;
 
-        Ok(response.txs.into_iter().next())
+        let m_response = responses.txs.into_iter().next();
+
+        match m_response {
+            Some(response) => {
+                // Try to ensure that the chain progress to a later height than the height that
+                // returns the response, so that side effects such as merkle proofs can always
+                // be queried from the chain thereafter.
+                //
+                // This is usually not an issue in local tests. But when interacting with public
+                // RPC servers, at the first moment the transaction becomes available, it is not
+                // always propogated to all full nodes yet. This would result in the relayer
+                // interacting with a past chain state that did not have the transaction available
+                // yet, resulting in errors such as ack not found.
+                //
+                // The best way to work around this is to have the relayer always interact with only
+                // one dedicated full node. That way, when the full node says that the transaction
+                // is already there, then it is guaranteed to always available there onward.
+                // But we need this workaround so that the relayer still works with multiple full
+                // nodes and with public RPC endpoints.
+                for _ in 0..20 {
+                    let response_height: u64 = response.height.into();
+                    let chain_height = chain.query_chain_height().await?;
+
+                    // We can technically wait for the same height with >=, but we use > to be
+                    // a little safer to ensure that all full nodes have processed the transaction.
+                    if Chain::revision_height(&chain_height) > response_height {
+                        break;
+                    } else {
+                        chain.runtime().sleep(Duration::from_millis(500)).await;
+                    }
+                }
+
+                Ok(Some(response))
+            }
+            None => Ok(None),
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR attempts to fix a race condition issue when the relayer interacts with multiple full nodes through a public RPC endpoint.

Previously, when the relayer polls for a tx response, it immediately returns and continue relaying operations as soon as the tx response becomes available. Although this works in local settings or when the relayer has a dedicated full node, this approach may not work when the relayer interacts with multiple full nodes.

The main issue is that when the relayer found a tx response from one full node, the other full nodes may still be lagging behind the latest block, and thus not have the tx response available. If the relayer proceeds immediately and try to query for merkle proofs such as ack from other full nodes, then that proof may still not be available.

An even more basic problem is that if the relayer queries for the chain's latest height after getting the tx response, some full nodes may return a height that is earlier than the tx response's height. If the relayer just tries to construct merkle proofs based on this height, it would never succeed.

To workaround this, we update `QueryCosmosTxResponse` to wait for the chain to progress at least one height _after_ the tx response's height, so that hopefully all full nodes it interacts with will have already synchronized and processed the given transaction. This would in turn help reduce the chance that the relayer interacting with stale chain states later on.