### PR TITLE
Write Architecture Notes Documentation, part 3

### DIFF
--- a/crates/cosmos/cosmos-relayer/src/contexts/birelay.rs
+++ b/crates/cosmos/cosmos-relayer/src/contexts/birelay.rs
@@ -1,6 +1,5 @@
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeProviderComponent};
 use cgp::core::field::Index;
-use cgp::core::types::WithType;
 use cgp::extra::run::RunnerComponent;
 use hermes_core::logging_components::traits::LoggerComponent;
 use hermes_core::relayer_components::birelay::traits::AutoBiRelayerComponent;
@@ -37,12 +36,14 @@ delegate_components! {
         RuntimeTypeProviderComponent: UseType<HermesRuntime>,
         RuntimeGetterComponent: UseField<symbol!("runtime")>,
         LoggerComponent: TracingLogger,
-        ChainTypeProviderAtComponent<Index<0>>: WithType<CosmosChain>,
-        ChainTypeProviderAtComponent<Index<1>>: WithType<CosmosChain>,
+        [
+            ChainTypeProviderAtComponent<Index<0>>,
+            ChainTypeProviderAtComponent<Index<1>>,
+        ]: UseType<CosmosChain>,
         [
             RelayTypeProviderAtComponent<Index<0>, Index<1>>,
             RelayTypeProviderAtComponent<Index<1>, Index<0>>,
-        ]: WithType<CosmosRelay>,
+        ]: UseType<CosmosRelay>,
         RelayGetterAtComponent<Index<0>, Index<1>>:
             UseField<symbol!("relay_a_to_b")>,
         RelayGetterAtComponent<Index<1>, Index<0>>:

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -9,6 +9,7 @@
 - [Field Types](./field-types.md)
 - [Presets](./presets.md)
 - [`UseDelegate`](./use-delegate.md)
+- [Context Fields](./context-fields.md)
 
 ## Relayer Architecture
 

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -13,4 +13,5 @@
 ## Relayer Architecture
 
 - [Crate Organization](./crate-organization.md)
+- [Code Navigation](./navigation.md)
 - [Encoding](./encoding.md)

