### PR TITLE
Split dependencies for client recovery test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
  "sha2 0.10.8",
  "subtle-encoding",
  "time",
+ "tokio",
  "toml",
  "tonic",
 ]

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/binary_channel/test_driver.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/binary_channel/test_driver.rs
@@ -13,8 +13,10 @@ use hermes_core::test_components::setup::traits::{
     CreateClientMessageOptionsGetterAtComponent, CreateClientPayloadOptionsGetterAtComponent,
     PortIdGetterAtComponent, RecoverClientPayloadOptionsGetterAtComponent,
 };
+use hermes_core::test_components::test_case::traits::recover_client::RecoverClientHandlerComponent;
 use hermes_cosmos_core::chain_components::impls::CosmosRecoverClientPayload;
 use hermes_cosmos_core::chain_components::types::CosmosCreateClientOptions;
+use hermes_cosmos_core::test_components::chain::impls::RecoverClientWithProposals;
 use hermes_cosmos_core::tracing_logging_components::contexts::TracingLogger;
 use hermes_error::handlers::DebugError;
 use hermes_error::impls::UseHermesError;
@@ -63,6 +65,8 @@ delegate_components! {
         ]:
             UseCosmosTestTypes,
         LoggerComponent: TracingLogger,
+        RecoverClientHandlerComponent:
+            RecoverClientWithProposals,
         ChainDriverGetterAtComponent<Index<0>>:
             UseField<symbol!("chain_driver_a")>,
         ChainDriverGetterAtComponent<Index<1>>:

--- a/crates/cosmos/cosmos-test-components/Cargo.toml
+++ b/crates/cosmos/cosmos-test-components/Cargo.toml
@@ -29,6 +29,7 @@ secp256k1  = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 time       = { workspace = true }
+tokio      = { workspace = true }
 toml       = { workspace = true }
 tonic      = { workspace = true }
 

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/mod.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/mod.rs
@@ -7,6 +7,9 @@ pub use messages::*;
 mod proposal;
 pub use proposal::*;
 
+mod recover_client;
+pub use recover_client::*;
+
 mod queries;
 pub use queries::*;
 

