### PR TITLE
Refactoring and fix IBC transfer interfaces

### DIFF
--- a/crates/cosmos/cosmos-integration-tests/tests/filter.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/filter.rs
@@ -113,12 +113,12 @@ fn no_packet_filter_test() -> Result<(), Error> {
 
         let a_to_b_amount = setup.chain_driver_a.random_amount(1000, &balance_a).await;
 
-        let balance_b =
-            <CosmosChain as CanConvertIbcTransferredAmount<CosmosChain>>::ibc_transfer_amount_from(
-                &a_to_b_amount,
-                &setup.channel_id_b,
-                &setup.port_id_b,
-            )?;
+        let balance_b = CosmosChain::ibc_transfer_amount_from(
+            PhantomData::<CosmosChain>,
+            &a_to_b_amount,
+            &setup.channel_id_b,
+            &setup.port_id_b,
+        )?;
 
         let balance_after_escrow = Amount::new(
             balance_a.quantity - a_to_b_amount.quantity,

--- a/crates/cosmos/cosmos-integration-tests/tests/filter.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/filter.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+use core::marker::PhantomData;
 use std::collections::HashMap;
 
 use hermes_cosmos_chain_components::types::messages::packet::packet_filter::PacketFilterConfig;
@@ -47,16 +48,19 @@ fn packet_filter_test() -> Result<(), Error> {
 
         let _relayer = setup.relay_driver.run_relayer_in_background().await?;
 
-        let packet = <CosmosChain as CanIbcTransferToken<CosmosChain>>::ibc_transfer_token(
-            &setup.chain_driver_a.chain,
-            &setup.channel_id_a,
-            &setup.port_id_a,
-            &setup.chain_driver_a.user_wallet_a,
-            &setup.chain_driver_b.user_wallet_b.address,
-            &a_to_b_amount,
-            &setup.chain_driver_a.chain.default_memo(),
-        )
-        .await?;
+        let packet = setup
+            .chain_driver_a
+            .chain
+            .ibc_transfer_token(
+                PhantomData::<CosmosChain>,
+                &setup.channel_id_a,
+                &setup.port_id_a,
+                &setup.chain_driver_a.user_wallet_a,
+                &setup.chain_driver_b.user_wallet_b.address,
+                &a_to_b_amount,
+                &setup.chain_driver_a.chain.default_memo(),
+            )
+            .await?;
 
         // Assert tokens have been escrowed
         setup
@@ -121,16 +125,19 @@ fn no_packet_filter_test() -> Result<(), Error> {
             balance_a.denom.clone(),
         );
 
-        let packet = <CosmosChain as CanIbcTransferToken<CosmosChain>>::ibc_transfer_token(
-            &setup.chain_driver_a.chain,
-            &setup.channel_id_a,
-            &setup.port_id_a,
-            &setup.chain_driver_a.user_wallet_a,
-            &setup.chain_driver_b.user_wallet_b.address,
-            &a_to_b_amount,
-            &setup.chain_driver_a.chain.default_memo(),
-        )
-        .await?;
+        let packet = setup
+            .chain_driver_a
+            .chain
+            .ibc_transfer_token(
+                PhantomData::<CosmosChain>,
+                &setup.channel_id_a,
+                &setup.port_id_a,
+                &setup.chain_driver_a.user_wallet_a,
+                &setup.chain_driver_b.user_wallet_b.address,
+                &a_to_b_amount,
+                &setup.chain_driver_a.chain.default_memo(),
+            )
+            .await?;
 
         // Assert tokens have been escrowed
         setup

--- a/crates/cosmos/cosmos-integration-tests/tests/filter.rs
+++ b/crates/cosmos/cosmos-integration-tests/tests/filter.rs
@@ -9,6 +9,7 @@ use hermes_cosmos_integration_tests::init::{init_preset_bootstraps, init_test_ru
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_test_components::chain::types::amount::Amount;
 use hermes_error::types::Error;
+use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::queries::packet_is_received::CanQueryPacketIsReceived;
 use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
 use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
@@ -59,6 +60,7 @@ fn packet_filter_test() -> Result<(), Error> {
                 &setup.chain_driver_b.user_wallet_b.address,
                 &a_to_b_amount,
                 &setup.chain_driver_a.chain.default_memo(),
+                &setup.chain_driver_b.chain.query_chain_status().await?,
             )
             .await?;
 
@@ -136,6 +138,7 @@ fn no_packet_filter_test() -> Result<(), Error> {
                 &setup.chain_driver_b.user_wallet_b.address,
                 &a_to_b_amount,
                 &setup.chain_driver_a.chain.default_memo(),
+                &setup.chain_driver_b.chain.query_chain_status().await?,
             )
             .await?;
 

--- a/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/chain.rs
@@ -118,7 +118,7 @@ use hermes_runtime_components::traits::runtime::{
 };
 use hermes_test_components::chain::traits::assert::eventual_amount::EventualAmountAsserterComponent;
 use hermes_test_components::chain::traits::messages::ibc_transfer::{
-    CanBuildIbcTokenTransferMessage, IbcTokenTransferMessageBuilderComponent,
+    CanBuildIbcTokenTransferMessages, IbcTokenTransferMessageBuilderComponent,
 };
 use hermes_test_components::chain::traits::proposal::query_status::ProposalStatusQuerierComponent;
 use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
@@ -327,7 +327,7 @@ pub trait CanUseCosmosChain:
         CosmosChain,
         CreateClientPayloadOptions = CosmosCreateClientOptions,
     > + HasCommitmentPrefixType<CommitmentPrefix = Vec<u8>>
-    + CanBuildIbcTokenTransferMessage<CosmosChain>
+    + CanBuildIbcTokenTransferMessages<CosmosChain>
     + HasRawClientStateType<RawClientState = Any>
     + CanExtractFromMessageResponse<CosmosCreateClientEvent>
 {

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
@@ -34,7 +34,7 @@ where
     Counterparty: HasAddressType + HasHeightFields + HasTimeoutType<Timeout = Timestamp>,
     Chain::Message: From<CosmosMessage>,
 {
-    async fn build_ibc_token_transfer_message(
+    async fn build_ibc_token_transfer_messages(
         _chain: &Chain,
         _counterparty: PhantomData<Counterparty>,
         channel_id: &ChannelId,

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
@@ -26,13 +26,12 @@ where
     Chain: HasAsyncErrorType
         + HasAddressType
         + HasMessageType
-        + HasHeightType<Height = Height>
-        + HasTimeoutType<Timeout = Timestamp>
         + HasAmountType<Amount = Amount>
         + HasMemoType<Memo = Option<String>>
         + HasChannelIdType<Counterparty, ChannelId = ChannelId>
         + HasPortIdType<Counterparty, PortId = PortId>,
-    Counterparty: HasAddressType,
+    Counterparty:
+        HasAddressType + HasHeightType<Height = Height> + HasTimeoutType<Timeout = Timestamp>,
     Chain::Message: From<CosmosMessage>,
 {
     async fn build_ibc_token_transfer_message(

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
@@ -17,9 +17,7 @@ use ibc::primitives::Timestamp;
 use crate::chain::types::amount::Amount;
 use crate::chain::types::messages::token_transfer::TokenTransferMessage;
 
-pub struct BuildCosmosIbcTransferMessage;
-
-#[cgp_provider(IbcTokenTransferMessageBuilderComponent)]
+#[cgp_new_provider(IbcTokenTransferMessageBuilderComponent)]
 impl<Chain, Counterparty> IbcTokenTransferMessageBuilder<Chain, Counterparty>
     for BuildCosmosIbcTransferMessage
 where
@@ -44,7 +42,7 @@ where
         memo: &Option<String>,
         timeout_height: Option<&Height>,
         timeout_time: Option<&Timestamp>,
-    ) -> Result<Chain::Message, Chain::Error> {
+    ) -> Result<Vec<Chain::Message>, Chain::Error> {
         let message = TokenTransferMessage {
             channel_id: channel_id.clone(),
             port_id: port_id.clone(),
@@ -55,6 +53,8 @@ where
             timeout_time: timeout_time.cloned(),
         };
 
-        Ok(message.to_cosmos_message().into())
+        let messages = vec![message.to_cosmos_message().into()];
+
+        Ok(messages)
     }
 }

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/messages/ibc_transfer.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use cgp::prelude::*;
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
@@ -35,6 +37,7 @@ where
 {
     async fn build_ibc_token_transfer_message(
         _chain: &Chain,
+        _counterparty: PhantomData<Counterparty>,
         channel_id: &ChannelId,
         port_id: &PortId,
         recipient_address: &Counterparty::Address,

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/transfer/amount.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/transfer/amount.rs
@@ -1,3 +1,4 @@
+use core::marker::PhantomData;
 use std::string::FromUtf8Error;
 
 use cgp::prelude::*;
@@ -25,6 +26,7 @@ where
     Counterparty: HasAmountType<Amount = Amount>,
 {
     fn ibc_transfer_amount_from(
+        _counterparty: PhantomData<Counterparty>,
         counterparty_amount: &Amount,
         channel_id: &ChannelId,
         port_id: &PortId,
@@ -38,7 +40,11 @@ where
         })
     }
 
-    fn transmute_counterparty_amount(counterparty_amount: &Amount, denom: &Denom) -> Amount {
+    fn transmute_counterparty_amount(
+        _counterparty: PhantomData<Counterparty>,
+        counterparty_amount: &Amount,
+        denom: &Denom,
+    ) -> Amount {
         Amount {
             quantity: counterparty_amount.quantity,
             denom: denom.clone(),

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/transfer/timeout.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/transfer/timeout.rs
@@ -13,10 +13,10 @@ use time::OffsetDateTime;
 pub struct IbcTransferTimeoutAfterSeconds<const SECS: u64>;
 
 #[cgp_provider(IbcTransferTimeoutCalculatorComponent)]
-impl<Chain, const SECS: u64> IbcTransferTimeoutCalculator<Chain>
+impl<Chain, Counterparty, const SECS: u64> IbcTransferTimeoutCalculator<Chain, Counterparty>
     for IbcTransferTimeoutAfterSeconds<SECS>
 where
-    Chain: HasTimeType<Time = Time> + HasTimeoutType<Timeout = Timestamp> + HasHeightType,
+    Counterparty: HasTimeType<Time = Time> + HasTimeoutType<Timeout = Timestamp> + HasHeightType,
 {
     fn ibc_transfer_timeout_time(_chain: &Chain, current_time: &Time) -> Option<Timestamp> {
         let time = (*current_time + Duration::from_secs(SECS)).unwrap();
@@ -25,8 +25,8 @@ where
 
     fn ibc_transfer_timeout_height(
         _chain: &Chain,
-        _current_height: &Chain::Height,
-    ) -> Option<Chain::Height> {
+        _current_height: &Counterparty::Height,
+    ) -> Option<Counterparty::Height> {
         None
     }
 }

--- a/crates/test/test-components/src/chain/impls/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/impls/ibc_transfer.rs
@@ -7,6 +7,7 @@ use hermes_relayer_components::chain::traits::packet::from_send_packet::CanBuild
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::ibc_events::send_packet::HasSendPacketEvent;
+use hermes_relayer_components::chain::traits::types::status::HasChainStatusType;
 use hermes_relayer_components::transaction::traits::send_messages_with_signer::CanSendMessagesWithSigner;
 
 use crate::chain::traits::messages::ibc_transfer::CanBuildIbcTokenTransferMessage;
@@ -39,7 +40,7 @@ where
         + CanExtractFromEvent<Chain::SendPacketEvent>
         + CanRaiseAsyncError<MissingSendPacketEventError>
         + CanSendMessagesWithSigner,
-    Counterparty: HasAddressType,
+    Counterparty: HasAddressType + HasChainStatusType,
 {
     async fn ibc_transfer_token(
         chain: &Chain,
@@ -50,6 +51,7 @@ where
         recipient_address: &Counterparty::Address,
         amount: &Chain::Amount,
         memo: &Chain::Memo,
+        counterparty_chain_status: &Counterparty::ChainStatus,
     ) -> Result<Chain::OutgoingPacket, Chain::Error> {
         let chain_status = chain.query_chain_status().await?;
 

--- a/crates/test/test-components/src/chain/impls/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/impls/ibc_transfer.rs
@@ -63,6 +63,7 @@ where
 
         let messages = chain
             .build_ibc_token_transfer_message(
+                PhantomData,
                 channel_id,
                 port_id,
                 recipient_address,

--- a/crates/test/test-components/src/chain/impls/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/impls/ibc_transfer.rs
@@ -43,6 +43,7 @@ where
 {
     async fn ibc_transfer_token(
         chain: &Chain,
+        _counterparty: PhantomData<Counterparty>,
         channel_id: &Chain::ChannelId,
         port_id: &Chain::PortId,
         sender_wallet: &Chain::Wallet,

--- a/crates/test/test-components/src/chain/impls/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/impls/ibc_transfer.rs
@@ -6,7 +6,7 @@ use hermes_chain_type_components::traits::types::height::HasHeightType;
 use hermes_chain_type_components::traits::types::timeout::HasTimeoutType;
 use hermes_relayer_components::chain::traits::extract_data::CanExtractFromEvent;
 use hermes_relayer_components::chain::traits::packet::from_send_packet::CanBuildPacketFromSendPacket;
-use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use hermes_relayer_components::chain::traits::types::ibc::{HasChannelIdType, HasPortIdType};
 use hermes_relayer_components::chain::traits::types::ibc_events::send_packet::HasSendPacketEvent;
 use hermes_relayer_components::chain::traits::types::status::HasChainStatusType;
 use hermes_relayer_components::transaction::traits::send_messages_with_signer::CanSendMessagesWithSigner;
@@ -34,7 +34,8 @@ where
         + HasMessageResponseEvents
         + CanCalculateIbcTransferTimeout<Counterparty>
         + CanBuildIbcTokenTransferMessage<Counterparty>
-        + HasIbcChainTypes<Counterparty>
+        + HasPortIdType<Counterparty>
+        + HasChannelIdType<Counterparty>
         + HasSendPacketEvent<Counterparty>
         + CanBuildPacketFromSendPacket<Counterparty>
         + CanExtractFromEvent<Chain::SendPacketEvent>

--- a/crates/test/test-components/src/chain/impls/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/impls/ibc_transfer.rs
@@ -11,7 +11,7 @@ use hermes_relayer_components::chain::traits::types::ibc_events::send_packet::Ha
 use hermes_relayer_components::chain::traits::types::status::HasChainStatusType;
 use hermes_relayer_components::transaction::traits::send_messages_with_signer::CanSendMessagesWithSigner;
 
-use crate::chain::traits::messages::ibc_transfer::CanBuildIbcTokenTransferMessage;
+use crate::chain::traits::messages::ibc_transfer::CanBuildIbcTokenTransferMessages;
 use crate::chain::traits::transfer::ibc_transfer::{
     TokenIbcTransferrer, TokenIbcTransferrerComponent,
 };
@@ -33,7 +33,7 @@ where
         + HasWalletSigner
         + HasMessageResponseEvents
         + CanCalculateIbcTransferTimeout<Counterparty>
-        + CanBuildIbcTokenTransferMessage<Counterparty>
+        + CanBuildIbcTokenTransferMessages<Counterparty>
         + HasPortIdType<Counterparty>
         + HasChannelIdType<Counterparty>
         + HasSendPacketEvent<Counterparty>
@@ -61,7 +61,7 @@ where
             chain.ibc_transfer_timeout_time(Counterparty::chain_status_time(counterparty_status));
 
         let messages = chain
-            .build_ibc_token_transfer_message(
+            .build_ibc_token_transfer_messages(
                 PhantomData,
                 channel_id,
                 port_id,

--- a/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
@@ -29,6 +30,7 @@ where
 {
     async fn build_ibc_token_transfer_message(
         &self,
+        _counterparty: PhantomData<Counterparty>,
         channel_id: &Self::ChannelId,
         port_id: &Self::PortId,
         recipient_address: &Counterparty::Address,

--- a/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::ibc::{HasChannelIdType, HasPortIdType};
@@ -34,5 +36,5 @@ where
         memo: &Self::Memo,
         timeout_height: Option<&Self::Height>,
         timeout_time: Option<&Self::Timeout>,
-    ) -> Result<Self::Message, Self::Error>;
+    ) -> Result<Vec<Self::Message>, Self::Error>;
 }

--- a/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
@@ -21,12 +21,10 @@ pub trait CanBuildIbcTokenTransferMessage<Counterparty>:
     + HasAmountType
     + HasMemoType
     + HasMessageType
-    + HasHeightType
-    + HasTimeoutType
     + HasChannelIdType<Counterparty>
     + HasPortIdType<Counterparty>
 where
-    Counterparty: HasAddressType,
+    Counterparty: HasAddressType + HasHeightType + HasTimeoutType,
 {
     async fn build_ibc_token_transfer_message(
         &self,
@@ -36,7 +34,7 @@ where
         recipient_address: &Counterparty::Address,
         amount: &Self::Amount,
         memo: &Self::Memo,
-        timeout_height: Option<&Self::Height>,
-        timeout_time: Option<&Self::Timeout>,
+        timeout_height: Option<&Counterparty::Height>,
+        timeout_time: Option<&Counterparty::Timeout>,
     ) -> Result<Vec<Self::Message>, Self::Error>;
 }

--- a/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/messages/ibc_transfer.rs
@@ -16,7 +16,7 @@ use crate::chain::traits::types::memo::HasMemoType;
   context: ChainDriver,
 }]
 #[async_trait]
-pub trait CanBuildIbcTokenTransferMessage<Counterparty>:
+pub trait CanBuildIbcTokenTransferMessages<Counterparty>:
     HasAsyncErrorType
     + HasAmountType
     + HasMemoType
@@ -26,7 +26,7 @@ pub trait CanBuildIbcTokenTransferMessage<Counterparty>:
 where
     Counterparty: HasAddressType + HasHeightType + HasTimeoutType,
 {
-    async fn build_ibc_token_transfer_message(
+    async fn build_ibc_token_transfer_messages(
         &self,
         _counterparty: PhantomData<Counterparty>,
         channel_id: &Self::ChannelId,

--- a/crates/test/test-components/src/chain/traits/transfer/amount.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/amount.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 
@@ -13,12 +15,14 @@ where
     Counterparty: HasAmountType,
 {
     fn ibc_transfer_amount_from(
+        _counterparty: PhantomData<Counterparty>,
         counterparty_amount: &Counterparty::Amount,
         channel_id: &Self::ChannelId,
         port_id: &Self::PortId,
     ) -> Result<Self::Amount, Self::Error>;
 
     fn transmute_counterparty_amount(
+        _counterparty: PhantomData<Counterparty>,
         counterparty_amount: &Counterparty::Amount,
         denom: &Self::Denom,
     ) -> Self::Amount;

--- a/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
@@ -24,6 +26,7 @@ where
 {
     async fn ibc_transfer_token(
         &self,
+        _counterparty: PhantomData<Counterparty>,
         channel_id: &Self::ChannelId,
         port_id: &Self::PortId,
         sender_wallet: &Self::Wallet,

--- a/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
@@ -8,8 +8,8 @@ use crate::chain::traits::types::memo::HasMemoType;
 use crate::chain::traits::types::wallet::HasWalletType;
 
 #[cgp_component {
-  provider: TokenIbcTransferrer,
-  context: Chain,
+    provider: TokenIbcTransferrer,
+    context: Chain,
 }]
 #[async_trait]
 pub trait CanIbcTransferToken<Counterparty>:

--- a/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
+use hermes_relayer_components::chain::traits::types::status::HasChainStatusType;
 
 use crate::chain::traits::types::address::HasAddressType;
 use crate::chain::traits::types::amount::HasAmountType;
@@ -22,7 +23,7 @@ pub trait CanIbcTransferToken<Counterparty>:
     + HasOutgoingPacketType<Counterparty>
     + HasMemoType
 where
-    Counterparty: HasAddressType,
+    Counterparty: HasAddressType + HasChainStatusType,
 {
     async fn ibc_transfer_token(
         &self,
@@ -33,5 +34,6 @@ where
         recipient_address: &Counterparty::Address,
         amount: &Self::Amount,
         memo: &Self::Memo,
+        counterparty_chain_status: &Counterparty::ChainStatus,
     ) -> Result<Self::OutgoingPacket, Self::Error>;
 }

--- a/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/ibc_transfer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use cgp::prelude::*;
-use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use hermes_relayer_components::chain::traits::types::ibc::{HasChannelIdType, HasPortIdType};
 use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
 use hermes_relayer_components::chain::traits::types::status::HasChainStatusType;
 
@@ -19,7 +19,8 @@ pub trait CanIbcTransferToken<Counterparty>:
     HasAsyncErrorType
     + HasWalletType
     + HasAmountType
-    + HasIbcChainTypes<Counterparty>
+    + HasPortIdType<Counterparty>
+    + HasChannelIdType<Counterparty>
     + HasOutgoingPacketType<Counterparty>
     + HasMemoType
 where

--- a/crates/test/test-components/src/chain/traits/transfer/timeout.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/timeout.rs
@@ -1,10 +1,11 @@
+use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::timestamp::HasTimeoutType;
 
 #[cgp_component {
-  provider: IbcTransferTimeoutCalculator,
-  context: Chain,
+    provider: IbcTransferTimeoutCalculator,
+    context: Chain,
 }]
 pub trait CanCalculateIbcTransferTimeout<Counterparty>
 where
@@ -19,4 +20,27 @@ where
         &self,
         current_height: &Counterparty::Height,
     ) -> Option<Counterparty::Height>;
+}
+
+#[cgp_provider(IbcTransferTimeoutCalculatorComponent)]
+impl<Chain, Counterparty, Components> IbcTransferTimeoutCalculator<Chain, Counterparty>
+    for UseDelegate<Components>
+where
+    Counterparty: HasTimeoutType + HasHeightType,
+    Components: DelegateComponent<Counterparty>,
+    Components::Delegate: IbcTransferTimeoutCalculator<Chain, Counterparty>,
+{
+    fn ibc_transfer_timeout_time(
+        chain: &Chain,
+        current_time: &Counterparty::Time,
+    ) -> Option<Counterparty::Timeout> {
+        Components::Delegate::ibc_transfer_timeout_time(chain, current_time)
+    }
+
+    fn ibc_transfer_timeout_height(
+        chain: &Chain,
+        current_height: &Counterparty::Height,
+    ) -> Option<Counterparty::Height> {
+        Components::Delegate::ibc_transfer_timeout_height(chain, current_height)
+    }
 }

--- a/crates/test/test-components/src/chain/traits/transfer/timeout.rs
+++ b/crates/test/test-components/src/chain/traits/transfer/timeout.rs
@@ -4,10 +4,19 @@ use hermes_relayer_components::chain::traits::types::timestamp::HasTimeoutType;
 
 #[cgp_component {
   provider: IbcTransferTimeoutCalculator,
-  context: ChainDriver,
+  context: Chain,
 }]
-pub trait CanCalculateIbcTransferTimeout: HasTimeoutType + HasHeightType {
-    fn ibc_transfer_timeout_time(&self, current_time: &Self::Time) -> Option<Self::Timeout>;
+pub trait CanCalculateIbcTransferTimeout<Counterparty>
+where
+    Counterparty: HasTimeoutType + HasHeightType,
+{
+    fn ibc_transfer_timeout_time(
+        &self,
+        current_time: &Counterparty::Time,
+    ) -> Option<Counterparty::Timeout>;
 
-    fn ibc_transfer_timeout_height(&self, current_height: &Self::Height) -> Option<Self::Height>;
+    fn ibc_transfer_timeout_height(
+        &self,
+        current_height: &Counterparty::Height,
+    ) -> Option<Counterparty::Height>;
 }

--- a/crates/test/test-suite/src/tests/clearing.rs
+++ b/crates/test/test-suite/src/tests/clearing.rs
@@ -255,7 +255,7 @@ where
         + CanQueryChainStatus
         + HasPacketSequence<DstChain>
         + HasAmountMethods,
-    DstChain: HasWalletType + CanQueryPacketIsReceived<SrcChain>,
+    DstChain: HasWalletType + CanQueryChainStatus + CanQueryPacketIsReceived<SrcChain>,
     Driver::Error: From<SrcChain::Error> + From<DstChain::Error> + From<Relay::Error>,
 {
     let sender_wallet = src_chain_driver.wallet_at(UserWallet, PhantomData::<Index<0>>);
@@ -286,6 +286,7 @@ where
             receiver_address,
             &transfer_amount_1,
             &src_chain.default_memo(),
+            &dst_chain.query_chain_status().await?,
         )
         .await?;
 
@@ -332,6 +333,7 @@ where
             receiver_address,
             &transfer_amount_2,
             &src_chain.default_memo(),
+            &dst_chain.query_chain_status().await?,
         )
         .await?;
 

--- a/crates/test/test-suite/src/tests/clearing.rs
+++ b/crates/test/test-suite/src/tests/clearing.rs
@@ -279,6 +279,7 @@ where
 
     let packet_1 = src_chain
         .ibc_transfer_token(
+            PhantomData,
             src_channel_id,
             src_port_id,
             sender_wallet,
@@ -324,6 +325,7 @@ where
 
     let packet_2 = src_chain
         .ibc_transfer_token(
+            PhantomData,
             src_channel_id,
             src_port_id,
             sender_wallet,

--- a/crates/test/test-suite/src/tests/transfer.rs
+++ b/crates/test/test-suite/src/tests/transfer.rs
@@ -118,6 +118,7 @@ where
 
         chain_a
             .ibc_transfer_token(
+                PhantomData,
                 channel_id_a,
                 port_id_a,
                 wallet_a1,
@@ -161,6 +162,7 @@ where
 
         chain_b
             .ibc_transfer_token(
+                PhantomData,
                 channel_id_b,
                 port_id_b,
                 wallet_b,

--- a/crates/test/test-suite/src/tests/transfer.rs
+++ b/crates/test/test-suite/src/tests/transfer.rs
@@ -134,7 +134,8 @@ where
 
         assert_eq!(balance_a2, balance_a3);
 
-        let balance_b1 = ChainB::ibc_transfer_amount_from(&a_to_b_amount, channel_id_b, port_id_b)?;
+        let balance_b1 =
+            ChainB::ibc_transfer_amount_from(PhantomData, &a_to_b_amount, channel_id_b, port_id_b)?;
 
         logger
             .log_message(&format!(
@@ -184,7 +185,7 @@ where
 
         let balance_a5 = ChainA::add_amount(
             &balance_a4,
-            &ChainA::transmute_counterparty_amount(&b_to_a_amount, denom_a),
+            &ChainA::transmute_counterparty_amount(PhantomData, &b_to_a_amount, denom_a),
         )?;
 
         chain_a

--- a/crates/test/test-suite/src/tests/transfer.rs
+++ b/crates/test/test-suite/src/tests/transfer.rs
@@ -5,6 +5,7 @@ use cgp::core::field::Index;
 use cgp::prelude::*;
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLogMessage;
+use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
 use hermes_relayer_components::chain::traits::types::chain_id::HasChainId;
 use hermes_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
 use hermes_relayer_components::chain::traits::types::packet::HasOutgoingPacketType;
@@ -51,6 +52,7 @@ where
         + HasChainId
         + HasOutgoingPacketType<ChainB>
         + CanQueryBalance
+        + CanQueryChainStatus
         + HasAmountMethods
         + CanConvertIbcTransferredAmount<ChainB>
         + CanIbcTransferToken<ChainB>
@@ -61,6 +63,7 @@ where
         + HasOutgoingPacketType<ChainA>
         + HasAmountMethods
         + CanQueryBalance
+        + CanQueryChainStatus
         + CanIbcTransferToken<ChainA>
         + CanConvertIbcTransferredAmount<ChainA>
         + CanAssertEventualAmount
@@ -125,6 +128,7 @@ where
                 address_b,
                 &a_to_b_amount,
                 &chain_a.default_memo(),
+                &chain_b.query_chain_status().await?,
             )
             .await?;
 
@@ -170,6 +174,7 @@ where
                 address_a2,
                 &b_to_a_amount,
                 &chain_b.default_memo(),
+                &chain_a.query_chain_status().await?,
             )
             .await?;
 


### PR DESCRIPTION
- Allow `build_ibc_token_transfer_message` to return more than one messages.
- Add `PhantomData<Counterparty>` parameter to IBC transfer methods to help with type inference.
- Fix `build_ibc_token_transfer_message` to accept timeout from `Counterparty` instead of `Self`.
- Accept and additional `Counterparty::ChainStatus` parameter in `ibc_transfer_token` to derive timeout from it.