### PR TITLE
Retry querying events if query fails during event polling

### DIFF
--- a/crates/chain/chain-type-components/src/traits/types/event.rs
+++ b/crates/chain/chain-type-components/src/traits/types/event.rs
@@ -2,6 +2,8 @@
    Trait definition for [`HasEventType`].
 */
 
+use core::fmt::Debug;
+
 use cgp::core::component::WithProvider;
 use cgp::core::types::ProvideType;
 use hermes_prelude::*;
@@ -44,5 +46,5 @@ pub trait HasEventType: Sized + Async {
        [`WriteAckEvent`](crate::traits::HasWriteAckEvent::WriteAckEvent),
        and _extraction_ methods to parse the variant information from the event.
     */
-    type Event: Async;
+    type Event: Async + Debug;
 }

--- a/crates/relayer/relayer-components/src/transaction/traits/types/signer.rs
+++ b/crates/relayer/relayer-components/src/transaction/traits/types/signer.rs
@@ -1,6 +1,8 @@
+use core::fmt::Debug;
+
 use hermes_prelude::*;
 
 #[cgp_type]
 pub trait HasSignerType: Async {
-    type Signer: Async;
+    type Signer: Async + Debug;
 }

--- a/crates/relayer/relayer-components/src/transaction/traits/types/tx_response.rs
+++ b/crates/relayer/relayer-components/src/transaction/traits/types/tx_response.rs
@@ -1,6 +1,8 @@
+use core::fmt::Debug;
+
 use hermes_prelude::*;
 
 #[cgp_type]
 pub trait HasTxResponseType: Async {
-    type TxResponse: Async;
+    type TxResponse: Async + Debug;
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->
This PR adds logic to retry the `query_block_events` at the same height if it fails after 1 second.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