--- a/crates/cosmos/cosmos-test-components/src/chain/impls/recover_client.rs
+++ b/crates/cosmos/cosmos-test-components/src/chain/impls/recover_client.rs
@@ -1,0 +1,148 @@
+use core::marker::PhantomData;
+use core::time::Duration;
+
+use hermes_core::chain_components::traits::{
+    CanQueryClientStatus, HasAmountType, HasClientIdType, HasClientStatusMethods, HasDenomType,
+};
+use hermes_core::logging_components::traits::CanLogMessage;
+use hermes_core::relayer_components::multi::traits::chain_at::HasChainTypeAt;
+use hermes_core::relayer_components::transaction::traits::CanSendMessagesWithSigner;
+use hermes_prelude::*;
+use hermes_test_components::chain::traits::{
+    CanBuildDepositProposalMessage, CanBuildVoteProposalMessage, CanQueryProposalStatus,
+    HasWalletSigner,
+};
+use hermes_test_components::chain::types::{ProposalStatus, ProposalVote};
+use hermes_test_components::chain_driver::traits::{
+    CanGenerateRandomAmount, HasChain, HasDenom, HasWallet, StakingDenom, ValidatorWallet,
+};
+use hermes_test_components::driver::traits::HasChainDriverAt;
+use hermes_test_components::test_case::traits::recover_client::{
+    RecoverClientHandler, RecoverClientHandlerComponent,
+};
+use ibc::core::host::types::identifiers::ClientId;
+
+const MAX_RETRIES_FOR_PROPOSAL_STATUS: usize = 15;
+const WAIT_SECONDS_FOR_PROPOSAL_STATUS: u64 = 1;
+
+pub struct RecoverClientWithProposals;
+
+#[cgp_provider(RecoverClientHandlerComponent)]
+impl<Driver, ChainDriverA, ChainA, ChainB>
+    RecoverClientHandler<Driver, ChainDriverA, ChainA, ChainB> for RecoverClientWithProposals
+where
+    Driver: HasChainTypeAt<Index<1>, Chain = ChainB>
+        + HasChainDriverAt<Index<0>, ChainDriver = ChainDriverA>
+        + CanLogMessage
+        + CanRaiseAsyncError<String>,
+    ChainDriverA: HasChain<Chain = ChainA>
+        + HasDenom<StakingDenom>
+        + HasWallet<ValidatorWallet>
+        + CanGenerateRandomAmount,
+    ChainA: CanQueryProposalStatus<ProposalId = u64, ProposalStatus = ProposalStatus>
+        + CanQueryClientStatus<ChainB>
+        + CanBuildDepositProposalMessage
+        + CanBuildVoteProposalMessage<ProposalVote = ProposalVote>
+        + CanSendMessagesWithSigner
+        + HasClientIdType<ChainB, ClientId = ClientId>
+        + HasAmountType
+        + HasDenomType
+        + HasWalletSigner,
+    ChainB: HasClientStatusMethods<ChainA>,
+{
+    async fn handle_recover_client(
+        driver: &Driver,
+        subject_client_id: &ClientId,
+        substitute_client_id: &ClientId,
+    ) -> Result<(), Driver::Error> {
+        let chain_driver_a = driver.chain_driver_at(PhantomData::<Index<0>>);
+
+        let chain_a = chain_driver_a.chain();
+
+        let validator_wallet = chain_driver_a.wallet(PhantomData::<ValidatorWallet>);
+
+        let denom_a = chain_driver_a.denom(PhantomData::<StakingDenom>);
+
+        let deposit_amount = chain_driver_a.fixed_amount(11000000, denom_a).await;
+
+        let proposal_status = chain_a
+            .query_proposal_status(&1)
+            .await
+            .map_err(|e| Driver::raise_error(format!("{e:?}")))?;
+
+        if proposal_status == ProposalStatus::DepositPeriod {
+            let deposit_message = chain_a.build_deposit_proposal_message(&1, &deposit_amount);
+
+            chain_a
+                .send_messages_with_signer(
+                    ChainA::wallet_signer(validator_wallet),
+                    &[deposit_message],
+                )
+                .await
+                .map_err(|e| Driver::raise_error(format!("{e:?}")))?;
+        }
+
+        let mut try_number = 0;
+        loop {
+            let proposal_status = chain_a
+                .query_proposal_status(&1)
+                .await
+                .map_err(|e| Driver::raise_error(format!("{e:?}")))?;
+
+            if proposal_status == ProposalStatus::VotingPeriod {
+                let voting_message = chain_a.build_vote_proposal_message(&1, &ProposalVote::Yes);
+
+                chain_a
+                    .send_messages_with_signer(
+                        ChainA::wallet_signer(validator_wallet),
+                        &[voting_message],
+                    )
+                    .await
+                    .map_err(|e| Driver::raise_error(format!("{e:?}")))?;
+
+                break;
+            }
+
+            if try_number > MAX_RETRIES_FOR_PROPOSAL_STATUS {
+                return Err(Driver::raise_error(format!("Client recovery proposal failed, expected proposal to be in voting period but is {proposal_status:?}")));
+            }
+            try_number += 1;
+
+            tokio::time::sleep(Duration::from_secs(WAIT_SECONDS_FOR_PROPOSAL_STATUS)).await;
+        }
+
+        try_number = 0;
+        loop {
+            let proposal_status = chain_a
+                .query_proposal_status(&1)
+                .await
+                .map_err(|e| Driver::raise_error(format!("{e:?}")))?;
+
+            if proposal_status == ProposalStatus::Passed {
+                // Wait before querying client status
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                let subject_client_status = chain_a
+                    .query_client_status(PhantomData, subject_client_id)
+                    .await
+                    .map_err(|e| Driver::raise_error(format!("{e:?}")))?;
+
+                if ChainB::client_status_is_active(&subject_client_status) {
+                    driver
+                        .log_message(&format!(
+                            "successfully performed client recovery for subject client {subject_client_id} to substitute client {substitute_client_id}"
+                        ))
+                        .await;
+
+                    return Ok(());
+                }
+            }
+            if try_number == 15 {
+                return Err(Driver::raise_error(format!("Client recovery proposal failed, expected proposal to have passed but is {proposal_status:?}")));
+            }
+            try_number += 1;
+
+            tokio::time::sleep(Duration::from_secs(WAIT_SECONDS_FOR_PROPOSAL_STATUS)).await;
+        }
+    }
+}

--- a/crates/test/test-components/src/test_case/traits/mod.rs
+++ b/crates/test/test-components/src/test_case/traits/mod.rs
@@ -1,1 +1,2 @@
+pub mod recover_client;
 pub mod test_case;

--- a/crates/test/test-components/src/test_case/traits/recover_client.rs
+++ b/crates/test/test-components/src/test_case/traits/recover_client.rs
@@ -1,0 +1,18 @@
+use hermes_chain_type_components::traits::HasClientIdType;
+use hermes_prelude::*;
+
+#[cgp_component {
+  provider: RecoverClientHandler,
+  context: Driver,
+}]
+#[async_trait]
+pub trait CanHandleRecoverClient<ChainDriverA, ChainA, ChainB>: HasAsyncErrorType
+where
+    ChainA: HasClientIdType<ChainB>,
+{
+    async fn handle_recover_client(
+        &self,
+        subject_client_id: &ChainA::ClientId,
+        substitute_client_id: &ChainA::ClientId,
+    ) -> Result<(), Self::Error>;
+}

