### PR TITLE
refactor: packet timeout and polling

### DIFF
--- a/crates/cosmos/cosmos-chain-preset/src/presets/chain.rs
+++ b/crates/cosmos/cosmos-chain-preset/src/presets/chain.rs
@@ -226,7 +226,7 @@ mod preset {
     use hermes_relayer_components::transaction::traits::types::transaction::TransactionTypeComponent;
     use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionHashTypeComponent;
     use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
-    use hermes_test_components::chain::impls::assert::default_assert_duration::ProvideDefaultPollAssertDuration;
+    use hermes_test_components::chain::impls::assert::assert_duration::ProvidePollAssertDuration;
     use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::PollAssertEventualAmount;
     use hermes_test_components::chain::impls::default_memo::ProvideDefaultMemo;
     use hermes_test_components::chain::impls::ibc_transfer::SendIbcTransferMessage;
@@ -490,7 +490,7 @@ mod preset {
             TokenIbcTransferrerComponent:
                 SendIbcTransferMessage,
             IbcTransferTimeoutCalculatorComponent:
-                IbcTransferTimeoutAfterSeconds<90>,
+                IbcTransferTimeoutAfterSeconds<300>,
             IbcTokenTransferMessageBuilderComponent:
                 BuildCosmosIbcTransferMessage,
             BalanceQuerierComponent:
@@ -498,7 +498,7 @@ mod preset {
             EventualAmountAsserterComponent:
                 PollAssertEventualAmount,
             PollAssertDurationGetterComponent:
-                ProvideDefaultPollAssertDuration,
+                ProvidePollAssertDuration<1, 300>,
             ProposalStatusQuerierComponent:
                 QueryProposalStatusWithGrpc,
             ProposalStatusPollerComponent:

--- a/crates/test/test-components/src/chain/impls/assert/assert_duration.rs
+++ b/crates/test/test-components/src/chain/impls/assert/assert_duration.rs
@@ -6,18 +6,19 @@ use crate::chain::traits::assert::poll_assert::{
     PollAssertDurationGetter, PollAssertDurationGetterComponent,
 };
 
-pub struct ProvideDefaultPollAssertDuration;
+pub struct ProvidePollAssertDuration<const INTERVAL: u64, const ATTEMPTS: u32>;
 
 #[cgp_provider(PollAssertDurationGetterComponent)]
-impl<Chain> PollAssertDurationGetter<Chain> for ProvideDefaultPollAssertDuration
+impl<Chain, const INTERVAL: u64, const ATTEMPTS: u32> PollAssertDurationGetter<Chain>
+    for ProvidePollAssertDuration<INTERVAL, ATTEMPTS>
 where
     Chain: Async,
 {
     fn poll_assert_interval(_chain: &Chain) -> Duration {
-        Duration::from_secs(1)
+        Duration::from_secs(INTERVAL)
     }
 
     fn poll_assert_attempts(_chain: &Chain) -> u32 {
-        90
+        ATTEMPTS
     }
 }

--- a/crates/test/test-components/src/chain/impls/assert/mod.rs
+++ b/crates/test/test-components/src/chain/impls/assert/mod.rs
@@ -1,2 +1,2 @@
-pub mod default_assert_duration;
+pub mod assert_duration;
 pub mod poll_assert_eventual_amount;

--- a/crates/test/test-components/src/chain/impls/assert/poll_assert_eventual_amount.rs
+++ b/crates/test/test-components/src/chain/impls/assert/poll_assert_eventual_amount.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 use cgp::prelude::*;
 use hermes_logging_components::traits::has_logger::HasLogger;
 use hermes_logging_components::traits::logger::CanLog;
-use hermes_logging_components::types::level::{LevelError, LevelTrace};
+use hermes_logging_components::types::level::LevelError;
 use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_runtime_components::traits::sleep::CanSleep;
 
@@ -28,7 +28,7 @@ where
         + HasLogger
         + for<'a> CanRaiseAsyncError<EventualAmountTimeoutError<'a, Chain>>,
     Chain::Runtime: CanSleep,
-    Chain::Logger: CanLog<LevelError> + CanLog<LevelTrace>,
+    Chain::Logger: CanLog<LevelError>,
 {
     async fn assert_eventual_amount(
         chain: &Chain,
@@ -55,12 +55,12 @@ where
             balance_result = chain.query_balance(address, denom).await;
         }
 
-        let balance = balance_result?;
+        let final_balance = balance_result?;
 
         chain
             .logger()
             .log(
-                &format!("Expected balance `{amount}`, found finally `{balance}`"),
+                &format!("Expected balance `{amount}`, found `{final_balance}`"),
                 &LevelError,
             )
             .await;


### PR DESCRIPTION
this is required for ibc-starknet as the e2e tests are failing at `ubuntu-arm` for packet timeout being not enough.