--- a/docs/notes/context-fields.md
+++ b/docs/notes/context-fields.md
@@ -1,0 +1,164 @@
+# Context Fields
+
+This document provides some guidelines on how to define the fields in a concrete context.
+
+## Plain Fields
+
+When getting started, the most straightforward way to define the context fields is to add them directly inside the concrete context struct:
+
+```rust
+#[cgp_context(MyContextComponents)]
+#[derive(HasField, Clone)]
+pub struct MyContext {
+    pub config: Config,
+    pub runtime: Runtime,
+    pub other_fields: OtherFields,
+    ...
+}
+```
+
+Typically, a concrete context would derive `HasField`, so that we can use providers like `UseField` to wire up field accessors. In Hermes SDK, it is also common for the context to derive `Clone`, so that we can clone a context to use it inside multiple async tasks or parent contexts.
+
+However, the auto-derived `Clone` implementation may be inefficient if the context contains many fields. If so, the cloning could become expensive quickly if it is done many times.
+
+## `Arc` Fields
+
+A more efficient approach is to hide the context fields behind an `Arc`, so that we can clone the context more cheaply:
+
+```rust
+#[cgp_context(MyContextComponents)]
+pub struct MyContext {
+    pub fields: Arc<MyContextFields>,
+}
+
+#[derive(HasField)]
+pub struct MyContextFields {
+    pub config: Config,
+    pub runtime: Runtime,
+    pub other_fields: OtherFields,
+    ...
+}
+
+impl Deref for MyContext {
+    type Target = MyContextFields;
+
+    fn deref(&self) -> &MyContextFields {
+        &self.fields
+    }
+}
+```
+
+In the above example, we move all fields of `MyContext` into a separate struct `MyContextFields`. The original context now contains an `Arc<MyContextFields>` field, which can now be cloned cheaply.
+
+We also implement `Deref` for `MyContext` with `MyContextFields` being the target. This way, we can use the fields in `MyContextFields` directly as if they are defined in `MyContext`.
+
+We also move the derivation of `HasField` from `MyContext` to `MyContextFields`. The `HasField` trait has a blanket implementation for types that implement `Deref`. So `MyContext` automatically implements any `HasField` that is implemented by `MyContextFields`.
+
+## Fields with Abstract Types
+
+As we make more advanced uses of CGP, we may want to make use of CGP traits to define fields with _abstract types_ inside a context, using the component wiring of that context.
+
+For example, we may want to define the `runtime` field with the abstract `Runtime` type as follows:
+
+```rust
+#[cgp_context(MyContextComponents)]
+#[derive(HasField, Clone)]
+pub struct MyContext {
+    pub runtime: <MyContext as HasRuntimeType>::Runtime,
+    ...
+}
+
+delegate_components! {
+    MyContextComponents {
+        RuntimeTypeProviderComponent: UseType<MyRuntime>,
+        ...
+    }
+}
+```
+
+In the above example, we have a wiring of `RuntimeTypeProviderComponent` to use the type `MyRuntime` as the runtime. So conceptually, the field `MyContext::runtime` would resolve to have the type `MyRuntime`.
+
+However, if we try to compile the code, we would encounter cyclic error that we try to resolve the trait implementation of `MyContext` before the struct is fully defined. As a result, we would need different workaround to be able to use abstract types that refer back to the context itself.
+
+For the above example, it may seem trivial that we can replace the field definition directly with `MyRuntime`. However, there are more complex examples where the context definition can be significantly simplified using composite abstract types that are made of multiple inner abstract types. An example would be the `MessageBatchSender` type for the relay context, which is made of a combination of sender, receiver, message, event, and error.
+
+A naive attempt to solve this would be to use the context fields pattern earlier, and make use of the abstract field type inside `MyContextFields`:
+
+```rust
+#[cgp_context(MyContextComponents)]
+pub struct MyContext {
+    pub fields: Arc<MyContextFields>,
+}
+
+#[derive(HasField)]
+pub struct MyContextFields {
+    pub runtime: <MyContext as HasRuntimeType>::Runtime,
+    ...
+}
+
+impl Deref for MyContext {
+    type Target = MyContextFields;
+
+    fn deref(&self) -> &MyContextFields {
+        &self.fields
+    }
+}
+
+delegate_components! {
+    MyContextComponents {
+        RuntimeTypeProviderComponent: UseType<MyRuntime>,
+        ...
+    }
+}
+```
+
+However, if we try to compile the code, we would still encounter the same error. Essentially, to define `MyContext`, we need to define `MyContextFields`, which needs `MyContext` to be defined first, resulting in an infinite loop.
+
+## Proxy Field Traits
+
+The solution is to define a _proxy field trait_ that "hides" the concrete field type behind a trait.
+
+
+```rust
+#[cgp_context(MyContextComponents)]
+pub struct MyContext {
+    pub fields: Arc<dyn HasMyContextFields>,
+}
+
+#[derive(HasField)]
+pub struct MyContextFields {
+    pub runtime: <MyContext as HasRuntimeType>::Runtime,
+    ...
+}
+
+pub trait HasMyContextFields {
+    fn fields(&self) -> &MyContextFields;
+}
+
+impl HasMyContextFields for MyContextFields {
+    fn fields(&self) -> &MyContextFields {
+        self
+    }
+}
+
+impl Deref for MyContext {
+    type Target = MyContextFields;
+
+    fn deref(&self) -> &MyContextFields {
+        &self.fields.fields()
+    }
+}
+
+delegate_components! {
+    MyContextComponents {
+        RuntimeTypeProviderComponent: UseType<MyRuntime>,
+        ...
+    }
+}
+```
+
+In the above example, we introduce a `HasMyContextFields` trait, with an accessor method to convert a `&self` to `&MyContextFields`. We then trivially implement `HasMyContextFields` for `MyContextFields`, with it just returning `self`.
+
+In the definition of `MyContext`, we now define the `fields` to be `Arc<dyn HasMyContextFields>`. Now even though it is essentially the same as `Arc<MyContextFields>`, the `dyn` trait makes Rust "forgets" the concrete type, and allows the struct `MyContext` to be considered defined without trying to walk into `MyContextFields`.
+
+With this technique in place, we are able to get around the cyclic error, and define our context struct with abstract field types directly.