--- a/crates/test/test-suite/src/traits/types.rs
+++ b/crates/test/test-suite/src/traits/types.rs
@@ -31,17 +31,12 @@ use hermes_relayer_components::relay::traits::{
     CanAutoRelayWithHeights, CanRelayReceivePacket, DestinationTarget, HasChainTargets,
     HasDstChain, HasSrcChain, SourceTarget,
 };
-use hermes_relayer_components::transaction::traits::CanSendMessagesWithSigner;
 use hermes_test_components::chain::traits::{
-    CanAssertEventualAmount, CanBuildDepositProposalMessage, CanBuildVoteProposalMessage,
-    CanConvertIbcTransferredAmount, CanIbcTransferToken, CanQueryBalance, CanQueryProposalStatus,
-    HasAmountMethods, HasDefaultMemo, HasProposalIdType, HasProposalStatusType,
-    HasProposalVoteType, HasWalletSigner, HasWalletType, WalletOf,
+    CanAssertEventualAmount, CanConvertIbcTransferredAmount, CanIbcTransferToken, CanQueryBalance,
+    HasAmountMethods, HasDefaultMemo, HasWalletSigner, HasWalletType, WalletOf,
 };
-use hermes_test_components::chain::types::{ProposalStatus, ProposalVote};
 use hermes_test_components::chain_driver::traits::{
-    CanGenerateRandomAmount, HasChain, HasDenom, HasWallet, StakingDenom, TransferDenom,
-    UserWallet, ValidatorWallet,
+    CanGenerateRandomAmount, HasChain, HasDenom, HasWallet, StakingDenom, TransferDenom, UserWallet,
 };
 use hermes_test_components::driver::traits::{HasChainDriverAt, HasChannelIdAt, HasRelayDriverAt};
 use hermes_test_components::relay_driver::run::CanRunRelayerInBackground;
@@ -135,13 +130,11 @@ pub trait CanUseBinaryTestDriverMethods<A, B>:
                           + HasDenom<StakingDenom>
                           + HasWallet<UserWallet<0>>
                           + HasWallet<UserWallet<1>>
-                          + HasWallet<ValidatorWallet>
                           + CanGenerateRandomAmount,
         ChainDriverB: HasDenom<TransferDenom>
                           + HasDenom<StakingDenom>
                           + HasWallet<UserWallet<0>>
                           + HasWallet<UserWallet<1>>
-                          + HasWallet<ValidatorWallet>
                           + CanGenerateRandomAmount,
         ChainA: HasChainId
                     + HasWalletType
@@ -154,13 +147,6 @@ pub trait CanUseBinaryTestDriverMethods<A, B>:
                     + HasDefaultMemo
                     + CanSendSingleMessage
                     + CanSendMessages
-                    + CanSendMessagesWithSigner
-                    + HasProposalIdType<ProposalId = u64>
-                    + HasProposalStatusType<ProposalStatus = ProposalStatus>
-                    + HasProposalVoteType<ProposalVote = ProposalVote>
-                    + CanQueryProposalStatus
-                    + CanBuildDepositProposalMessage
-                    + CanBuildVoteProposalMessage
                     + HasCreateClientPayloadOptionsType<Self::ChainB>
                     + CanBuildCreateClientPayload<Self::ChainB>
                     + CanBuildCreateClientMessage<Self::ChainB>
@@ -194,13 +180,6 @@ pub trait CanUseBinaryTestDriverMethods<A, B>:
                     + HasDefaultMemo
                     + CanSendSingleMessage
                     + CanSendMessages
-                    + CanSendMessagesWithSigner
-                    + HasProposalIdType<ProposalId = u64>
-                    + HasProposalStatusType<ProposalStatus = ProposalStatus>
-                    + HasProposalVoteType<ProposalVote = ProposalVote>
-                    + CanQueryProposalStatus
-                    + CanBuildDepositProposalMessage
-                    + CanBuildVoteProposalMessage
                     + HasCreateClientPayloadOptionsType<Self::ChainA>
                     + CanBuildCreateClientPayload<Self::ChainA>
                     + CanBuildCreateClientMessage<Self::ChainA>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR improves the test driver by removing Cosmos dependencies required for client recovery test.

Previously we added components related to proposals, e.g. `CanQueryProposalStatus`, to the `CanUseBinaryTestDriverMethods` trait. But these are Cosmos specific.

Instead this PR adds a new component `RecoverClientHandlerComponent` which allows specific implementations, such as querying the proposal status and sending relevant messages for Cosmos <-> Cosmos.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
