### PR TITLE
Wait for Cosmos chain GRPC service to become ready in bootstrap

### DIFF
--- a/crates/cosmos/cosmos-chain-components/src/traits/grpc_address.rs
+++ b/crates/cosmos/cosmos-chain-components/src/traits/grpc_address.rs
@@ -1,10 +1,38 @@
 use cgp::prelude::*;
 use tendermint_rpc::Url;
+use tonic::client::Grpc;
+use tonic::transport::Endpoint;
 
 #[cgp_component {
-  provider: GrpcAddressGetter,
-  context: Chain,
+    provider: GrpcAddressGetter,
+    context: Chain,
 }]
 pub trait HasGrpcAddress: Async {
     fn grpc_address(&self) -> &Url;
+}
+
+#[async_trait]
+pub trait CanQueryGrpcServiceStatus: HasAsyncErrorType {
+    async fn query_grpc_service_status_is_ready(&self) -> Result<bool, Self::Error>;
+}
+
+impl<Chain> CanQueryGrpcServiceStatus for Chain
+where
+    Chain: HasGrpcAddress + CanRaiseAsyncError<tonic::transport::Error>,
+{
+    async fn query_grpc_service_status_is_ready(&self) -> Result<bool, Chain::Error> {
+        let endpoint: Endpoint = self
+            .grpc_address()
+            .to_string()
+            .try_into()
+            .map_err(Chain::raise_error)?;
+
+        let channel = endpoint.connect().await.map_err(Chain::raise_error)?;
+
+        let mut rpc_client = Grpc::new(channel);
+
+        let ready = rpc_client.ready().await.is_ok();
+
+        Ok(ready)
+    }
 }

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
@@ -7,7 +7,7 @@ use hermes_cosmos_test_components::chain::types::wallet::CosmosTestWallet;
 use hermes_error::types::HermesError;
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLog;
-use hermes_logging_components::types::level::{LevelDebug, LevelTrace};
+use hermes_logging_components::types::level::{LevelDebug, LevelTrace, LevelWarn};
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
 use hermes_relayer_components::chain::traits::types::poll_interval::HasPollInterval;
