### PR TITLE
fix: move Halt and resume full nodes to be ChainDriver components

### DIFF
--- a/crates/cosmos/cosmos-integration-tests/src/contexts/binary_channel/test_driver.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/binary_channel/test_driver.rs
@@ -11,8 +11,7 @@ use hermes_core::test_components::driver::traits::{
 };
 use hermes_core::test_components::setup::traits::{
     CreateClientMessageOptionsGetterAtComponent, CreateClientPayloadOptionsGetterAtComponent,
-    FullNodeForkerComponent, FullNodeHalterComponent, PortIdGetterAtComponent,
-    RecoverClientPayloadOptionsGetterAtComponent,
+    FullNodeForkerComponent, PortIdGetterAtComponent, RecoverClientPayloadOptionsGetterAtComponent,
 };
 use hermes_core::test_components::test_case::traits::recover_client::RecoverClientHandlerComponent;
 use hermes_cosmos_core::chain_components::impls::CosmosRecoverClientPayload;
@@ -70,7 +69,6 @@ delegate_components! {
             RecoverClientWithProposals,
         [
             FullNodeForkerComponent,
-            FullNodeHalterComponent,
         ]:
             ForkSecondFullNode,
         ChainDriverGetterAtComponent<Index<0>>:

--- a/crates/cosmos/cosmos-integration-tests/src/contexts/chain_driver.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/contexts/chain_driver.rs
@@ -19,6 +19,7 @@ use hermes_core::test_components::chain_driver::traits::{
     StakingDenom, TransferDenom, UserWallet, ValidatorWallet, WalletGetterComponent,
     WalletsGetterComponent,
 };
+use hermes_core::test_components::test_case::traits::node::FullNodeHalterComponent;
 use hermes_core::test_components::test_case::traits::upgrade_client::{
     SetupUpgradeClientTestHandlerComponent, UpgradeClientHandlerComponent,
 };
@@ -48,6 +49,8 @@ use hermes_runtime::impls::types::runtime::ProvideHermesRuntime;
 use hermes_runtime::types::runtime::HermesRuntime;
 use tokio::process::Child;
 use toml::to_string_pretty;
+
+use crate::impls::HaltCosmosFullNode;
 
 /**
    A chain driver for adding test functionalities to a Cosmos chain.
@@ -84,6 +87,8 @@ delegate_components! {
             CosmosHandleUpgradeClient,
         SetupUpgradeClientTestHandlerComponent:
             SetupCosmosUpgradeClientTest,
+        FullNodeHalterComponent:
+            HaltCosmosFullNode,
         LoggerComponent:
             TracingLogger,
         WalletsGetterComponent:

--- a/crates/cosmos/cosmos-integration-tests/src/impls/fork.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/fork.rs
@@ -1,13 +1,9 @@
 use alloc::sync::Arc;
 use core::str::FromStr;
-use std::path::PathBuf;
 
 use cgp::extra::runtime::HasRuntime;
-use eyre::eyre;
-use hermes_core::runtime_components::traits::{CanCreateDir, CanExecCommand, CanSleep};
-use hermes_core::test_components::setup::traits::{
-    FullNodeForker, FullNodeForkerComponent, FullNodeHalter, FullNodeHalterComponent,
-};
+use hermes_core::runtime_components::traits::{CanCreateDir, CanSleep};
+use hermes_core::test_components::setup::traits::{FullNodeForker, FullNodeForkerComponent};
 use hermes_cosmos_core::test_components::bootstrap::traits::CanStartChainFullNodes;
 use hermes_cosmos_relayer::contexts::{CosmosBuilder, CosmosChain};
 use hermes_error::HermesError;
@@ -20,47 +16,6 @@ use crate::contexts::{
 use crate::impls::copy_dir_recursive;
 
 pub struct ForkSecondFullNode;
-
-#[cgp_provider(FullNodeHalterComponent)]
-impl FullNodeHalter<CosmosBinaryChannelTestDriver> for ForkSecondFullNode {
-    async fn halt_full_node(
-        driver: &CosmosBinaryChannelTestDriver,
-        chain_id: String,
-    ) -> Result<(), HermesError> {
-        let runtime = driver.chain_driver_a.chain.runtime.clone();
-        let node_pid = if chain_id == driver.chain_driver_a.chain.chain_id.to_string() {
-            driver
-                .chain_driver_a
-                .chain_processes
-                .first()
-                .expect("Failed to retrieve Chain Driver A chain process")
-                .id()
-                .expect("failed to retrieve Chain Driver A chain process ID")
-        } else if chain_id == driver.chain_driver_b.chain.chain_id.to_string() {
-            driver
-                .chain_driver_b
-                .chain_processes
-                .first()
-                .expect("Failed to retrieve Chain Driver B chain process")
-                .id()
-                .expect("failed to retrieve Chain Driver B chain process ID")
-        } else {
-            return Err(eyre!("Unknown chain ID: {chain_id}").into());
-        };
-
-        // Stop full node
-        // `kill` is used here instead of `Child::kill()` as the `kill()` method requires
-        // the child process to be mutable.
-        runtime
-            .exec_command(
-                &PathBuf::from("kill".to_string()),
-                &["-s", "KILL", &node_pid.to_string()],
-            )
-            .await?;
-
-        Ok(())
-    }
-}
 
 #[cgp_provider(FullNodeForkerComponent)]
 impl FullNodeForker<CosmosBinaryChannelTestDriver> for ForkSecondFullNode {

--- a/crates/cosmos/cosmos-integration-tests/src/impls/mod.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/mod.rs
@@ -10,6 +10,9 @@ pub use fork::*;
 mod init_channel_options;
 pub use init_channel_options::*;
 
+mod node;
+pub use node::*;
+
 mod test_driver;
 pub use test_driver::*;
 

--- a/crates/cosmos/cosmos-integration-tests/src/impls/node.rs
+++ b/crates/cosmos/cosmos-integration-tests/src/impls/node.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use hermes_core::runtime_components::traits::CanExecCommand;
+use hermes_core::test_components::test_case::traits::node::{
+    FullNodeHalter, FullNodeHalterComponent,
+};
+use hermes_error::HermesError;
+use hermes_prelude::*;
+
+use crate::contexts::CosmosChainDriver;
+
+#[cgp_new_provider(FullNodeHalterComponent)]
+impl FullNodeHalter<CosmosChainDriver> for HaltCosmosFullNode {
+    async fn halt_full_node(chain_driver: &CosmosChainDriver) -> Result<(), HermesError> {
+        let runtime = chain_driver.chain.runtime.clone();
+        let node_pid = chain_driver
+            .chain_processes
+            .first()
+            .expect("Failed to retrieve Chain Driver A chain process")
+            .id()
+            .expect("failed to retrieve Chain Driver A chain process ID");
+
+        // Stop full node
+        // `kill` is used here instead of `Child::kill()` as the `kill()` method requires
+        // the child process to be mutable.
+        runtime
+            .exec_command(
+                &PathBuf::from("kill".to_string()),
+                &["-s", "KILL", &node_pid.to_string()],
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/relayer/relayer-components/src/relay/impls/event_relayers/packet_event.rs
+++ b/crates/relayer/relayer-components/src/relay/impls/event_relayers/packet_event.rs
@@ -110,10 +110,25 @@ where
                         .await
                         .map_err(Relay::raise_error)?;
 
-                    src_chain
+                    if let Err(e) = src_chain
                         .send_message(msg)
                         .await
-                        .map_err(Relay::raise_error)?;
+                        .map_err(Relay::raise_error)
+                    {
+                        relay
+                            .log(
+                                &format!("Failed to submit misbeahviour message: {e:?}"),
+                                &LevelWarn,
+                            )
+                            .await;
+                    } else {
+                        relay
+                        .log(
+                            &format!("Successfully submitted misbehaviour message for client {src_client_id}"),
+                            &LevelDebug,
+                        )
+                        .await;
+                    }
                 }
                 Ok(None) => {
                     relay.log("no misbehaviour detected", &LevelDebug).await;

--- a/crates/test/test-components/src/setup/traits/node.rs
+++ b/crates/test/test-components/src/setup/traits/node.rs
@@ -10,21 +10,3 @@ use hermes_prelude::*;
 pub trait CanForkFullNode: HasAsyncErrorType + Async + Sized {
     async fn fork_full_node(&self, chain_id: String) -> Result<Self, Self::Error>;
 }
-
-#[cgp_component {
-  provider: FullNodeHalter,
-  context: Driver,
-}]
-#[async_trait]
-pub trait CanHaltFullNode: HasAsyncErrorType + Async + Sized {
-    async fn halt_full_node(&self, chain_id: String) -> Result<(), Self::Error>;
-}
-
-#[cgp_component {
-  provider: FullNodeResumer,
-  context: Driver,
-}]
-#[async_trait]
-pub trait CanResumeFullNode: HasAsyncErrorType + Async + Sized {
-    async fn resume_full_node(&self, chain_id: String) -> Result<Self, Self::Error>;
-}

--- a/crates/test/test-components/src/test_case/traits/mod.rs
+++ b/crates/test/test-components/src/test_case/traits/mod.rs
@@ -1,3 +1,4 @@
+pub mod node;
 pub mod recover_client;
 pub mod test_case;
 pub mod upgrade_client;

--- a/crates/test/test-components/src/test_case/traits/node.rs
+++ b/crates/test/test-components/src/test_case/traits/node.rs
@@ -1,0 +1,19 @@
+use hermes_prelude::*;
+
+#[cgp_component {
+  provider: FullNodeHalter,
+  context: ChainDriver,
+}]
+#[async_trait]
+pub trait CanHaltFullNode: HasAsyncErrorType {
+    async fn halt_full_node(&self) -> Result<(), Self::Error>;
+}
+
+#[cgp_component {
+  provider: FullNodeResumer,
+  context: ChainDriver,
+}]
+#[async_trait]
+pub trait CanResumeFullNode: HasAsyncErrorType + Async + Sized {
+    async fn resume_full_node(&self) -> Result<Self, Self::Error>;
+}

--- a/crates/test/test-components/src/test_case/traits/node.rs
+++ b/crates/test/test-components/src/test_case/traits/node.rs
@@ -14,6 +14,14 @@ pub trait CanHaltFullNode: HasAsyncErrorType {
   context: ChainDriver,
 }]
 #[async_trait]
-pub trait CanResumeFullNode: HasAsyncErrorType + Async + Sized {
-    async fn resume_full_node(&self) -> Result<Self, Self::Error>;
+pub trait CanResumeFullNode: HasResumeFullNodeOptionsType + HasAsyncErrorType + Sized {
+    async fn resume_full_node(
+        &self,
+        options: &Self::ResumeFullNodeOptions,
+    ) -> Result<Self, Self::Error>;
+}
+
+#[cgp_type]
+pub trait HasResumeFullNodeOptionsType {
+    type ResumeFullNodeOptions: Async;
 }

--- a/crates/test/test-suite/src/tests/misebehaviour.rs
+++ b/crates/test/test-suite/src/tests/misebehaviour.rs
@@ -33,7 +33,6 @@ where
     async fn run_test(&self, driver: &Driver) -> Result<(), Driver::Error> {
         let relay_driver = driver.relay_driver();
 
-        let chain_driver_a = driver.chain_driver_a();
         let chain_driver_b = driver.chain_driver_b();
 
         let chain_a = driver.chain_a();
@@ -46,10 +45,6 @@ where
 
         tokio::time::sleep(Duration::from_secs(10)).await;
 
-        chain_driver_a
-            .halt_full_node()
-            .await
-            .map_err(Driver::raise_error)?;
         chain_driver_b
             .halt_full_node()
             .await

--- a/crates/test/test-suite/src/traits/types.rs
+++ b/crates/test/test-suite/src/traits/types.rs
@@ -45,6 +45,7 @@ use hermes_test_components::setup::traits::{
     HasCreateClientMessageOptionsAt, HasCreateClientPayloadOptionsAt, HasPortIdAt,
     HasRecoverClientPayloadOptionsAt,
 };
+use hermes_test_components::test_case::traits::node::CanHaltFullNode;
 
 #[blanket_trait]
 pub trait HasBinaryTestDriverFields<A, B>:
@@ -132,13 +133,15 @@ pub trait CanUseBinaryTestDriverMethods<A, B>:
                           + HasWallet<UserWallet<0>>
                           + HasWallet<UserWallet<1>>
                           + CanGenerateRandomAmount
-                          + HasSetupUpgradeClientTestResultType,
+                          + HasSetupUpgradeClientTestResultType
+                          + CanHaltFullNode,
         ChainDriverB: HasDenom<TransferDenom>
                           + HasDenom<StakingDenom>
                           + HasWallet<UserWallet<0>>
                           + HasWallet<UserWallet<1>>
                           + CanGenerateRandomAmount
-                          + HasSetupUpgradeClientTestResultType,
+                          + HasSetupUpgradeClientTestResultType
+                          + CanHaltFullNode,
         ChainA: HasChainId
                     + HasWalletType
                     + HasWalletSigner


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR Moves the Halting and resuming full node components from being a test driver component to a chain driver component

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