--- a/docs/notes/crate-organization.md
+++ b/docs/notes/crate-organization.md
@@ -40,6 +40,40 @@ The main risk of monolithic crate is that it becomes very easy to write context-
 
 This section gives an overview of the crates currently present in Hermes SDK.
 
+### Meta Crates
+
+- `hermes-prelude` - Re-exports `cgp::prelude` as a proxy crate to mediate potential breaking changes.
+
+- `hermes-core` - Re-exports the following common abstract crates that are essential for building a relayer:
+    - `hermes-runtime-components`
+    - `hermes-logging-components`
+    - `hermes-encoding-components`
+    - `hermes-chain-type-components`
+    - `hermes-chain-components`
+    - `hermes-test-components`
+    - `hermes-relayer-components`
+    - `hermes-relayer-components-extra`
+
+- `hermes-cosmos-core` - Re-exports the following context-generic crates that are essential for building a Cosmos relayer:
+    - `hermes-cosmos-chain-components`
+    - `hermes-cosmos-test-components`
+    - `hermes-wasm-client-components`
+    - `hermes-wasm-encoding-components`
+    - `hermes-wasm-test-components`
+    - `hermes-cosmos-chain-preset`
+    - `hermes-cosmos-encoding-components`
+    - `hermes-protobuf-encoding-components`
+    - `hermes-tracing-logging-components `
+    - `hermes-comet-light-client-components`
+
+- `hermes-cosmos` - Re-exports the following concrete Cosmos contexts crates, in addition to everything from `hermes-cosmos-core`:
+    - `hermes-cosmos-relayer`
+    - `hermes-cosmos-wasm-relayer`
+    - `hermes-cosmos-integration-tests`
+    - `hermes-comet-light-client-context`
+    - `hermes-runtime`
+    - `hermes-error`
+
 ### Fully Abstract Core Crates
 
 - `hermes-encoding-components` - Contains encoding-agnostic traits that can be used to implement any encoding.