@@ -21,7 +21,7 @@ use crate::traits::bootstrap::build_chain::{
 use crate::traits::bootstrap::cosmos_builder::HasCosmosBuilder;
 use crate::traits::bootstrap::relayer_chain_config::CanBuildRelayerChainConfig;
 
-const RETRY_COUNT: u64 = 40;
+const RETRY_COUNT: u64 = 100;
 
 #[cgp_new_provider(ChainBuilderWithNodeConfigComponent)]
 impl<Bootstrap> ChainBuilderWithNodeConfig<Bootstrap> for BuildCosmosChainWithNodeConfig
@@ -38,7 +38,7 @@ where
         + CanQueryGrpcServiceStatus
         + HasPollInterval
         + HasChainId
-        + HasLogger<Logger: CanLog<LevelDebug> + CanLog<LevelTrace>>,
+        + HasLogger<Logger: CanLog<LevelWarn> + CanLog<LevelDebug> + CanLog<LevelTrace>>,
 {
     async fn build_chain_with_node_config(
         bootstrap: &Bootstrap,
@@ -68,7 +68,7 @@ where
             .await;
 
         // Wait for both RPC and gRPC servers to start before resuming bootstrapping
-        for _ in 0..RETRY_COUNT {
+        for i in 0..RETRY_COUNT {
             let rpc_server_is_ready = chain.query_chain_status().await.is_ok();
 
             let grpc_server_is_ready = chain
@@ -77,22 +77,34 @@ where
                 .unwrap_or(false);
 
             if rpc_server_is_ready && grpc_server_is_ready {
+                chain
+                    .logger()
+                    .log(
+                        &format!(
+                            "RPC and GRPC services of chain `{}`  are now ready",
+                            chain.chain_id()
+                        ),
+                        &LevelDebug,
+                    )
+                    .await;
+
                 break;
+            } else if i + 1 == RETRY_COUNT {
+                chain
+                    .logger()
+                    .log(
+                        &format!(
+                            "RPC and GRPC services of chain `{}`  are still not ready after {} tries. Will continue with possible failure",
+                            chain.chain_id(),
+                            RETRY_COUNT,
+                        ),
+                        &LevelWarn,
+                    )
+                    .await;
             }
 
             bootstrap.runtime().sleep(chain.poll_interval()).await;
         }
-
-        chain
-            .logger()
-            .log(
-                &format!(
-                    "chain `{}` RPC and GRPC services to are now ready`",
-                    chain.chain_id()
-                ),
-                &LevelDebug,
-            )
-            .await;
 
         Ok(chain)
     }

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
@@ -74,7 +74,7 @@ where
             let grpc_server_is_ready = chain
                 .query_grpc_service_status_is_ready()
                 .await
-                .map_err(Bootstrap::raise_error)?;
+                .unwrap_or(false);
 
             if rpc_server_is_ready && grpc_server_is_ready {
                 break;

--- a/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/bootstrap/build_cosmos_chain.rs
@@ -1,6 +1,5 @@
-use core::time::Duration;
-
 use cgp::prelude::*;
+use hermes_cosmos_chain_components::traits::grpc_address::CanQueryGrpcServiceStatus;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_test_components::bootstrap::traits::fields::dynamic_gas_fee::HasDynamicGas;
 use hermes_cosmos_test_components::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;
@@ -11,6 +10,7 @@ use hermes_logging_components::traits::logger::CanLog;
 use hermes_logging_components::types::level::{LevelDebug, LevelTrace};
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
+use hermes_relayer_components::chain::traits::types::poll_interval::HasPollInterval;
 use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_runtime_components::traits::sleep::CanSleep;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
@@ -21,11 +21,9 @@ use crate::traits::bootstrap::build_chain::{
 use crate::traits::bootstrap::cosmos_builder::HasCosmosBuilder;
 use crate::traits::bootstrap::relayer_chain_config::CanBuildRelayerChainConfig;
 
-const RETRY_START: u64 = 40;
+const RETRY_COUNT: u64 = 40;
 
-pub struct BuildCosmosChainWithNodeConfig;
-
-#[cgp_provider(ChainBuilderWithNodeConfigComponent)]
+#[cgp_new_provider(ChainBuilderWithNodeConfigComponent)]
 impl<Bootstrap> ChainBuilderWithNodeConfig<Bootstrap> for BuildCosmosChainWithNodeConfig
 where
     Bootstrap: HasChainType<Chain = CosmosChain>
@@ -37,6 +35,8 @@ where
         + CanRaiseAsyncError<HermesError>,
     Bootstrap::Runtime: CanSleep,
     Bootstrap::Chain: CanQueryChainStatus
+        + CanQueryGrpcServiceStatus
+        + HasPollInterval
         + HasChainId
         + HasLogger<Logger: CanLog<LevelDebug> + CanLog<LevelTrace>>,
 {
@@ -60,7 +60,7 @@ where
             .logger()
             .log(
                 &format!(
-                    "Waiting for chain `{}` to reach height 5`",
+                    "waiting for chain `{}` RPC and GRPC services to become ready`",
                     chain.chain_id()
                 ),
                 &LevelDebug,
@@ -68,20 +68,31 @@ where
             .await;
 
         // Wait for both RPC and gRPC servers to start before resuming bootstrapping
-        for _ in 0..RETRY_START {
-            if let Ok(status) = chain.query_chain_status().await {
-                let current_height = status.height.revision_height();
-                if current_height > 4 {
-                    break;
-                }
-                chain
-                    .logger()
-                    .log(&format!("Current height `{current_height}`"), &LevelTrace)
-                    .await;
+        for _ in 0..RETRY_COUNT {
+            let rpc_server_is_ready = chain.query_chain_status().await.is_ok();
+
+            let grpc_server_is_ready = chain
+                .query_grpc_service_status_is_ready()
+                .await
+                .map_err(Bootstrap::raise_error)?;
+
+            if rpc_server_is_ready && grpc_server_is_ready {
+                break;
             }
 
-            bootstrap.runtime().sleep(Duration::from_millis(500)).await;
+            bootstrap.runtime().sleep(chain.poll_interval()).await;
         }
+
+        chain
+            .logger()
+            .log(
+                &format!(
+                    "chain `{}` RPC and GRPC services to are now ready`",
+                    chain.chain_id()
+                ),
+                &LevelDebug,
+            )
+            .await;
 
         Ok(chain)
     }

--- a/crates/test/test-suite/src/tests/clearing.rs
+++ b/crates/test/test-suite/src/tests/clearing.rs
@@ -195,9 +195,10 @@ where
             assert!(is_received);
 
             birelay
-                .auto_bi_relay(Some(Duration::from_secs(10)), Some(Duration::from_secs(0)))
+                .auto_bi_relay(Some(Duration::from_secs(15)), Some(Duration::from_secs(0)))
                 .await
                 .unwrap();
+
             let is_cleared = chain_driver_a
                 .chain()
                 .query_packet_is_cleared(port_id_a, channel_id_a, &a_to_b_sequences[0])


### PR DESCRIPTION
Instead of always waiting for the chain to reach height 5, we directly poll for the chain's GRPC service to become ready.

This polling is needed, as Osmosis' GRPC service starts much slower than other Cosmos chains.