--- a/docs/notes/navigation.md
+++ b/docs/notes/navigation.md
@@ -1,0 +1,204 @@
+# Code Navigation
+
+This document provides a quick guide on how to navigate the code base in Hermes SDK.
+
+With CGP being new to most people, one can easily get lost in figuring how to start navigating the code base in Hermes SDK. The main challenge lies in knowing which part of the code to look for, and how to find out which concrete implementation is being used. However, with some quick guidance here, you can learn that the navigation is concentrated at a few places, and it would become much clearer once you know where to look.
+
+## Start with concrete contexts
+
+When getting started with Hermes SDK, the main goal of a new developer would typically be figuring out the execution path of a concrete implementation of the relayer, such as the Cosmos relayer. To do that, it would be useful to start looking at crates that contain the concrete contexts, such as `hermes-cosmos-relayer`.
+
+From the crate, you can start looking at how concrete contexts such as `CosmosChain` is defined. The first thing to look for is the use of `#[cgp_context]` attribute, such as:
+
+```rust
+#[cgp_context(CosmosChainContextComponents: CosmosChainPreset)]
+pub struct CosmosChain {
+    ...
+}
+```
+
+The `#[cgp_context]` macro helps with performing the wiring of the implementation of consumer traits for `CosmosChain` with the provider `CosmosChainContextComponents`. Often, the given provider also inherits from another preset, such as `CosmosChainPreset`, so that the bulk of the wiring can be reused by multiple concrete contexts.
+
+## Look for `delegate_components!`
+
+Once we know the context provider that is wired with the concrete context, we can next look for `delegate_components!` calls that perform the wiring of individual providers with the context provider. It would usually be defined at the same file as the concrete context, and looks something like:
+
+```rust
+delegate_components! {
+    CosmosChainContextComponents {
+        ...
+    }
+}
+```
+
+Sometimes, a context provider may also directly implement a provider trait specifically for the concrete context. This is typically done in the same file. So you should also look for implementation blocks such as:
+
+```rust
+#[cgp_provider(GrpcAddressGetterComponent)]
+impl GrpcAddressGetter<CosmosChain> for CosmosChainContextComponents {
+    ...
+}
+```
+
+## Look for `cgp_preset!`
+
+When a concrete context is simple, we can find all the wirings to be done within the context provider. But for more complicated contexts, we would also need to look for the wiring of the preset that it is inherited from, which would be defined with the `cgp_preset!` macro:
+
+```rust
+cgp_preset! {
+    CosmosChainPreset {
+        ...
+    }
+}
+```
+
+The preset is usually defined in a separate module or crate. But you can use Rust Analyzer to hover over the identifier used in `#[cgp_context]`, and jump to the definition quickly.
+
+The rules for whether to look for a wiring in the base context provider or the inherited preset is similar to how inheritance works in OOP. So we know that we can start from looking at the context provider, and then only look for the wiring at the preset if one is not found.
+
+Aside from the base inheritance, a preset may also inherit from a parent preset with the `ParentPreset::with_components!` macro. In such cases, we just need to look up to the ancestor presets, all the way until we find the component wiring that we look for.
+
+## Look for check traits
+
+The wirings of providers in a concrete context is done declaratively, with the concrete implementation instantiated lazily when it is first used. When looking just at the wirings, it may not be clear what has been implemented, and whether the wiring is correct. A good place to look at next is the use of `check_components!`, which would check on whether the concrete context implements a certain component.
+
+```rust
+check_components! {
+    CanUseCosmosChainComponents for CosmosChain {
+        ...
+    }
+}
+```
+
+Currently, the use of `check_components!` is not very comprehensive. So if you are unsure and wanted to check whether the context have implemented a certain component, it is a good idea to quickly add an additional line in `check_components` to check on the wiring.
+
+## Watch out for `UseDelegate` dispatches
+
+Another main source of confusion for newcomers are when encountering the use of `UseDelegate` to implement static dispatches. The `UseDelegate` pattern is used to dispatch on the provider implementations, beased on the extra generic parameters of consumer traits. For example, chain contexts like `CosmosChain` use it to dispatch chain implementations based on the counterparty chain.
+
+As a result, it is good to know what to look next when encountering delegation to `UseDelegate` such as:
+
+```rust
+cgp_preset! {
+    CosmosChainPreset {
+        ...
+        [
+            ...
+            ClientStateQuerierComponent,
+            ...
+        ]:
+            UseDelegate<DelegateCosmosChainComponents>,
+    }
+}
+```
+
+The key to understand here is that the implementation of `ClientStateQuerierComponent` depends on which `Counterparty` type is used with the main chain context. The wiring look up is now forwarded to the `DelegateCosmosChainComponents` type. So we need to look for an implementation of `impl DelegateComponent<Counterparty> for DelegateCosmosChainComponents`.
+
+For the case of Cosmos to Cosmos relayer, we know that we want to look up for an implementation of of `ClientStateQuerierComponent` for `CosmosChain`, where the counterparty is _also_ `CosmosChain`. So we look around and find the entry:
+
+```rust
+delegate_components! {
+    DelegateCosmosChainComponents {
+        CosmosChain: CosmosToCosmosComponents::Provider,
+    }
+}
+```
+
+So we know that when `Counterparty` is `CosmosChain`, then the implementation is forwarded to `CosmosToCosmosComponents::Provider`, which contains the entry:
+
+```rust
+    cgp_preset! {
+        CosmosToCosmosComponents {
+            ...
+            ClientStateQuerierComponent: QueryAndConvertRawClientState,
+            ...
+        }
+    }
+```
+
+So with that, we reached the actual provider implementation for `ClientStateQuerier<CosmosChain, CosmosChain>`, which is `QueryAndConvertRawClientState`.
+
+## Example Walkthrough
+
+We will have an example walk through to demonstrate how to navigate the code for Hermes SDK.
+
+Supposed that we want to find out how the relayer starts auto-relaying packets between two Cosmos chains. We first need to identify the trait that is called, which in our case is `CanAutoBiRelay`.
+
+We then need to find the concrete context which contains the wiring of the component `AutoBiRelayerComponent`, which in this case is `CosmosBiRelay`:
+
+```rust
+#[cgp_context(CosmosBiRelayComponents: DefaultBiRelayComponents)]
+pub struct CosmosBiRelay {
+    ...
+}
+```
+
+With the `#[cgp_context]` definition, we know to first look for a wiring of `AutoBiRelayerComponent` in `CosmosBiRelayComponents`, which we don't find. we then look one level up for the wiring at the `DefaultBiRelayComponents` preset, and found it as:
+
+```rust
+cgp_preset! {
+    DefaultBiRelayComponents {
+        ...
+        AutoBiRelayerComponent: PerformAutoBiRelay,
+    }
+}
+```
+
+With that, we know that `CosmosBiRelay` uses `PerformAutoBiRelay` to implement `AutoBiRelayerComponent`.
+
+Inside the implementation of `PerformAutoBiRelay`, we see that `CanAutoRelayWithHeights` is used to perform the inner auto relaying on the relay contexts `RelayAToB` and `RelayBToA`. We now need to find out which concrete relay contexts are wired with `CosmosBiRelay`, which we can find out to be `CosmosRelay` in the wiring in `CosmosBiRelayComponents`:
+
+```rust
+
+delegate_components! {
+    CosmosBiRelayComponents {
+        ...
+        [
+            RelayTypeProviderAtComponent<Index<0>, Index<1>>,
+            RelayTypeProviderAtComponent<Index<1>, Index<0>>,
+        ]: UseType<CosmosRelay>,
+    }
+}
+```
+
+So we then look at the context definition of `CosmosRelay`:
+
+```rust
+#[cgp_context(CosmosRelayComponents: ExtraRelayPreset)]
+pub struct CosmosRelay {
+    ...
+}
+```
+
+In this case, we find that `AutoRelayerWithHeightsComponent` is not found in `CosmosRelayComponents` and `ExtraRelayPreset`. But `ExtraRelayPreset` is inherited from `DefaultRelayPreset` with the definition:
+
+```rust
+DefaultRelayPreset::with_components! {
+    ...
+    | Components | {
+        cgp_preset! {
+            ExtraRelayPreset {
+                ...
+                Components:
+                    DefaultRelayPreset::Provider,
+            }
+        }
+    }
+}
+```
+
+So we look into `DefaultRelayPreset` and found the wiring to be `RelayWithPolledEvents`:
+
+```rust
+cgp_preset! {
+    DefaultRelayPreset {
+        AutoRelayerWithHeightsComponent: RelayWithPolledEvents,
+    }
+}
+```
+
+With that, we can now look at the implementation of `RelayWithPolledEvents`, and try and understand how it implements `AutoRelayerWithHeights<CosmosRelay, SourceTarget>` and `AutoRelayerWithHeights<CosmosRelay, DestinationTarget>`.
+
+Following similar steps, we can further trace into how each component is wired and implemented in the contexts, all the way until the final implementation is reached.
+
+Hopefully with this walk through, it is now clearer on how you can navigate the Hermes SDK code base.


### PR DESCRIPTION
[Rendered](https://github.com/informalsystems/hermes-sdk/tree/soares/docs-3/docs/notes#hermes-sdk-architecture-notes)

Follow up on #596.

This PR adds new notes for [code navigation](https://github.com/informalsystems/hermes-sdk/blob/soares/docs-3/docs/notes/navigation.md) and [context fields](https://github.com/informalsystems/hermes-sdk/blob/soares/docs-3/docs/notes/context-fields.md).